### PR TITLE
feat(docs): add Google Analytics tracking for usage insights

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -79,6 +79,15 @@ const config = {
   //     type: 'text/css',
   //   },
   // ],
+  plugins: [
+    [
+      '@docusaurus/plugin-google-gtag',
+      {
+        trackingID: 'G-KKBQGEHBY7',
+        anonymizeIP: true, // For GDPR compliance
+      },
+    ],
+  ],
   themes: [
     '@docusaurus/theme-live-codeblock',
     // '@docusaurus/theme-mermaid',

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@allxsmith/bestax-bulma": "^2.0.0",
     "@docusaurus/core": "^3.8.1",
+    "@docusaurus/plugin-google-gtag": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-live-codeblock": "^3.8.1",
     "@fortawesome/fontawesome-free": "^6.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
     },
     "bulma-ui": {
       "name": "@allxsmith/bestax-bulma",
-      "version": "2.0.1",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^9.0.3",
@@ -103,6 +103,7 @@
       "dependencies": {
         "@allxsmith/bestax-bulma": "^2.0.0",
         "@docusaurus/core": "^3.8.1",
+        "@docusaurus/plugin-google-gtag": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
         "@docusaurus/theme-live-codeblock": "^3.8.1",
         "@fortawesome/fontawesome-free": "^6.7.2",


### PR DESCRIPTION
## Summary
- Integrated Google Analytics (GA4) into the Docusaurus documentation site
- Configured tracking with measurement ID G-KKBQGEHBY7
- Enabled IP anonymization for GDPR compliance

## Changes
- Installed `@docusaurus/plugin-google-gtag` package
- Added Google Analytics plugin configuration to `docusaurus.config.js`
- Configured GA4 tracking to monitor documentation usage and user behavior

## Test plan
- [x] Build documentation site successfully
- [ ] Deploy to production and verify GA4 tracking in Google Analytics dashboard
- [ ] Confirm page views are being tracked
- [ ] Verify IP anonymization is working

Closes #68