### PR TITLE
Synchronize create-bestax and bestax-bulma versions to 2.4.0

### DIFF
--- a/create-bestax/package.json
+++ b/create-bestax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bestax",
-  "version": "1.2.0",
+  "version": "2.4.0",
   "description": "Create a new bestax-bulma project",
   "type": "module",
   "bin": {
@@ -48,7 +48,7 @@
     "url": "https://github.com/allxsmith/bestax/issues"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "^2.1.3",
+    "@allxsmith/bestax-bulma": "2.4.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "fs-extra": "^11.2.0",

--- a/create-bestax/templates/vite-ts/package.json
+++ b/create-bestax/templates/vite-ts/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "^2.1.3",
+    "@allxsmith/bestax-bulma": "^2.4.0",
     "bulma": "^1.0.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/create-bestax/templates/vite/package.json
+++ b/create-bestax/templates/vite/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "^2.1.3",
+    "@allxsmith/bestax-bulma": "^2.4.0",
     "bulma": "^1.0.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"


### PR DESCRIPTION
## Description

This PR synchronizes the version numbers between create-bestax and @allxsmith/bestax-bulma packages to 2.4.0.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Closes #96

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated

## Changes Made

- Updated create-bestax version from 1.2.0 to 2.4.0
- Updated @allxsmith/bestax-bulma dependency to exact version 2.4.0 (removed caret)
- This is a one-time manual synchronization to align package versions
- Future releases will use independent versioning with caret ranges

## Additional Context

This is a one-time manual synchronization. After this PR, both packages will release independently based on their actual changes, and create-bestax will use caret ranges for its bestax-bulma dependency.