### PR TITLE
ci: don't lint semantic-release's release commit (unblock publish)

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,6 +22,11 @@ export default {
       },
     },
   ],
+  // semantic-release's @semantic-release/git makes a "chore(release): <version>
+  // [skip ci]" commit whose body is the full changelog (long lines, URLs). That
+  // machine commit must not be linted — otherwise the husky commit-msg hook
+  // (installed in CI by `npm ci`) fails the release on body/footer-max-line-length.
+  ignores: [message => message.startsWith('chore(release):')],
   rules: {
     'release-scope-required': [2, 'always'],
   },


### PR DESCRIPTION
# 🐛 Bug Fix Pull Request

## Description

With the workspace ERESOLVE issues fixed (#143, #145), the publish now reaches `@semantic-release/git`, which creates a `chore(release): <version> [skip ci]` commit whose body is the full changelog. The husky `commit-msg` hook — installed in CI by `npm ci` (`prepare: husky`) — runs commitlint on that machine commit, and the long changelog lines (commit subjects + GitHub URLs) trip `footer-max-line-length`, so the commit is rejected and the release aborts.

**Fix:** add an `ignores` matcher to `commitlint.config.js` so semantic-release's release commit is skipped:

```js
ignores: [message => message.startsWith('chore(release):')],
```

Lint rules stay fully enforced for normal commits — only the machine `chore(release):` commit is exempt.

## Related Issue(s)

Closes #146

## Affected Package(s)

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): release tooling (commitlint / husky / semantic-release)

## Checklist

- [x] I have added a test to confirm the fix — verified locally: the `chore(release): 3.0.0 [skip ci]` + long-changelog message now **passes** commitlint, while a normal commit with an over-long footer still **fails** (rule intact), and a normal valid commit passes
- [x] All tests are passing after my change — config-only change
- [x] I have documented the fix if necessary — rationale in the config comment, commit body, and #146

## Additional Context

```
✖ footer's lines must not be longer than 100 characters [footer-max-line-length]
husky - commit-msg script failed (code 1)
```

This is the third and final blocker in the publish chain (after ionicons #143 and workspace pins #145). On merge, the release job should finally publish **`@allxsmith/bestax-bulma@3.0.0`**.
