### PR TITLE
fix: implement independent package versioning strategy

### DIFF
--- a/bulma-ui/release.config.js
+++ b/bulma-ui/release.config.js
@@ -7,23 +7,15 @@ export default {
       {
         preset: 'angular',
         releaseRules: [
-          // Release for BOTH bulma-ui AND create-bestax scoped commits (synchronized versioning)
+          // Release only for bulma-ui scoped commits (independent versioning)
           { type: 'feat', scope: 'bulma-ui', release: 'minor' },
           { type: 'fix', scope: 'bulma-ui', release: 'patch' },
           { type: 'perf', scope: 'bulma-ui', release: 'patch' },
           { type: 'refactor', scope: 'bulma-ui', release: 'patch' },
           { type: 'style', scope: 'bulma-ui', release: 'patch' },
 
-          // Also release for create-bestax changes (keeps versions in sync)
-          { type: 'feat', scope: 'create-bestax', release: 'minor' },
-          { type: 'fix', scope: 'create-bestax', release: 'patch' },
-          { type: 'perf', scope: 'create-bestax', release: 'patch' },
-          { type: 'refactor', scope: 'create-bestax', release: 'patch' },
-          { type: 'style', scope: 'create-bestax', release: 'patch' },
-
-          // Breaking changes for either package
+          // Breaking changes for bulma-ui
           { breaking: true, scope: 'bulma-ui', release: 'major' },
-          { breaking: true, scope: 'create-bestax', release: 'major' },
 
           // Explicitly ignore docs and other scopes
           { scope: 'docs', release: false },

--- a/create-bestax/package.json
+++ b/create-bestax/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/allxsmith/bestax/issues"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "2.4.0",
+    "@allxsmith/bestax-bulma": "^2.6.1",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "figures": "^3.2.0",

--- a/create-bestax/release.config.js
+++ b/create-bestax/release.config.js
@@ -7,23 +7,15 @@ export default {
       {
         preset: 'angular',
         releaseRules: [
-          // Release for BOTH create-bestax AND bulma-ui scoped commits (synchronized versioning)
+          // Release only for create-bestax scoped commits (independent versioning)
           { type: 'feat', scope: 'create-bestax', release: 'minor' },
           { type: 'fix', scope: 'create-bestax', release: 'patch' },
           { type: 'perf', scope: 'create-bestax', release: 'patch' },
           { type: 'refactor', scope: 'create-bestax', release: 'patch' },
           { type: 'style', scope: 'create-bestax', release: 'patch' },
 
-          // Also release for bulma-ui changes (keeps versions in sync)
-          { type: 'feat', scope: 'bulma-ui', release: 'minor' },
-          { type: 'fix', scope: 'bulma-ui', release: 'patch' },
-          { type: 'perf', scope: 'bulma-ui', release: 'patch' },
-          { type: 'refactor', scope: 'bulma-ui', release: 'patch' },
-          { type: 'style', scope: 'bulma-ui', release: 'patch' },
-
-          // Breaking changes for either package
+          // Breaking changes for create-bestax
           { breaking: true, scope: 'create-bestax', release: 'major' },
-          { breaking: true, scope: 'bulma-ui', release: 'major' },
 
           // Explicitly ignore docs and other scopes
           { scope: 'docs', release: false },


### PR DESCRIPTION
# Pull Request

## Description

This PR implements independent versioning for bestax-bulma and create-bestax packages, fixing an issue where both packages were publishing new versions regardless of which package actually changed.

**Changes:**
1. Removed cross-package release rules from both semantic-release configs
2. Updated create-bestax dependency on bestax-bulma from pinned `2.4.0` to semver range `^2.6.1`
3. Each package now publishes independently based on its own scoped commits

**Benefits:**
- bestax-bulma only publishes when bulma-ui changes
- create-bestax only publishes when create-bestax changes
- Users automatically receive latest compatible bestax-bulma version (no longer stuck on 2.4.0)
- Reduces unnecessary npm publishes

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)

## Related Issue(s)

Fixes #110

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated

## Screenshots / Demos

N/A - This is a build configuration change

## Additional Context

### Before
- PR #109 (scoped to `create-bestax`) triggered releases for both packages
- create-bestax depended on outdated bestax-bulma@2.4.0
- Users couldn't benefit from new bestax-bulma versions

### After  
- Only the changed package will publish new versions
- create-bestax uses `^2.6.1` allowing automatic updates to latest compatible version
- Users running `npm create bestax` will get the latest bestax-bulma