### PR TITLE
feat(create-bestax)!: require Node.js 18+ and align with bestax-bulma v2

### DIFF
--- a/create-bestax/package.json
+++ b/create-bestax/package.json
@@ -38,6 +38,9 @@
   ],
   "author": "Alex Smith",
   "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/allxsmith/bestax.git",

--- a/create-bestax/src/index.ts
+++ b/create-bestax/src/index.ts
@@ -12,8 +12,8 @@ if (majorVersion < MINIMUM_NODE_VERSION) {
   console.error(
     chalk.red(
       `Error: create-bestax requires Node.js v${MINIMUM_NODE_VERSION}.0.0 or higher.\n` +
-      `You are currently running Node.js v${currentNodeVersion}.\n` +
-      `Please upgrade your Node.js version.`
+        `You are currently running Node.js v${currentNodeVersion}.\n` +
+        `Please upgrade your Node.js version.`
     )
   );
   process.exit(1);

--- a/create-bestax/src/index.ts
+++ b/create-bestax/src/index.ts
@@ -1,6 +1,23 @@
 #!/usr/bin/env node
 
 import { createCLI } from './cli.js';
+import chalk from 'chalk';
+
+// Check Node.js version requirement (Breaking change for v2.0.0)
+const currentNodeVersion = process.versions.node;
+const majorVersion = parseInt(currentNodeVersion.split('.')[0], 10);
+const MINIMUM_NODE_VERSION = 18;
+
+if (majorVersion < MINIMUM_NODE_VERSION) {
+  console.error(
+    chalk.red(
+      `Error: create-bestax requires Node.js v${MINIMUM_NODE_VERSION}.0.0 or higher.\n` +
+      `You are currently running Node.js v${currentNodeVersion}.\n` +
+      `Please upgrade your Node.js version.`
+    )
+  );
+  process.exit(1);
+}
 
 const program = createCLI();
 program.parse();


### PR DESCRIPTION
## Breaking Change 🚨

This PR introduces a **major version bump to v2.0.0** for create-bestax to align with the bestax-bulma v2.x ecosystem.

## Summary
- ✅ Enforces Node.js 18.0.0 or higher requirement
- ✅ Aligns create-bestax version with bestax-bulma v2.x
- ✅ Includes the new logo-centric homepage design from PR #116

## Breaking Changes
- **Minimum Node.js version**: Now requires Node.js 18.0.0 or higher
- The CLI will exit with a clear error message if running on Node.js < 18
- Added `engines` field to package.json to enforce this requirement

## Why Node.js 18+?
- Node.js 16 reached end-of-life in September 2023
- Node.js 18 is the current LTS with support until April 2025
- Aligns with modern tooling requirements (Vite 5+, etc.)
- Security and performance improvements

## Changes
- Added Node.js version check in `src/index.ts`
- Added `engines` field to `package.json`

## Testing
The change is straightforward - the CLI will:
1. Check the Node.js version on startup
2. Display a helpful error message if < 18
3. Exit gracefully, prompting users to upgrade

This change ensures users are on a supported, secure version of Node.js when creating new Bestax projects.