### PR TITLE
fix(create-bestax): read version from package.json instead of hardcoded value

### DIFF
--- a/create-bestax/src/cli.ts
+++ b/create-bestax/src/cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { ProjectCreator, type CLIOptions } from './project-creator.js';
 import { copyDirectory } from './file-system.js';
 
@@ -64,6 +67,18 @@ export async function createProject(
   return projectCreator.create(projectDir, options);
 }
 
+function getPackageVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const packageJsonPath = join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    return packageJson.version || '0.1.0';
+  } catch {
+    return '0.1.0';
+  }
+}
+
 export function createCLI(): Command {
   const program = new Command();
   const projectCreator = new ProjectCreator();
@@ -71,7 +86,7 @@ export function createCLI(): Command {
   program
     .name('create-bestax')
     .description('Create a new bestax-bulma project')
-    .version('0.1.0')
+    .version(getPackageVersion())
     .argument('[project-directory]', 'project directory to create')
     .option('-t, --template <template>', 'template to use (vite, vite-ts)')
     .option(


### PR DESCRIPTION
# Pull Request

## Description

Fixed the CLI version display to read from package.json instead of using a hardcoded value. The CLI was showing version 0.1.0 when it should display the actual package version (1.4.0).

- [x] create-bestax (`create-bestax`)

## Related Issue(s)

Testing visual regression CI/CD workflow

## Type of Change

- [x] Bug fix

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated

## Screenshots / Demos

Before: CLI displayed version 0.1.0
After: CLI displays version 1.4.0 (from package.json)

## Additional Context

This PR is primarily to test the visual regression testing workflow after the fixes in PR #108.