### PR TITLE
fix(docs): update Storybook logo path to /img/logo.svg (#85)

### DIFF
--- a/bulma-ui/.storybook/manager-head.html
+++ b/bulma-ui/.storybook/manager-head.html
@@ -1,4 +1,4 @@
-<link rel="icon" type="image/svg+xml" href="/logo.svg" />
+<link rel="icon" type="image/svg+xml" href="/img/logo.svg" />
 <style>
   /* Control logo size in sidebar */
   .sidebar-header img {

--- a/bulma-ui/.storybook/manager.ts
+++ b/bulma-ui/.storybook/manager.ts
@@ -12,7 +12,7 @@ const lightTheme = create({
   base: 'light',
   brandTitle: 'Bestax Bulma',
   brandUrl: 'https://bestax.io',
-  brandImage: '/logo.svg',
+  brandImage: '/img/logo.svg',
   brandTarget: '_self',
   // Control logo size
   layoutMargin: 10,
@@ -22,7 +22,7 @@ const darkTheme = create({
   base: 'dark',
   brandTitle: 'Bestax Bulma',
   brandUrl: 'https://bestax.io',
-  brandImage: '/logo.svg',
+  brandImage: '/img/logo.svg',
   brandTarget: '_self',
   // Control logo size
   layoutMargin: 10,


### PR DESCRIPTION
# 📝 Documentation Update Pull Request

## Description

Fix missing logo and favicon in deployed Storybook by updating the logo path from `/logo.svg` to `/img/logo.svg`.

The Storybook is deployed at `bestax.io/storybook` and shares static assets with the Docusaurus site. The logo needs to reference the Docusaurus static assets location at `/img/logo.svg` instead of `/logo.svg`.

## Related Issue(s)

Refs #85

## Checklist

- [x] Only documentation files are affected
- [x] I have checked formatting and spelling
- [x] Screenshots or previews added if relevant

## Additional Context

**Files Changed:**
- `bulma-ui/.storybook/manager.ts` - Updated `brandImage` from `/logo.svg` to `/img/logo.svg`
- `bulma-ui/.storybook/manager-head.html` - Updated favicon href from `/logo.svg` to `/img/logo.svg`

**URLs:**
- Deployed Storybook: https://bestax.io/storybook
- Working logo URL: https://bestax.io/img/logo.svg
- Broken logo URL: https://bestax.io/logo.svg (404)