### PR TITLE
docs: add copy button to BrowserWindow

### DIFF
--- a/docs/src/theme/CodeBlock/BrowserWindow/index.js
+++ b/docs/src/theme/CodeBlock/BrowserWindow/index.js
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import clsx from 'clsx';
+import { LiveContext } from 'react-live';
+import CustomCopyButton from '../CustomCopyButton';
+
 import styles from './styles.module.css';
 
 export default function BrowserWindow({
@@ -9,6 +12,8 @@ export default function BrowserWindow({
   style,
   bodyStyle,
 }) {
+  const { code } = useContext(LiveContext);
+
   return (
     <div className={clsx(styles.browserWindow)} style={style}>
       <div className={styles.browserWindowHeader}>
@@ -18,6 +23,9 @@ export default function BrowserWindow({
           <span className={styles.dot} style={{ background: '#58cb42' }} />
         </div>
         <div className={styles.browserWindowAddressBar}>{url}</div>
+        <div className={styles.buttonGroup}>
+          <CustomCopyButton code={code} />
+        </div>
       </div>
       <div
         className={styles.browserWindowBody}

--- a/docs/src/theme/CodeBlock/BrowserWindow/styles.module.css
+++ b/docs/src/theme/CodeBlock/BrowserWindow/styles.module.css
@@ -50,3 +50,16 @@ pre.prism-code {
   margin-right: 0.5rem;
   width: 0.8rem;
 }
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 1;
+}

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -3,20 +3,26 @@ import clsx from 'clsx';
 import Button from '@theme/CodeBlock/Buttons/Button';
 import IconCopy from '@theme/Icon/Copy';
 import IconSuccess from '@theme/Icon/Success';
+import IconClose from '../IconClose';
 
 import styles from './styles.module.css';
 
 function CustomCopyButton({ code, className }) {
   const [isCopied, setIsCopied] = useState(false);
+  const [isError, setIsError] = useState(false);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(code);
       setIsCopied(true);
+      setIsError(false);
       setTimeout(() => setIsCopied(false), 2000);
+      setTimeout(() => setIsError(false), 2000);
     } catch (error) {
       console.error('Failed to copy text to clipboard:', error);
-      alert('Failed to copy text. Please try again.');
+      setIsError(true);
+      setIsCopied(false);
+      setTimeout(() => setIsError(false), 2000);
     }
   };
 
@@ -28,13 +34,15 @@ function CustomCopyButton({ code, className }) {
       className={clsx(
         className,
         // styles.copyButton,
-        isCopied && styles.copyButtonCopied
+        isCopied && styles.copyButtonCopied,
+        isError && styles.copyButtonError
       )}
       onClick={handleCopy}
     >
       <span className={styles.copyButtonIcons} aria-hidden="true">
         <IconCopy className={styles.copyButtonIcon} />
         <IconSuccess className={styles.copyButtonSuccessIcon} />
+        <IconClose className={styles.copyButtonErrorIcon} />
       </span>
     </Button>
   );

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -33,7 +33,6 @@ function CustomCopyButton({ code, className }) {
       title="Copy"
       className={clsx(
         className,
-        // styles.copyButton,
         isCopied && styles.copyButtonCopied,
         isError && styles.copyButtonError
       )}

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import Button from '@theme/CodeBlock/Buttons/Button';
 import IconCopy from '@theme/Icon/Copy';
@@ -10,6 +10,8 @@ import styles from './styles.module.css';
 function CustomCopyButton({ code, className }) {
   const [isCopied, setIsCopied] = useState(false);
   const [isError, setIsError] = useState(false);
+  const copyTimeoutRef = useRef(null);
+  const errorTimeoutRef = useRef(null);
 
   const timeoutRef = useRef([]);
 
@@ -25,15 +27,24 @@ function CustomCopyButton({ code, className }) {
     try {
       await navigator.clipboard.writeText(code);
       setIsCopied(true);
-      timeoutRef.current.push(setTimeout(() => setIsCopied(false), 2000));
-      
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setIsCopied(false), 1300);
     } catch (error) {
       console.error('Failed to copy text to clipboard:', error);
       setIsError(true);
       setIsCopied(false);
-      timeoutRef.current.push(setTimeout(() => setIsError(false), 2000));
+      if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
+      errorTimeoutRef.current = setTimeout(() => setIsError(false), 1300);
     }
   };
+
+  useEffect(() => {
+    return () => {
+      // Clear all timeouts on component unmount
+      copyTimeoutRef.current && clearTimeout(copyTimeoutRef.current);
+      errorTimeoutRef.current && clearTimeout(errorTimeoutRef.current);
+    };
+  }, []);
 
   return (
     <Button

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Button from '@theme/CodeBlock/Buttons/Button';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
+
+import styles from './styles.module.css';
+
+function CustomCopyButton({ code, className }) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
+  };
+
+  return (
+    <Button
+      type="button"
+      aria-label={isCopied ? 'Copied' : 'Copy code to clipboard'}
+      title="Copy"
+      className={clsx(
+        className,
+        styles.copyButton,
+        isCopied && styles.copyButtonCopied
+      )}
+      onClick={handleCopy}
+    >
+      <span className={styles.copyButtonIcons} aria-hidden="true">
+        <IconCopy className={styles.copyButtonIcon} />
+        <IconSuccess className={styles.copyButtonSuccessIcon} />
+      </span>
+    </Button>
+  );
+}
+
+export default CustomCopyButton;

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import clsx from 'clsx';
-import Translate from '@docusaurus/Translate';
 import Button from '@theme/CodeBlock/Buttons/Button';
 import IconCopy from '@theme/Icon/Copy';
 import IconSuccess from '@theme/Icon/Success';
@@ -28,7 +27,7 @@ function CustomCopyButton({ code, className }) {
       title="Copy"
       className={clsx(
         className,
-        styles.copyButton,
+        // styles.copyButton,
         isCopied && styles.copyButtonCopied
       )}
       onClick={handleCopy}

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -11,17 +11,27 @@ function CustomCopyButton({ code, className }) {
   const [isCopied, setIsCopied] = useState(false);
   const [isError, setIsError] = useState(false);
 
+  const timeoutRef = useRef([]);
+
+  useEffect(() => {
+    return () => {
+      // Clear all timeouts on component unmount
+      timeoutRef.current.forEach(clearTimeout);
+      timeoutRef.current = [];
+    };
+  }, []);
+
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(code);
       setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 2000);
+      timeoutRef.current.push(setTimeout(() => setIsCopied(false), 2000));
       
     } catch (error) {
       console.error('Failed to copy text to clipboard:', error);
       setIsError(true);
       setIsCopied(false);
-      setTimeout(() => setIsError(false), 2000);
+      timeoutRef.current.push(setTimeout(() => setIsError(false), 2000));
     }
   };
 

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -15,9 +15,8 @@ function CustomCopyButton({ code, className }) {
     try {
       await navigator.clipboard.writeText(code);
       setIsCopied(true);
-      setIsError(false);
       setTimeout(() => setIsCopied(false), 2000);
-      setTimeout(() => setIsError(false), 2000);
+      
     } catch (error) {
       console.error('Failed to copy text to clipboard:', error);
       setIsError(true);

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -13,16 +13,6 @@ function CustomCopyButton({ code, className }) {
   const copyTimeoutRef = useRef(null);
   const errorTimeoutRef = useRef(null);
 
-  const timeoutRef = useRef([]);
-
-  useEffect(() => {
-    return () => {
-      // Clear all timeouts on component unmount
-      timeoutRef.current.forEach(clearTimeout);
-      timeoutRef.current = [];
-    };
-  }, []);
-
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(code);

--- a/docs/src/theme/CodeBlock/CustomCopyButton/index.js
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/index.js
@@ -11,9 +11,14 @@ function CustomCopyButton({ code, className }) {
   const [isCopied, setIsCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(code);
-    setIsCopied(true);
-    setTimeout(() => setIsCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(code);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy text to clipboard:', error);
+      alert('Failed to copy text. Please try again.');
+    }
   };
 
   return (

--- a/docs/src/theme/CodeBlock/CustomCopyButton/styles.module.css
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/styles.module.css
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+:global(.theme-code-block:hover) .copyButtonCopied {
+  opacity: 1 !important;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all var(--ifm-transition-fast) ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}

--- a/docs/src/theme/CodeBlock/CustomCopyButton/styles.module.css
+++ b/docs/src/theme/CodeBlock/CustomCopyButton/styles.module.css
@@ -15,8 +15,14 @@
   height: 1.125rem;
 }
 
+.copyButtonError {
+  width: 1rem;
+  height: 1rem;
+}
+
 .copyButtonIcon,
-.copyButtonSuccessIcon {
+.copyButtonSuccessIcon,
+.copyButtonErrorIcon {
   position: absolute;
   top: 0;
   left: 0;
@@ -35,12 +41,33 @@
   color: #00d600;
 }
 
-.copyButtonCopied .copyButtonIcon {
+.copyButtonErrorIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #d53035;
+}
+
+.copyButtonCopied .copyButtonIcon,
+.copyButtonCopied .copyButtonErrorIcon {
   transform: scale(0.33);
   opacity: 0;
 }
 
 .copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}
+
+.copyButtonError .copyButtonIcon,
+.copyButtonError .copyButtonSuccessIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonError .copyButtonErrorIcon {
   transform: translate(-50%, -50%) scale(1);
   opacity: 1;
   transition-delay: 0.075s;

--- a/docs/src/theme/CodeBlock/IconClose/index.js
+++ b/docs/src/theme/CodeBlock/IconClose/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function IconClose(props) {
+  return (
+    <svg viewBox="0 0 24 24" {...props}>
+      <g stroke="#d53035" strokeWidth="3">
+        <path d="M.75.75l13.5 13.5M14.25.75L.75 14.25" />
+      </g>
+    </svg>
+  );
+}

--- a/docs/src/theme/CodeBlock/index.js
+++ b/docs/src/theme/CodeBlock/index.js
@@ -8,7 +8,7 @@ import * as BestaxBulma from '@allxsmith/bestax-bulma';
 import rawBulmaStyles from '!!raw-loader!bulma/css/bulma.min.css';
 import rawFontAwesomeStyles from '!!raw-loader!@fortawesome/fontawesome-free/css/all.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
-import BrowserWindow from '../../components/ BrowserWindow';
+import BrowserWindow from './BrowserWindow';
 
 // Preprocess: Replace :root with :host for Shadow DOM compatibility
 const bulmaStyles = rawBulmaStyles
@@ -41,6 +41,19 @@ const scope = {
   useEffect,
 };
 
+function BrowserEditor() {
+  return (
+    <BrowserWindow>
+      <LiveEditor
+        style={{
+          backgroundColor: 'var(--prism-background-color)',
+          font: 'var(--ifm-code-font-size) / var(--ifm-pre-line-height) var(--ifm-font-family-monospace)',
+        }}
+      />
+    </BrowserWindow>
+  );
+}
+
 export default function CodeBlockEnhancer(props) {
   const { colorMode } = useColorMode();
 
@@ -61,14 +74,7 @@ export default function CodeBlockEnhancer(props) {
         <LivePreview />
       </root.div>
       <LiveError className="live-error alert alert--danger" />
-      <BrowserWindow>
-        <LiveEditor
-          style={{
-            backgroundColor: 'var(--prism-background-color)',
-            font: 'var(--ifm-code-font-size) / var(--ifm-pre-line-height) var(--ifm-font-family-monospace)',
-          }}
-        />
-      </BrowserWindow>
+      <BrowserEditor />
     </LiveProvider>
   ) : (
     <OriginalCodeBlock {...props} />


### PR DESCRIPTION
# Pull Request

## Description

To resolve issue #44, I added a copy button to the BrowserWindow component which serves as a frame or decoration around the LiveEditor

- [] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Closes #44 
Fixes #
Resolves #

Refs #
See #
Related to #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [x] I have updated Storybook stories as needed (bulma-ui)
- [x] My changes require a change to the documentation
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated

