### PR TITLE
docs: clarify wording for Checkboxes and Radios components

### DIFF
--- a/docs/docs/api/form/checkbox.md
+++ b/docs/docs/api/form/checkbox.md
@@ -13,7 +13,7 @@ The `Checkbox` component provides a Bulma-styled checkbox input. Pass the label 
 
 ## Import
 
-```tsx live
+```tsx
 import { Checkboxes, Checkbox } from '@allxsmith/bestax-bulma';
 ```
 
@@ -37,7 +37,7 @@ import { Checkboxes, Checkbox } from '@allxsmith/bestax-bulma';
 This example shows a simple `Checkbox` component for a single boolean choice. The label is provided as the `children` prop, and the checkbox is fully accessible and styled with Bulma.
 
 ```tsx live
-<Checkbox>Stay Signed In</Checkbox>
+<Checkbox> Stay Signed In </Checkbox>
 ```
 
 ### Checkbox With Link
@@ -59,25 +59,25 @@ This example demonstrates using the `Checkbox` component with a custom label tha
 Set the `disabled` prop to render a non-interactive checkbox. This is useful for indicating unavailable options in forms, and the checkbox will appear visually disabled and cannot be toggled by the user.
 
 ```tsx live
-<Checkbox disabled>Stay Signed In</Checkbox>
+<Checkbox disabled> Stay Signed In </Checkbox>
 ```
 
 ### Group/List of Checkboxes
 
-This example uses the `Checkboxes` component to render a vertical group of checkboxes. Each `Checkbox` receives its own label via the `children` prop. Use this pattern for lists of boolean options, such as tasks or preferences.
+This example uses the `Checkboxes` component to render a list of checkboxes. Each `Checkbox` receives its own label via the `children` prop. Use this pattern for lists of boolean options, such as tasks or preferences.
 
 ```tsx live
 <Checkboxes>
-  <Checkbox>Make the bed</Checkbox>
-  <Checkbox>Brush teeth</Checkbox>
-  <Checkbox>Do homework</Checkbox>
-  <Checkbox>Feed the pet</Checkbox>
-  <Checkbox>Take out the trash</Checkbox>
-  <Checkbox>Clean your room</Checkbox>
-  <Checkbox>Set the table</Checkbox>
-  <Checkbox>Help with dishes</Checkbox>
-  <Checkbox>Water the plants</Checkbox>
-  <Checkbox>Put away toys</Checkbox>
+  <Checkbox> Make the bed </Checkbox>
+  <Checkbox> Brush teeth </Checkbox>
+  <Checkbox> Do homework </Checkbox>
+  <Checkbox> Feed the pet </Checkbox>
+  <Checkbox> Take out the trash </Checkbox>
+  <Checkbox> Clean your room </Checkbox>
+  <Checkbox> Set the table </Checkbox>
+  <Checkbox> Help with dishes </Checkbox>
+  <Checkbox> Water the plants </Checkbox>
+  <Checkbox> Put away toys </Checkbox>
 </Checkboxes>
 ```
 

--- a/docs/docs/api/form/checkboxes.md
+++ b/docs/docs/api/form/checkboxes.md
@@ -7,7 +7,7 @@ sidebar_label: Checkboxes
 
 ## Overview
 
-The `Checkboxes` component wraps multiple `Checkbox` components in a Bulma-styled group. Use for vertical lists of boolean choices, such as preference lists or to-do checklists.
+The `Checkboxes` component wraps multiple `Checkbox` components in a Bulma-styled group. Use for lists of boolean choices, such as preference lists or to-do checklists.
 
 ---
 
@@ -33,20 +33,20 @@ import { Checkboxes, Checkbox } from '@allxsmith/bestax-bulma';
 
 ### Grouped Checkboxes
 
-This example demonstrates the `Checkboxes` component wrapping multiple `Checkbox` children. Use this pattern for vertical lists of boolean options, such as to-do lists or preference selections. Each `Checkbox` receives its own label via the `children` prop.
+This example demonstrates the `Checkboxes` component wrapping multiple `Checkbox` children. Use this pattern for lists of boolean options, such as to-do lists or preference selections. Each `Checkbox` receives its own label via the `children` prop.
 
 ```tsx live
 <Checkboxes>
