### PR TITLE
fix(bulma-ui): restrict semantic-release to bulma-ui scoped commits only

### DIFF
--- a/bulma-ui/release.config.js
+++ b/bulma-ui/release.config.js
@@ -2,7 +2,39 @@ export default {
   branches: ['main'],
   tagFormat: '@allxsmith/bestax-bulma@${version}', // Ensures correct tag format for this package
   plugins: [
-    '@semantic-release/commit-analyzer',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular',
+        releaseRules: [
+          // Only release for bulma-ui scoped commits
+          { type: 'feat', scope: 'bulma-ui', release: 'minor' },
+          { type: 'fix', scope: 'bulma-ui', release: 'patch' },
+          { type: 'perf', scope: 'bulma-ui', release: 'patch' },
+          { type: 'refactor', scope: 'bulma-ui', release: 'patch' },
+          { type: 'style', scope: 'bulma-ui', release: 'patch' },
+
+          // Breaking changes for bulma-ui
+          { breaking: true, scope: 'bulma-ui', release: 'major' },
+
+          // Explicitly ignore docs and other scopes
+          { scope: 'docs', release: false },
+          { scope: 'docs/*', release: false },
+          { type: 'docs', release: false },
+          { type: 'chore', release: false },
+          { type: 'ci', release: false },
+          { type: 'test', release: false },
+          { type: 'build', release: false },
+
+          // IMPORTANT: Ignore all commits without bulma-ui scope
+          { type: 'feat', release: false },
+          { type: 'fix', release: false },
+          { type: 'perf', release: false },
+          { type: 'refactor', release: false },
+          { type: 'style', release: false },
+        ],
+      },
+    ],
     '@semantic-release/release-notes-generator',
     [
       '@semantic-release/changelog',

--- a/bulma-ui/release.config.js
+++ b/bulma-ui/release.config.js
@@ -19,7 +19,6 @@ export default {
 
           // Explicitly ignore docs and other scopes
           { scope: 'docs', release: false },
-          { scope: 'docs/*', release: false },
           { type: 'docs', release: false },
           { type: 'chore', release: false },
           { type: 'ci', release: false },


### PR DESCRIPTION
# 🐛 Bug Fix Pull Request

## Description

This PR fixes the semantic-release configuration that was incorrectly triggering npm publishes for documentation commits. The issue was that commits like `feat(docs): update documentation` were triggering new package releases of `@allxsmith/bestax-bulma` even though they didn't contain any package changes.

The fix adds explicit `releaseRules` to the semantic-release configuration to ensure only commits scoped to `bulma-ui` trigger releases.

## Related Issue(s)

Fixes #62

## Affected Package(s)

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Checklist

- [ ] I have added a test to confirm the fix
- [x] All tests are passing after my change
- [ ] I have documented the fix if necessary

## Additional Context

### Changes Made:
- Updated `bulma-ui/release.config.js` to add `releaseRules` configuration
- Only `feat(bulma-ui)` and `fix(bulma-ui)` commits will now trigger releases
- Explicitly ignore `docs` scope and unscoped commits
- This prevents accidental npm publishes from documentation or other monorepo changes

### Testing:
After this change:
- `feat(docs): update docs` → No release
- `feat(bulma-ui): add new component` → Minor release
- `fix(bulma-ui): fix button bug` → Patch release
- `feat: generic feature` → No release