### PR TITLE
fix(bulma-ui): improve npm package discoverability with optimized keywords and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# bestax-bulma
+# @allxsmith/bestax-bulma
+
+[![npm version](https://img.shields.io/npm/v/@allxsmith/bestax-bulma.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+[![npm downloads](https://img.shields.io/npm/dm/@allxsmith/bestax-bulma.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@allxsmith/bestax-bulma.svg)](https://bundlephobia.com/package/@allxsmith/bestax-bulma)
+[![TypeScript](https://img.shields.io/badge/TypeScript-100%25-blue.svg)](https://www.typescriptlang.org/)
+[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax)
+[![Bulma](https://img.shields.io/badge/Bulma-v1.0+-00d1b2.svg)](https://bulma.io)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+React Bulma components library - TypeScript-first component library for Bulma CSS framework. Build accessible, modern UIs with fully-typed React components.
 
 A modern, flexible React component library built with the latest Bulma v1 and TypeScript.
 

--- a/bulma-ui/README.md
+++ b/bulma-ui/README.md
@@ -1,4 +1,14 @@
-# bestax-bulma
+# @allxsmith/bestax-bulma
+
+[![npm version](https://img.shields.io/npm/v/@allxsmith/bestax-bulma.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+[![npm downloads](https://img.shields.io/npm/dm/@allxsmith/bestax-bulma.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@allxsmith/bestax-bulma.svg)](https://bundlephobia.com/package/@allxsmith/bestax-bulma)
+[![TypeScript](https://img.shields.io/badge/TypeScript-100%25-blue.svg)](https://www.typescriptlang.org/)
+[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax)
+[![Bulma](https://img.shields.io/badge/Bulma-v1.0+-00d1b2.svg)](https://bulma.io)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+React Bulma components library - TypeScript-first component library for Bulma CSS framework. Build accessible, modern UIs with fully-typed React components.
 
 A modern, flexible React component library built with the latest Bulma v1 and TypeScript.
 

--- a/bulma-ui/package.json
+++ b/bulma-ui/package.json
@@ -78,27 +78,10 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "keywords": [
-    "bulma",
-    "bulma-react",
-    "bulma components",
-    "bulma ui",
     "react",
-    "react components",
-    "react bulma",
-    "react bulma components",
-    "react ui",
+    "bulma",
     "typescript",
-    "component library",
-    "ui library",
-    "ui kit",
-    "design system",
-    "frontend",
-    "web components",
-    "css framework",
-    "bootstrap alternative",
-    "material alternative",
-    "storybook",
-    "bestax"
+    "components"
   ],
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -46,27 +46,10 @@
     "typescript": "^5.8.3"
   },
   "keywords": [
-    "bulma",
-    "bulma-react",
-    "bulma components",
-    "bulma ui",
     "react",
-    "react components",
-    "react bulma",
-    "react-bulma-components",
-    "react ui",
+    "bulma",
     "typescript",
-    "component library",
-    "ui library",
-    "ui kit",
-    "design system",
-    "frontend",
-    "web components",
-    "css framework",
-    "bootstrap alternative",
-    "material alternative",
-    "storybook",
-    "bestax"
+    "components"
   ],
   "commitlint": {
     "extends": [


### PR DESCRIPTION
# 🐛 Bug Fix Pull Request

## Description

Fixed poor npm search discoverability by optimizing keywords and adding trust badges. The previous keyword strategy with 20+ terms was diluting search relevance for core queries like "React Bulma". This fix reduces keywords to an ultra-focused list and adds npm badges to improve trust signals and conversion rates.

## Related Issue(s)

Closes #72

## Affected Package(s)

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Checklist

- [ ] I have added a test to confirm the fix
- [x] All tests are passing after my change
- [x] I have documented the fix if necessary

## Additional Context

### Changes Made:
- Reduced keywords from 20+ to 4 ultra-focused terms: `react`, `bulma`, `typescript`, `components`
- Added 7 npm badges to both README files (version, downloads, bundle size, TypeScript, coverage, Bulma compatibility, MIT license)
- Updated README headers with improved package name and description

### Expected Impact:
- **Search ranking**: Dramatically improved relevance score for "React Bulma" searches
- **Trust signals**: Badges provide social proof and technical validation
- **Conversion rate**: Professional appearance increases installs from search results

This fix trades broad discoverability for dominant ranking in core searches, which should result in more targeted traffic and higher conversion rates.