### PR TITLE
🐛 Fix bulma-ui release config to ignore create-bestax commits

### DIFF
--- a/bulma-ui/release.config.js
+++ b/bulma-ui/release.config.js
@@ -7,6 +7,10 @@ export default {
       {
         preset: 'angular',
         releaseRules: [
+          // Explicitly ignore create-bestax scoped commits (including breaking changes)
+          { scope: 'create-bestax', release: false },
+          { breaking: true, scope: 'create-bestax', release: false },
+
           // Release only for bulma-ui scoped commits (independent versioning)
           { type: 'feat', scope: 'bulma-ui', release: 'minor' },
           { type: 'fix', scope: 'bulma-ui', release: 'patch' },


### PR DESCRIPTION
# 🐛 Bug Fix Pull Request

## Description

This PR fixes the bulma-ui semantic-release configuration to explicitly ignore commits scoped to create-bestax, including breaking changes. This was causing CI failures when create-bestax had breaking changes, as bulma-ui would incorrectly attempt to bump its version.

## Related Issue(s)

Fixes #119

## Affected Package(s)

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Checklist

- [x] I have added a test to confirm the fix (configuration change, tested in CI)
- [x] All tests are passing after my change
- [x] I have documented the fix if necessary (added inline comments in config)

## Additional Context

The issue was that when PR #118 introduced a breaking change for create-bestax (Node.js 18+ requirement), the bulma-ui semantic-release tried to bump to v3.0.0, causing npm dependency conflicts. This fix ensures true independent versioning where:
- create-bestax will correctly bump to 2.0.0 
- bulma-ui will remain at 2.6.2 (no version change)

The fix adds explicit rules to the bulma-ui release.config.js to ignore all create-bestax scoped commits.