### PR TITLE
feat(docs): migrate from GitHub Pages to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,16 @@
-name: Deploy to GitHub Pages
+name: Deploy to Cloudflare Pages
 
 on:
   push:
     branches:
       - main
+
 permissions:
   contents: read
 
 jobs:
   build-and-deploy:
-    name: Build Docusaurus and Storybook
+    name: Build and Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -35,24 +36,9 @@ jobs:
           mkdir -p docs/build/storybook
           cp -r bulma-ui/storybook-static/* docs/build/storybook/
 
-      - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
         with:
-          path: docs/build
-
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build-and-deploy
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    outputs:
-      page_url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs/build --project-name=bestax --commit-dirty=true

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     branches:
       - main
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test-deploy:
-    name: Test Docusaurus deployment
+    name: Test and Preview Deployment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,5 +24,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test build website
+      - name: Build Docusaurus
         run: npm run build -- --filter=@allxsmith/bestax-docs
+
+      - name: Build Storybook
+        run: npm run build-storybook -w bulma-ui
+
+      - name: Copy Storybook to Docusaurus build
+        run: |
+          mkdir -p docs/build/storybook
+          cp -r bulma-ui/storybook-static/* docs/build/storybook/
+
+      - name: Deploy Preview to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        id: deploy
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs/build --project-name=bestax --branch=${{ github.head_ref }} --commit-dirty=true
+
+      - name: Comment Preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '## Preview Deployment\n\nPreview URL: ${{ steps.deploy.outputs.deployment-url }}'
+            })

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,0 @@
-bestax.io


### PR DESCRIPTION
# Pull Request

## Description

Migrate hosting from GitHub Pages to Cloudflare Pages using GitHub Actions + Wrangler CLI.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): GitHub Actions workflows

## Related Issue(s)

Closes #131

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated

## Screenshots / Demos

N/A - Infrastructure change

## Additional Context

### Changes Made
- **deploy.yml**: Updated to use `cloudflare/wrangler-action@v3` instead of `actions/deploy-pages@v4`
- **test-deploy.yml**: Now deploys PR previews to Cloudflare Pages and comments the preview URL on PRs
- **docs/static/CNAME**: Deleted (GitHub Pages specific)

### Required Manual Steps (before merging)
1. Add GitHub secrets:
   - `CLOUDFLARE_API_TOKEN`
   - `CLOUDFLARE_ACCOUNT_ID`

### Required Manual Steps (after merging)
1. Configure custom domain `bestax.io` in Cloudflare Pages dashboard
2. Remove old GitHub Pages DNS records
3. Disable GitHub Pages in repository settings