### PR TITLE
fix(docs): emit per-page markdown so llms.txt links resolve (#200)

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -87,6 +87,15 @@ const config = {
         // concatenated docs (/llms-full.txt) at build time, per llmstxt.org.
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
+        // Emit a per-page markdown file for every doc page and point llms.txt
+        // at them (e.g. /docs/guides/intro.md). Without this, llms.txt links to
+        // .md URLs (addMdExtension defaults true) that 404 because no markdown
+        // is emitted. preserveDirectoryStructure (default) keeps the .md paths
+        // aligned with the HTML routes. excludeImports strips MDX import lines
+        // so the generated markdown is clean for agent ingestion.
+        generateMarkdownFiles: true,
+        excludeImports: true,
+        removeDuplicateHeadings: true,
         docsDir: 'docs',
         title: 'Bestax-Bulma',
         description:


### PR DESCRIPTION
## Summary

Closes #200. The generated `llms.txt` links every doc page to a per-page `.md` URL (the plugin's `addMdExtension` defaults on), but no per-page markdown was emitted — so every one of those links **404'd**, breaking the intended llms.txt flow (read the index, then fetch the linked `.md`).

## Fix

Enable `generateMarkdownFiles` in the `docusaurus-plugin-llms` config (already supported in the installed `0.4.0` — no upgrade needed):

```js
generateMarkdownFiles: true,   // emit a clean .md per page; llms.txt links to them
excludeImports: true,          // strip MDX import lines from generated markdown
removeDuplicateHeadings: true, // tidy output for agent ingestion
```

`preserveDirectoryStructure` (default) keeps the generated `.md` paths aligned with the HTML routes, so the URLs `llms.txt` already emits now resolve. This publishes **rendered, version-matched** markdown on-site — the approach Mantine (`/llms/*.md`) and MUI (co-located `*.md`) use — rather than pointing agents at raw MDX sources.

## Verification (local `docs` build)

- **127 / 127** `llms.txt` links resolve to built files under `docs/build/docs/**` (0 missing).
- **128** per-page `.md` generated; content is clean markdown (no leaked `import` lines).
- `docs` build passes with no broken links; `docusaurus.config.js` is prettier-clean.

Production follow-up (not blocking): confirm Cloudflare Pages serves the `.md` with a text content type (not SPA-rewritten) once deployed.

This is `fix(docs)` — the docs package is private (no npm release); merging redeploys the docs site.

https://claude.ai/code/session_01MoujiGigUjNPaPpkX6KJyP
