### PR TITLE
fix(docs): correct Content Signals syntax in robots.txt

### DIFF
--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -33,9 +33,7 @@
 
 User-agent: *
 Allow: /
-search: yes
-ai-input: yes
-ai-train: yes
+Content-signal: search=yes, ai-input=yes, ai-train=yes
 
 # ============================================================================
 # SITEMAP


### PR DESCRIPTION
# 📝 Documentation Update Pull Request

## Description

Fixed invalid Content Signals syntax in `robots.txt` that was causing Google Search Console errors.

Changed from invalid separate directives:
```
search: yes
ai-input: yes
ai-train: yes
```

To the correct Cloudflare Content Signals format:
```
Content-signal: search=yes, ai-input=yes, ai-train=yes
```

## Related Issue(s)

Fixes #133

## Checklist

- [x] Only documentation files are affected
- [x] I have checked formatting and spelling
- [x] Screenshots or previews added if relevant

## Additional Context

- [Cloudflare Content Signals Policy](https://blog.cloudflare.com/content-signals-policy/)
- [Cloudflare managed robots.txt docs](https://developers.cloudflare.com/bots/additional-configurations/managed-robots-txt/)