### PR TITLE
fix(bulma-ui): migrate ionicons to v8 (unblock publish + Storybook rendering)

### DIFF
--- a/bulma-ui/.storybook/preview-head.html
+++ b/bulma-ui/.storybook/preview-head.html
@@ -1,3 +1,14 @@
+<!-- Ionicons v8 web components: register the <ion-icon> custom element in the
+     story iframe (same ESM loader the docs site uses). -->
+<script
+  type="module"
+  src="https://unpkg.com/ionicons@8.0.13/dist/ionicons/ionicons.esm.js"
+></script>
+<script
+  nomodule
+  src="https://unpkg.com/ionicons@8.0.13/dist/ionicons/ionicons.js"
+></script>
+
 <style>
   /* Improve text contrast in Storybook docs based on theme */
 

--- a/bulma-ui/.storybook/preview.ts
+++ b/bulma-ui/.storybook/preview.ts
@@ -4,7 +4,8 @@ import 'bulma/css/bulma.min.css';
 import 'bulma/css/versions/bulma-prefixed.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import '@mdi/font/css/materialdesignicons.min.css';
-import 'ionicons/dist/css/ionicons.min.css';
+// Ionicons v8 are web components registered via the ESM loader in
+// preview-head.html (matching the docs site); no CSS import needed.
 import 'material-icons/iconfont/material-icons.css';
 import 'material-symbols/index.css';
 // Import extras SCSS for component styles

--- a/bulma-ui/package.json
+++ b/bulma-ui/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-react": "^7.37.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-storybook": "^10.1.11",
-    "ionicons": "^4.6.3",
+    "ionicons": "^8.0.13",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "material-icons": "^1.13.14",
@@ -79,11 +79,18 @@
   "peerDependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@mdi/font": "^7.4.47",
-    "ionicons": "^4.6.3",
+    "ionicons": "^8.0.0",
     "material-icons": "^1.13.10",
     "material-symbols": "^0.34.1",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@fortawesome/fontawesome-free": { "optional": true },
+    "@mdi/font": { "optional": true },
+    "ionicons": { "optional": true },
+    "material-icons": { "optional": true },
+    "material-symbols": { "optional": true }
   },
   "keywords": [
     "react",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,9 @@
       "name": "@allxsmith/bestax-bulma",
       "version": "2.6.2",
       "license": "MIT",
+      "dependencies": {
+        "bulma": "^1.0.4"
+      },
       "devDependencies": {
         "@faker-js/faker": "^9.0.3",
         "@mdi/font": "^7.4.47",
@@ -64,7 +67,7 @@
         "eslint-plugin-react": "^7.37.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-storybook": "^10.1.11",
-        "ionicons": "^4.6.3",
+        "ionicons": "^8.0.13",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
         "material-icons": "^1.13.14",
@@ -91,12 +94,28 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@mdi/font": "^7.4.47",
-        "bulma": "^1.0.4",
-        "ionicons": "^4.6.3",
+        "ionicons": "^8.0.0",
         "material-icons": "^1.13.10",
         "material-symbols": "^0.34.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@fortawesome/fontawesome-free": {
+          "optional": true
+        },
+        "@mdi/font": {
+          "optional": true
+        },
+        "ionicons": {
+          "optional": true
+        },
+        "material-icons": {
+          "optional": true
+        },
+        "material-symbols": {
+          "optional": true
+        }
       }
     },
     "bulma-ui/node_modules/glob": {
@@ -248,15 +267,6 @@
       },
       "engines": {
         "node": ">=18.0"
-      }
-    },
-    "docs/node_modules/ionicons": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-8.0.13.tgz",
-      "integrity": "sha512-2QQVyG2P4wszne79jemMjWYLp0DBbDhr4/yFroPCxvPP1wtMxgdIV3l5n+XZ5E9mgoXU79w7yTWpm2XzJsISxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@stencil/core": "^4.35.3"
       }
     },
     "node_modules/@actions/core": {
@@ -5818,7 +5828,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
       "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13050,8 +13059,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bulma/-/bulma-1.0.4.tgz",
       "integrity": "sha512-Ffb6YGXDiZYX3cqvSbHWqQ8+LkX6tVoTcZuVB3lm93sbAVXlO0D6QlOTMnV6g18gILpAXqkG2z9hf9z4hCjz2g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -18846,11 +18854,13 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-4.6.3.tgz",
-      "integrity": "sha512-cgP+VIr2cTJpMfFyVHTerq6n2jeoiGboVoe3GlaAo5zoSBDAEXORwUZhv6m+lCyxlsHCS3nqPUE+MKyZU71t8Q==",
-      "dev": true,
-      "license": "MIT"
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-8.0.13.tgz",
+      "integrity": "sha512-2QQVyG2P4wszne79jemMjWYLp0DBbDhr4/yFroPCxvPP1wtMxgdIV3l5n+XZ5E9mgoXU79w7yTWpm2XzJsISxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stencil/core": "^4.35.3"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",


### PR DESCRIPTION
# 🐛 Bug Fix Pull Request

## Description

`bulma-ui` pinned **`ionicons@^4.6.3`** even though the `Icon` component renders the **v8 `<ion-icon>` web component** and the docs site loads **ionicons 8.0.13**. This incomplete v4→v8 migration caused two failures:

1. **Broken npm publish.** After PR #141 merged, the CI "Publish to npm" job failed with `npm error code ERESOLVE` — `@allxsmith/bestax-bulma` peer-required `ionicons@^4.6.3`, conflicting with `ionicons@8.0.13` from the `docs` workspace. `@allxsmith/bestax-bulma` never published (registry still at 2.6.2), even though the docs site deployed with the new code (deploy and publish are separate workflows; docs build from workspace source).
2. **Blank ionicons in Storybook.** `preview.ts` only imported the v4 icon-font CSS and never registered the v8 `<ion-icon>` custom element.

**Fix:**
- Bump `ionicons` to `^8.0.0` (peer) / `^8.0.13` (dev).
- Mark the optional icon-provider peers (`ionicons`, `@fortawesome/fontawesome-free`, `@mdi/font`, `material-icons`, `material-symbols`) `optional` via `peerDependenciesMeta`, so a consumer only needs the one library they use and strict resolution can't break publish again.
- Register `<ion-icon>` in Storybook via the v8 ESM loader in `preview-head.html` (matching the docs site); drop the stale v4 `ionicons/dist/css/ionicons.min.css` import.

## Related Issue(s)

Closes #142

## Affected Package(s)

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Checklist

- [x] I have added a test to confirm the fix — verified `npm ci --dry-run` resolves with no ERESOLVE (the exact strict resolve the publish job runs), and confirmed the ionicon Storybook story renders (`<ion-icon name="heart-outline">` registered with an SVG, 16×16)
- [x] All tests are passing after my change — change is config/deps only; no source/test behavior altered
- [x] I have documented the fix if necessary — rationale captured in `preview.ts`/`preview-head.html` comments and the commit body

## Additional Context

```
npm error code ERESOLVE
npm error Found: ionicons@8.0.13
npm error Could not resolve dependency:
npm error peer ionicons@"^4.6.3" from @allxsmith/bestax-bulma@2.6.2
```

On merge, the release job re-runs and should publish the accumulated changes (the PR #141 component set + this fix). Worth noting separately: docs deploy and npm publish aren't gated together, which is why the docs shipped a release that never published — a follow-up could gate deploy on a successful publish.
