### PR TITLE
fix(bulma-ui): complete domain migration and fix semantic-release configuration

### DIFF
--- a/bulma-ui/release.config.js
+++ b/bulma-ui/release.config.js
@@ -24,13 +24,6 @@ export default {
           { type: 'ci', release: false },
           { type: 'test', release: false },
           { type: 'build', release: false },
-
-          // IMPORTANT: Ignore all commits without bulma-ui scope
-          { type: 'feat', release: false },
-          { type: 'fix', release: false },
-          { type: 'perf', release: false },
-          { type: 'refactor', release: false },
-          { type: 'style', release: false },
         ],
       },
     ],

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -108,12 +108,12 @@ const config = {
             'bulma, bulma-react, bulma components, bulma ui, react, react components, react bulma, react-bulma-components, react ui, typescript, component library, ui library, ui kit, design system, frontend, web components, css framework, bootstrap alternative, material alternative, storybook',
         },
         { name: 'twitter:card', content: 'summary_large_image' },
-        { name: 'algolia-site-verification', content: '23EA554671D943E3' },
+        // { name: 'algolia-site-verification', content: '23EA554671D943E3' },
       ],
       algolia: {
         appId: 'O2KH2Y2NMJ',
-        apiKey: '03541df6645f47b7c9833bc1c162fe96',
-        indexName: 'bestax_cc_o2kh2y2nmj_pages',
+        apiKey: '18510063a0a75567625bf05512573ad6',
+        indexName: 'docs_bestax.io',
         contextualSearch: true, // Recommended for multi-language or multi-version sites
         searchPagePath: 'search', // Enables a dedicated search page at /search
       },


### PR DESCRIPTION
# Pull Request

## Description

Complete the domain migration from bestax.cc to bestax.io by updating Algolia search configuration and fixing semantic-release to properly trigger npm releases for bulma-ui scoped commits.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Fixes #64

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [x] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated

## Screenshots / Demos

Changes made:
1. **Algolia Configuration**: Updated to use new index `docs_bestax.io` with corresponding API key
2. **Semantic Release Fix**: Removed catch-all rules that were preventing bulma-ui scoped commits from triggering releases

## Additional Context

This PR completes the domain migration that was partially done in PR #70. The previous merge didn't trigger an npm release due to:

1. **Algolia needed reconfiguration** - Now using the new index for bestax.io domain
2. **Semantic-release configuration issue** - The catch-all rules at the end of releaseRules were preventing ANY commits from triggering releases, even properly scoped ones

After this PR is merged, semantic-release will properly recognize `fix(bulma-ui):` and `feat(bulma-ui):` commits and trigger appropriate npm package releases. This will publish version 2.1.1 with the updated domain references in the package metadata and documentation.