### PR TITLE
docs: update bestax-bulma blog post with comparison table and opensource blurb

### DIFF
--- a/docs/blog/2025-09-24-meet-bestax-bulma/index.md
+++ b/docs/blog/2025-09-24-meet-bestax-bulma/index.md
@@ -16,6 +16,8 @@ canonical_url: https://bestax.io/blog/2025/09/24/meet-bestax-bulma
 
 Hey React developers! 👋 Are you looking for a modern, actively maintained component library for Bulma CSS? Let me introduce you to **bestax-bulma** (pronounced "bee-stacks"), a TypeScript-first React component library that brings the full power of Bulma v1 to your React applications.
 
+**Opensource! Free as in beer🍺**
+
 <!-- truncate -->
 
 ## Why Another Bulma React Library?
@@ -219,14 +221,19 @@ Want to see bestax-bulma in action? Check out [bestax.io](https://bestax.io) for
 
 ## Comparison with Alternatives
 
-| Feature             | bestax-bulma | react-bulma-components | rbx     | bulma-react |
-| ------------------- | ------------ | ---------------------- | ------- | ----------- |
-| Bulma v1 Support    | ✅           | ❌                     | ❌      | ❌          |
-| TypeScript          | ✅ Built-in  | ⚠️ Separate            | ✅      | ❌          |
-| Test Coverage       | 99%          | ~70%                   | ~80%    | Unknown     |
-| Active Maintenance  | ✅ 2025      | ⚠️ 2023                | ❌ 2021 | ❌ 2020     |
-| Tree Shaking        | ✅           | ✅                     | ✅      | ❌          |
-| Compound Components | ✅           | ❌                     | ❌      | ❌          |
+| Feature             | bestax-bulma | react-bulma-components | rbx          | bulma-react |
+| ------------------- | ------------ | ---------------------- | ------------ | ----------- |
+| Bulma v1 Support    | ✅           | ❌                     | ❌           | ❌          |
+| TypeScript          | ✅ Built-in  | ⚠️ Separate            | ✅           | ❌          |
+| Test Coverage       | 99%          | ~70%                   | ~100%        | Unknown     |
+| Active Maintenance  | ✅ 2025      | ⚠️ 2021                | ❌ 2019      | ❌ 2015     |
+| Tree Shaking        | ✅           | ✅                     | ✅           | ❌          |
+| Compound Components | ✅           | ❌                     | ✅           | ❌          |
+| Comprehensive Docs  | ✅           | ❌                     | ⚠️ Partial   | ❌          |
+| Real CSS Grids      | ✅           | ❌                     | ❌           | ❌          |
+| Configurable        | ✅           | ❌                     | ❌           | ❌          |
+| Theme Support       | ✅           | ❌                     | ❌           | ❌          |
+| Quick Start CLI     | ✅           | ❌                     | ❌           | ❌          |
 
 ## Get Started Today
 


### PR DESCRIPTION
# 📝 Documentation Update Pull Request

## Description

Updated the "Meet bestax-bulma" blog post with corrected comparison table details and an opensource blurb. The changes include:

- Added "Opensource! Free as in beer🍺" blurb after the intro paragraph
- Updated comparison table with corrected maintenance dates for competing libraries (2023→2021, 2021→2019, 2020→2015)
- Added 5 new feature comparison rows: Comprehensive Docs, Real CSS Grids, Configurable, Theme Support, Quick Start CLI
- Corrected rbx test coverage from ~80% to ~100%
- Added compound components support notation for rbx

## Related Issue(s)

Closes #123

## Checklist

- [x] Only documentation files are affected
- [x] I have checked formatting and spelling
- [ ] Screenshots or previews added if relevant

## Additional Context

These changes need to be synchronized to the Dev.to and Medium articles after merging:
- Dev.to: https://dev.to/allxsmith/meet-bestax-bulma-modern-react-components-for-bulma-css-v1-4bf2
- Medium: https://medium.com/@allxsmith/meet-bestax-bulma-modern-react-components-for-bulma-css-v1-bestax-bulma-5671f797dfa4