### PR TITLE
feat(docs): add pronunciation guide and dark mode support

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -87,6 +87,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        defaultMode: 'light',
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
       announcementBar: {
         id: 'support_v1',
         content: 'Full support for Bulma v1 !!!',

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -384,6 +384,33 @@ function HomepageHeader() {
   );
 }
 
+function PronunciationSection() {
+  return (
+    <section className={styles.pronunciationSection}>
+      <div className="container">
+        <div className={styles.pronunciationCard}>
+          <Heading as="h2" className={styles.pronunciationHeading}>
+            How to Pronounce Bestax
+          </Heading>
+          <div className={styles.pronunciationContent}>
+            <div className={styles.pronunciationMain}>
+              <div className={styles.pronunciationCorrect}>
+                <strong>&ldquo;bee-stacks&rdquo;</strong>
+              </div>
+            </div>
+            <p className={styles.pronunciationExplanation}>
+              The name combines <strong>&ldquo;B&rdquo;</strong> (for Bulma) +{' '}
+              <strong>&ldquo;stacks&rdquo;</strong> (component stacks), creating
+              a memorable name that reflects building UIs with stacked Bulma
+              components.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
@@ -397,6 +424,7 @@ export default function Home() {
         <V1ComponentList />
         <ComponentLibrarySections />
       </main>
+      <PronunciationSection />
     </Layout>
   );
 }

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -423,8 +423,8 @@ export default function Home() {
         <HomepageFeatures />
         <V1ComponentList />
         <ComponentLibrarySections />
+        <PronunciationSection />
       </main>
-      <PronunciationSection />
     </Layout>
   );
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -29,7 +29,7 @@
 }
 
 [data-theme='dark'] .hero__subtitle {
-  color: #000000;
+  color: var(--ifm-color-black);
 }
 
 /* Pronunciation Section */

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -31,3 +31,150 @@
 [data-theme='dark'] .hero__subtitle {
   color: #000000;
 }
+
+/* Pronunciation Section */
+.pronunciationSection {
+  padding: 2rem 0;
+  background: var(--ifm-color-emphasis-100);
+  position: relative;
+  overflow: hidden;
+}
+
+[data-theme='dark'] .pronunciationSection {
+  background: #1e2936;
+}
+
+.pronunciationCard {
+  max-width: 600px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.pronunciationHeading {
+  text-align: center;
+  color: #2c3e50;
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+}
+
+[data-theme='dark'] .pronunciationHeading {
+  color: var(--ifm-heading-color);
+}
+
+.pronunciationContent {
+  text-align: center;
+}
+
+.pronunciationMain {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+
+.pronunciationCorrect {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ifm-color-primary);
+  font-size: 1.3rem;
+  font-style: italic;
+}
+
+[data-theme='dark'] .pronunciationCorrect {
+  color: var(--ifm-color-primary);
+}
+
+.checkIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: var(--ifm-color-primary);
+  color: white;
+  border-radius: 50%;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+[data-theme='dark'] .checkIcon {
+  background: var(--ifm-color-primary);
+}
+
+.pronunciationPhonetic {
+  font-family: 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;
+  color: #7f8c8d;
+  font-style: italic;
+  font-size: 1.1rem;
+}
+
+[data-theme='dark'] .pronunciationPhonetic {
+  color: #95a5a6;
+}
+
+.pronunciationNote {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 1rem;
+  margin-bottom: 1.5rem;
+  opacity: 0.9;
+}
+
+[data-theme='dark'] .pronunciationNote {
+  color: var(--ifm-color-emphasis-600);
+}
+
+.crossIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: var(--ifm-color-emphasis-600);
+  color: white;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.pronunciationExplanation {
+  color: #5a6c7d;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+  padding-top: 1rem;
+  border-top: 1px solid #ecf0f1;
+}
+
+[data-theme='dark'] .pronunciationExplanation {
+  color: var(--ifm-color-emphasis-700);
+  border-top-color: var(--ifm-color-emphasis-300);
+}
+
+/* Mobile responsiveness */
+@media screen and (max-width: 768px) {
+  .pronunciationSection {
+    padding: 1.5rem 1rem;
+  }
+
+  .pronunciationCard {
+    padding: 1.5rem;
+  }
+
+  .pronunciationMain {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .pronunciationHeading {
+    font-size: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
Enhance the documentation site with a pronunciation guide for "Bestax" and enable dark mode support with system preference detection.

## Changes Made

### 1. Dark Mode Configuration
- Added `colorMode` configuration to `docusaurus.config.js`
- Enabled dark/light mode toggle
- Respects user's system color scheme preference
- Provides better accessibility and user experience

### 2. Pronunciation Section
Added a new pronunciation guide section to the homepage that:
- Clearly shows the correct pronunciation: **"bee-stacks"**
- Explains the name etymology (B for Bulma + stacks for component stacks)
- Provides visual hierarchy with styled card layout
- Fully responsive design for mobile devices

### 3. Styling Enhancements
- Created comprehensive CSS module styles for the pronunciation section
- Dark mode compatible styles with proper color contrast
- Mobile-responsive breakpoints for smaller screens
- Smooth visual integration with existing design system

## Files Modified
- `docs/docusaurus.config.js` - Added dark mode configuration
- `docs/src/pages/index.js` - Added PronunciationSection component
- `docs/src/pages/index.module.css` - Added pronunciation section styles with dark mode support

## Benefits
- **Improved User Experience**: Users can now switch between light and dark themes based on preference
- **Brand Clarity**: Clear pronunciation guide helps with brand recognition and consistency
- **Accessibility**: Dark mode reduces eye strain for users in low-light environments
- **Professional Polish**: These enhancements make the documentation site more complete and user-friendly

## Testing
- [x] Dark mode toggle works correctly
- [x] System preference detection functions properly
- [x] Pronunciation section displays correctly in both light and dark modes
- [x] Mobile responsive design verified
- [x] No breaking changes to existing functionality

## Related Issues
Closes #58

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Breaking change

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Changes are responsive and mobile-friendly
- [x] Dark mode compatibility verified
- [x] No console errors or warnings