### PR TITLE
build: unblock major bulma-ui release (resolve internal workspace deps)

### DIFF
--- a/create-bestax/package.json
+++ b/create-bestax/package.json
@@ -51,7 +51,6 @@
     "url": "https://github.com/allxsmith/bestax/issues"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "^2.6.1",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",
     "figures": "^3.2.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "^2.0.0",
+    "@allxsmith/bestax-bulma": "*",
     "@docusaurus/core": "^3.9.2",
     "@docusaurus/preset-classic": "^3.9.2",
     "@docusaurus/theme-live-codeblock": "^3.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,7 +203,6 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@allxsmith/bestax-bulma": "^2.6.1",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "figures": "^3.2.0",
@@ -244,7 +243,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@allxsmith/bestax-bulma": "^2.0.0",
+        "@allxsmith/bestax-bulma": "*",
         "@docusaurus/core": "^3.9.2",
         "@docusaurus/preset-classic": "^3.9.2",
         "@docusaurus/theme-live-codeblock": "^3.9.2",
@@ -5828,6 +5827,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
       "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -33755,6 +33755,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",


### PR DESCRIPTION
# 🐛 Bug Fix Pull Request

## Description

The first **major** release of `@allxsmith/bestax-bulma` (3.0.0) couldn't publish. semantic-release analyzed the 61 unreleased commits, found `BREAKING CHANGE` footers (Snackbar→Toast, form auto-wrap) → **3.0.0**. But the internal workspace consumers pinned `@allxsmith/bestax-bulma` to `^2.x` (`docs` → `^2.0.0`, `create-bestax` → `^2.6.1`). When `@semantic-release/npm` bumped bulma-ui's version to `3.0.0` in place and npm re-resolved the workspace, those pins conflicted → `ERESOLVE`, and the package never published.

(This is the conflict *after* the ionicons fix in #143 — `Install dependencies`/`Build` now pass; this only triggers on a **major** bump.)

**Fix:**
- **`docs`** (private workspace): pin `@allxsmith/bestax-bulma` to `"*"` so it always resolves to the local workspace package — satisfies the current `2.6.2`, the in-release `3.0.0`, and any future major (no recurrence). No consumer impact since `docs` is private.
- **`create-bestax`** (published CLI): **remove** the unused `@allxsmith/bestax-bulma` dependency. The CLI never imports it — the only references in `src` are string literals it writes into scaffolded projects. This drops the second workspace conflict and de-bloats the published CLI.

A `^3.0.0` pin was rejected as the fix because it would break the *current* `2.6.2` install (chicken-and-egg); `"*"` handles the version transition cleanly.

## Related Issue(s)

Closes #144

## Affected Package(s)

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): `create-bestax`

## Checklist

- [x] I have added a test to confirm the fix — simulated the `3.0.0` major bump locally (`npm install --package-lock-only`) and confirmed the workspace resolves with **no ERESOLVE**; `npm ci --dry-run` passes (lockfile consistent)
- [x] All tests are passing after my change — manifest/lockfile-only change; no source behavior altered
- [x] I have documented the fix if necessary — rationale in the commit body and issue #144

## Additional Context

```
[semantic-release] The next release version is 3.0.0
npm error code ERESOLVE
npm error   @allxsmith/bestax-bulma@"^2.0.0" from @allxsmith/bestax-docs@1.0.0
```

On merge, the release job re-runs and should finally publish **`@allxsmith/bestax-bulma@3.0.0`** (the accumulated PR #141 components + the ionicons fix). Note this is a **major** release — confirm that's intended before merging.

Follow-ups worth considering (out of scope here): gate the docs deploy on a successful publish so they can't diverge, and audit the other internal workspace pins for the same `"*"` treatment.