-  <Checkbox>Make the bed</Checkbox>
-  <Checkbox>Brush teeth</Checkbox>
-  <Checkbox>Do homework</Checkbox>
-  <Checkbox>Feed the pet</Checkbox>
-  <Checkbox>Take out the trash</Checkbox>
-  <Checkbox>Clean your room</Checkbox>
-  <Checkbox>Set the table</Checkbox>
-  <Checkbox>Help with dishes</Checkbox>
-  <Checkbox>Water the plants</Checkbox>
-  <Checkbox>Put away toys</Checkbox>
+  <Checkbox> Make the bed </Checkbox>
+  <Checkbox> Brush teeth </Checkbox>
+  <Checkbox> Do homework </Checkbox>
+  <Checkbox> Feed the pet </Checkbox>
+  <Checkbox> Take out the trash </Checkbox>
+  <Checkbox> Clean your room </Checkbox>
+  <Checkbox> Set the table </Checkbox>
+  <Checkbox> Help with dishes </Checkbox>
+  <Checkbox> Water the plants </Checkbox>
+  <Checkbox> Put away toys </Checkbox>
 </Checkboxes>
 ```
 

--- a/docs/docs/api/form/radios.md
+++ b/docs/docs/api/form/radios.md
@@ -7,7 +7,7 @@ sidebar_label: Radios
 
 ## Overview
 
-The `Radios` component wraps multiple `Radio` components in a Bulma-styled group. Use it for vertical lists of mutually exclusive choices, such as RSVP or selection lists.
+The `Radios` component wraps multiple `Radio` components in a Bulma-styled group. Use it for lists of mutually exclusive choices, such as RSVP or selection lists.
 
 ---
 
@@ -33,7 +33,7 @@ import { Radios, Radio } from '@allxsmith/bestax-bulma';
 
 ### Grouped Radios (All Disabled Example)
 
-This example demonstrates the `Radios` component wrapping multiple `Radio` children, all with the same `name` prop for mutual exclusivity. The `disabled` prop is set on each `Radio` to render them as non-interactive. Use this pattern for vertical lists of mutually exclusive options, such as RSVP or selection lists.
+This example demonstrates the `Radios` component wrapping multiple `Radio` children, all with the same `name` prop for mutual exclusivity. The `disabled` prop is set on each `Radio` to render them as non-interactive. Use this pattern for lists of mutually exclusive options, such as RSVP or selection lists.
 
 ```tsx live
 <Radios>

--- a/docs/docs/guides/form.md
+++ b/docs/docs/guides/form.md
@@ -15,7 +15,7 @@ This page provides a summary of all Bulma-styled form components in Bestax, with
 A Bulma-styled checkbox input for boolean choices. Pass the label as children; supports custom JSX and links.
 
 ```tsx live
-<Checkbox>Stay Signed In</Checkbox>
+<Checkbox> Stay Signed In </Checkbox>
 ```
 
 [View full documentation.](../api/form/checkbox)
@@ -28,8 +28,8 @@ Wraps multiple `Checkbox` components in a vertical group for lists of boolean op
 
 ```tsx live
 <Checkboxes>
-  <Checkbox>Option 1</Checkbox>
-  <Checkbox>Option 2</Checkbox>
+  <Checkbox> Option 1 </Checkbox>
+  <Checkbox> Option 2 </Checkbox>
 </Checkboxes>
 ```
 
@@ -42,8 +42,10 @@ Wraps multiple `Checkbox` components in a vertical group for lists of boolean op
 A Bulma-styled radio button for mutually exclusive choices. Use the same `name` prop for grouping.
 
 ```tsx live
-<Radio name="group">Option A</Radio>
-<Radio name="group">Option B</Radio>
+<>
+  <Radio name="group"> Option A </Radio>
+  <Radio name="group"> Option B </Radio>
+</>
 ```
 
 [View full documentation.](../api/form/radio)
@@ -56,8 +58,8 @@ Groups multiple `Radio` components vertically for single-choice lists (e.g., RSV
 
 ```tsx live
 <Radios>
-  <Radio name="event">Attend</Radio>
-  <Radio name="event">Decline</Radio>
+  <Radio name="event"> Attend </Radio>
+  <Radio name="event"> Decline </Radio>
 </Radios>
 ```
 


### PR DESCRIPTION
# Pull Request

- Updated descriptions in checkboxes.md, radios.md, and radio.md to clarify these components are for lists of options, not specifically vertical lists
- Revised form.md summaries and examples for Checkboxes and Radios to match actual usage
- Ensured consistency and accuracy across all related

## Description

Cleans up the radios and checkboxes in our docusaurus site

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Closes #41 
Fixes #
Resolves #

Refs #
See #
Related to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [x] I have updated Storybook stories as needed (bulma-ui)
- [x] My changes require a change to the documentation
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated

## Additional Context

Add any other context or information about the pull request here.
