### PR TITLE
ci: fix Visual Regression (redundant create-bestax npm ci triggered husky 127)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -62,11 +62,11 @@ jobs:
           node-version: '24'
           cache: 'npm' # Cache enabled for create-bestax CLI installation
 
-      - name: Install root dependencies
-        run: npm ci
-
-      - name: Install create-bestax dependencies (with cache)
-        working-directory: create-bestax
+      - name: Install dependencies
+        # Root `npm ci` installs every workspace (incl. create-bestax dev deps),
+        # so no separate create-bestax install is needed. Running `npm ci` from
+        # the create-bestax subdir re-ran the root `prepare: husky` script with
+        # husky unresolvable and failed with exit 127 (npm workspaces quirk).
         run: npm ci
 
       - name: Build create-bestax CLI


### PR DESCRIPTION
# Pull Request

## Description

Fixes the **Visual Regression** workflow, which has been failing on `main` (daily schedule) and every PR since ~2026-06-23 — unrelated to any app code.

**Root cause:** the job ran `npm ci` a second time from inside the `create-bestax` workspace subdir. With npm 11 (pulled in by the `setup-node@v6` bump), running `npm ci` from a workspace subdir re-runs the **root** `prepare: husky` script with `husky` unresolvable, failing with `exit 127` (`sh: husky: command not found`). Reproduced locally.

**Fix:** remove the redundant step. The root `npm ci` immediately before it already installs every workspace (including create-bestax's dev deps) — this is exactly how `ci.yml` builds create-bestax from a single root install. Less work, and the husky 127 is gone.

- [ ] bulma-ui  [ ] create-bestax  [ ] docs  [x] Other: CI workflow

## Type of Change

- [x] Bug fix (CI)
- [x] Build tooling

## Checklist

- [x] I have performed a self-review of my code
- [x] All new and existing tests passed (workflow YAML validated; root `npm ci` confirmed healthy)

## Additional Context

Unblocks the Visual Regression matrix so it can validate create-bestax changes again (e.g. the pending Vite 8 template modernization in #168).
