### PR TITLE
fix(docs): remove Google Analytics and add robots.txt (#88)

### DIFF
--- a/bulma-ui/.storybook/manager.ts
+++ b/bulma-ui/.storybook/manager.ts
@@ -1,13 +1,6 @@
 import { addons } from 'storybook/manager-api';
 import { create } from 'storybook/theming';
 
-// Extend Window interface for GTM
-declare global {
-  interface Window {
-    dataLayer: any[];
-  }
-}
-
 const lightTheme = create({
   base: 'light',
   brandTitle: 'Bestax Bulma',
@@ -34,22 +27,3 @@ const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 addons.setConfig({
   theme: prefersDark ? darkTheme : lightTheme,
 });
-
-// Google Tag Manager integration
-if (typeof window !== 'undefined') {
-  // Load GTM script
-  const script = document.createElement('script');
-  script.async = true;
-  script.src = 'https://www.googletagmanager.com/gtag/js?id=G-KKBQGEHBY7';
-  document.head.appendChild(script);
-
-  // Initialize GTM
-  window.dataLayer = window.dataLayer || [];
-  function gtag(...args: any[]) {
-    window.dataLayer.push(args);
-  }
-  gtag('js', new Date());
-  gtag('config', 'G-KKBQGEHBY7', {
-    anonymize_ip: true,
-  });
-}

--- a/bulma-ui/public/robots.txt
+++ b/bulma-ui/public/robots.txt
@@ -1,0 +1,18 @@
+# robots.txt for bestax.io/storybook - Component documentation
+# Modern content signals approach for AI discovery and training
+
+# ============================================================================
+# PERMISSIONS (All uses allowed - search engines and AI)
+# ============================================================================
+
+User-agent: *
+Allow: /
+search: yes
+ai-input: yes
+ai-train: yes
+
+# ============================================================================
+# SITEMAP
+# ============================================================================
+
+Sitemap: https://bestax.io/sitemap.xml

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -79,15 +79,7 @@ const config = {
   //     type: 'text/css',
   //   },
   // ],
-  plugins: [
-    [
-      '@docusaurus/plugin-google-gtag',
-      {
-        trackingID: 'G-KKBQGEHBY7',
-        anonymizeIP: true, // For GDPR compliance
-      },
-    ],
-  ],
+  plugins: [],
   themes: [
     '@docusaurus/theme-live-codeblock',
     // '@docusaurus/theme-mermaid',

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@allxsmith/bestax-bulma": "^2.0.0",
     "@docusaurus/core": "^3.8.1",
-    "@docusaurus/plugin-google-gtag": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-live-codeblock": "^3.8.1",
     "@fortawesome/fontawesome-free": "^6.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     },
     "bulma-ui": {
       "name": "@allxsmith/bestax-bulma",
-      "version": "2.1.3",
+      "version": "2.3.3",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^9.0.3",
@@ -98,7 +98,7 @@
       }
     },
     "create-bestax": {
-      "version": "0.1.0",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -167,7 +167,6 @@
       "dependencies": {
         "@allxsmith/bestax-bulma": "^2.0.0",
         "@docusaurus/core": "^3.8.1",
-        "@docusaurus/plugin-google-gtag": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
         "@docusaurus/theme-live-codeblock": "^3.8.1",
         "@fortawesome/fontawesome-free": "^6.7.2",


### PR DESCRIPTION
# 📝 Documentation Update Pull Request

## Description

Remove Google Analytics tracking from both Docusaurus and Storybook, and add a robots.txt file to Storybook with modern AI content signals.

This change:
- Uninstalls and removes `@docusaurus/plugin-google-gtag` from Docusaurus
- Removes manual GTM implementation from Storybook
- Adds robots.txt to Storybook following the same modern content signals standard as the main site

## Related Issue(s)

Refs #88

## Checklist

- [x] Only documentation files are affected
- [x] I have checked formatting and spelling
- [x] Screenshots or previews added if relevant

## Additional Context

**Files Changed:**
- `docs/package.json` - Removed @docusaurus/plugin-google-gtag dependency
- `docs/docusaurus.config.js` - Removed Google Analytics plugin configuration
- `bulma-ui/.storybook/manager.ts` - Removed manual GTM implementation and window.dataLayer interface
- `bulma-ui/public/robots.txt` - Added with AI content signals (search: yes, ai-input: yes, ai-train: yes)
- `package-lock.json` - Updated after package removal

**Rationale:**
- Simplifies tracking infrastructure
- Both sites now use consistent robots.txt with modern AI content signals
- Removes unnecessary analytics overhead

**robots.txt Preview:**
The new Storybook robots.txt follows the same modern content signals approach as the main site, allowing search engines and AI to index and use the content.