### PR TITLE
ci: publish to npm via OIDC trusted publishing to fix EOTP failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # OIDC trusted publishing needs id-token: write to mint the short-lived
+    # token npm exchanges with the registry. The remaining scopes are what
+    # @semantic-release/git and @semantic-release/github require to push the
+    # release commit/tag and create the GitHub release.
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -99,6 +108,11 @@ jobs:
           node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing requires npm >= 11.5.1. Node 24 may ship an
+      # older npm, so pin a known-good version that supports OIDC.
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -121,13 +135,15 @@ jobs:
           git config --global commit.gpgsign true
           git config --global gpg.program gpg
 
+      # No NPM_TOKEN: publishing authenticates via OIDC trusted publishing.
+      # A present NPM_TOKEN takes precedence over OIDC and reintroduces the
+      # EOTP (one-time password) failure on 2FA-protected accounts.
       - name: Semantic Release (bulma-ui)
         working-directory: bulma-ui
         env:
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git log -1 --show-signature
           npx semantic-release
@@ -138,7 +154,6 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git log -1 --show-signature
           npx semantic-release

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 registry=https://registry.npmjs.org/
 access=public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,19 @@ We use [Semantic Release](https://semantic-release.gitbook.io/) to automate publ
 - The PR title and commit messages should reflect the type of release (fix, feat, BREAKING CHANGE, etc.).
 - Only the `main` branch is published.
 
+### npm authentication (OIDC trusted publishing)
+
+Publishing authenticates with npm via [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — there is **no long-lived `NPM_TOKEN`**. This avoids the `EOTP` (one-time password) failures that 2FA-protected accounts hit when publishing with a token.
+
+For this to work, each published package must have a trusted publisher configured **once** on npmjs.com (Package → Settings → Trusted Publisher):
+
+- Packages: `@allxsmith/bestax-bulma` and `create-bestax`
+- Provider: **GitHub Actions**
+- Repository: `allxsmith/bestax`
+- Workflow: `ci.yml`
+
+The CI `publish` job grants `id-token: write` and upgrades npm to a version that supports OIDC.
+
 ---
 
 ## Code Quality Standards


### PR DESCRIPTION
## Summary

The last release (`3.0.0`) was tagged but **never published to npm**. The `Publish to npm` job failed because `npm publish` demanded a one-time password:

```
npm error code EOTP
npm error This operation requires a one-time password from your authenticator.
```

CI authenticated with a long-lived `NPM_TOKEN`, which does not bypass the account's 2FA requirement, so the unattended publish was rejected.

Closes #148.

## Fix

Migrate publishing to [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — a short-lived, per-run credential that removes the token/OTP failure class entirely:

- **`.github/workflows/ci.yml`**: grant the `publish` job `id-token: write`; upgrade npm to a version that supports OIDC (`>= 11.5.1`); drop `NPM_TOKEN` from both `semantic-release` steps (a present `NPM_TOKEN` takes precedence over OIDC and would re-trigger `EOTP`).
- **`.npmrc`**: remove the `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` line.
- **`CONTRIBUTING.md`**: document the new auth model and the one-time npm setup.

## ⚠️ Required one-time setup on npmjs.com (before next release)

For each package, add a Trusted Publisher (Package → Settings → Trusted Publisher):

- Packages: `@allxsmith/bestax-bulma`, `create-bestax`
- Provider: **GitHub Actions**
- Repository: `allxsmith/bestax`
- Workflow: `ci.yml`

Without this, OIDC publishing will be rejected by the registry.

## Notes

- No code/runtime changes to the published packages — release pipeline only.
- The GPG-signed release commit/tag flow (`@semantic-release/git`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ71dzfBnJnvSHaymUyoZd)_