### PR TITLE
LLMs discoverability: guide page + discovery signals (#198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ Explore live, interactive component examples in our Storybook:
 
 ---
 
+## 🤖 For AI Tools
+
+Building with an AI agent (Claude Code, Cursor, Copilot)? bestax-bulma ships LLM-optimized docs:
+
+- 📘 **[LLMs guide](https://bestax.io/docs/guides/llms)** — how to use the library with AI tools
+- 📄 **[llms.txt](https://bestax.io/llms.txt)** — curated index · **[llms-full.txt](https://bestax.io/llms-full.txt)** — the full docs in one file
+- 🧩 **[Agent Skills](https://bestax.io/docs/skills/intro)** — teach your agent the bestax way:
+
+  ```bash
+  npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
+  ```
+
+---
+
 ## 🙏 Special Thanks
 
 ### [Bulma](https://github.com/jgthms/bulma)

--- a/bulma-ui/README.md
+++ b/bulma-ui/README.md
@@ -129,6 +129,20 @@ Explore live, interactive component examples in our Storybook:
 
 ---
 
+## 🤖 For AI Tools
+
+Building with an AI agent (Claude Code, Cursor, Copilot)? bestax-bulma ships LLM-optimized docs:
+
+- 📘 **[LLMs guide](https://bestax.io/docs/guides/llms)** — how to use the library with AI tools
+- 📄 **[llms.txt](https://bestax.io/llms.txt)** — curated index · **[llms-full.txt](https://bestax.io/llms-full.txt)** — the full docs in one file
+- 🧩 **[Agent Skills](https://bestax.io/docs/skills/intro)** — teach your agent the bestax way:
+
+  ```bash
+  npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
+  ```
+
+---
+
 ## 🙏 Special Thanks
 
 ### [Bulma](https://github.com/jgthms/bulma)

--- a/bulma-ui/package.json
+++ b/bulma-ui/package.json
@@ -189,6 +189,7 @@
     "directory": "bulma-ui"
   },
   "homepage": "https://bestax.io",
+  "llms": "https://bestax.io/llms.txt",
   "bugs": {
     "url": "https://github.com/allxsmith/bestax/issues"
   },

--- a/create-bestax/README.md
+++ b/create-bestax/README.md
@@ -31,6 +31,7 @@ You'll be asked to:
 2. Select a framework (Vite or Vite + TypeScript)
 3. Choose a Bulma CSS flavor (Complete or Minimal)
 4. Select an icon library (Font Awesome, Material Icons, etc.)
+5. Choose whether to install the bestax AI skills into `.claude/skills/`
 
 ### Command Line Options
 
@@ -61,11 +62,15 @@ npm create bestax@latest [project-directory] [options]
   - `material-icons` - Material Icons
   - `material-symbols` - Material Symbols  
     **Default:** `none`
+- `--skills` / `--no-skills` - Install (or skip) the bestax AI skills into
+  `.claude/skills/` (with a `CLAUDE.md`) so a Claude Code session picks them up
+  automatically. When omitted you're prompted; with `-y` the default is to install.
 - `-y, --yes` - Skip prompts and use defaults or provided options.  
   When used, the following defaults are selected unless overridden by flags:
   - Template: `vite`
   - Bulma flavor: `complete`
   - Icon library: `none`
+  - AI skills: installed (pass `--no-skills` to opt out)
 
 **Example:**
 
@@ -91,6 +96,15 @@ Each template includes:
 - Icon library support (Font Awesome, Material Design, etc.)
 - Sample components demonstrating library usage
 - Development and build scripts
+
+## For AI Tools
+
+Scaffolding for an AI agent? Pass `--skills` (or accept the prompt) to drop the bestax
+Agent Skills and a `CLAUDE.md` into the new project. The library also ships LLM-optimized
+docs:
+
+- [LLMs guide](https://bestax.io/docs/guides/llms) — using bestax with Claude Code, Cursor, Copilot
+- [llms.txt](https://bestax.io/llms.txt) (curated index) · [llms-full.txt](https://bestax.io/llms-full.txt) (full docs)
 
 ## Development
 

--- a/create-bestax/package.json
+++ b/create-bestax/package.json
@@ -48,6 +48,7 @@
     "directory": "create-bestax"
   },
   "homepage": "https://bestax.io",
+  "llms": "https://bestax.io/llms.txt",
   "bugs": {
     "url": "https://github.com/allxsmith/bestax/issues"
   },

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -61,6 +61,12 @@ automatically when the task matches:
 - **bestax-layout-scaffold** — scaffold full pages (app shell, landing, centered, card grid).
 
 Prefer the library's components and these skills over hand-written Bulma markup or custom CSS.
+
+## Docs
+
+- Docs site: https://bestax.io
+- LLM-ready docs: https://bestax.io/llms.txt (curated index) and https://bestax.io/llms-full.txt
+- Using bestax with AI tools: https://bestax.io/docs/guides/llms
 `;
 
 export interface IconLibrary {

--- a/docs/docs/guides/llms.md
+++ b/docs/docs/guides/llms.md
@@ -1,0 +1,70 @@
+---
+title: LLMs
+sidebar_label: LLMs
+sidebar_position: 4
+---
+
+# bestax-bulma with LLMs
+
+`@allxsmith/bestax-bulma` ships LLM-optimized documentation so AI coding agents —
+Claude Code, Cursor, GitHub Copilot, ChatGPT — can read the docs in full and build
+with the library correctly. This page explains what's published and how to use it.
+
+## How these docs are generated
+
+The LLM docs are generated at build time by
+[`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms)
+(configured in `docs/docusaurus.config.js`), following the
+[llmstxt.org](https://llmstxt.org) standard. Three artifacts are produced and served
+from the site root:
+
+| File                                                | What it is                                                                                                                          |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [`/llms.txt`](https://bestax.io/llms.txt)           | Curated **index** — a table of contents linking every doc page (per the llmstxt.org spec).                                          |
+| [`/llms-full.txt`](https://bestax.io/llms-full.txt) | The **entire documentation** concatenated into a single plain-text file.                                                            |
+| Per-page `.md`                                      | Every page is also served as clean Markdown at `<page>.md`, e.g. [`/docs/guides/intro.md`](https://bestax.io/docs/guides/intro.md). |
+
+All three are regenerated on every docs build, so they always match the deployed site.
+
+## Using bestax docs with AI tools
+
+Point your assistant at the docs — the approach is the same across Claude Code,
+Cursor, Copilot, and ChatGPT:
+
+- **Give it the index.** Add `https://bestax.io/llms.txt` to your project docs / rules,
+  or paste it into the chat, so the model can discover every page and fetch what it needs.
+- **Feed it everything.** For a one-shot load of the whole library, use
+  `https://bestax.io/llms-full.txt`.
+- **Fetch a single page.** For a focused question, link the page's Markdown directly —
+  e.g. `https://bestax.io/docs/api/elements/button.md` — to keep the context small.
+
+## Skills
+
+Beyond the raw docs, bestax ships **Agent Skills** that teach an agent _how_ to build
+with the library (conventions, patterns, and a component catalog). Install one with the
+[`skills`](https://skills.sh/) CLI:
+
+```bash
+npx skills add https://github.com/allxsmith/bestax --skill bestax-custom-component
+npx skills add https://github.com/allxsmith/bestax --skill bestax-form
+npx skills add https://github.com/allxsmith/bestax --skill bestax-theming
+npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
+```
+
+Starting a new app? `pnpm create bestax@latest` offers to **preinstall these skills**
+into the generated app's `.claude/skills/` (alongside a `CLAUDE.md`), so a Claude Code
+session picks them up automatically. See the [Skills overview](/docs/skills/intro) for
+what each one does.
+
+## MCP server (coming soon)
+
+A first-party bestax **MCP server** — for querying components, props, and examples
+directly from an MCP-compatible client — is planned. This page will document it once it
+ships. (bestax will provide its own server; it does not rely on a third-party one.)
+
+## Contributing
+
+Found the LLM docs unclear, incomplete, or wrong for your agent? Please
+[open an issue](https://github.com/allxsmith/bestax/issues/new/choose) describing what
+you expected and what happened — feedback on how well the docs work with AI tools is
+especially welcome.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -161,6 +161,16 @@ function Demo() {
 
 ---
 
+## For AI Tools
+
+Building with an AI agent? bestax-bulma ships LLM-optimized docs:
+
+- 🤖 **[LLMs guide](/docs/guides/llms)** - How to use the library with Claude Code, Cursor, and Copilot
+- 📄 **[llms.txt](https://bestax.io/llms.txt)** / **[llms-full.txt](https://bestax.io/llms-full.txt)** - Point your assistant straight at the docs
+- 🧩 **[Agent Skills](/docs/skills/intro)** - `npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold`
+
+---
+
 ## Why bestax-bulma?
 
 - ✅ **Latest Bulma v1** - Full support for the newest Bulma features

--- a/docs/src/components/AiReady/index.js
+++ b/docs/src/components/AiReady/index.js
@@ -11,8 +11,8 @@ const CARDS = [
     icon: DocsIcon,
     title: 'LLM-ready docs',
     desc: 'Token-friendly, plain-text documentation a model can read in full — point Claude, Cursor, Copilot, or ChatGPT straight at it.',
-    href: 'https://bestax.io/llms.txt',
-    cta: 'View llms.txt',
+    href: '/docs/guides/llms',
+    cta: 'Read the guide',
   },
   {
     key: 'skills',

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -40,3 +40,10 @@ Content-signal: search=yes, ai-input=yes, ai-train=yes
 # ============================================================================
 
 Sitemap: https://bestax.io/sitemap.xml
+
+# ============================================================================
+# LLM DOCS
+# ============================================================================
+# LLM-optimized documentation for AI agents (llmstxt.org standard):
+# LLM docs index: https://bestax.io/llms.txt
+# LLM docs (full): https://bestax.io/llms-full.txt


### PR DESCRIPTION
## Summary

Closes #198. Adds a dedicated **LLMs guide page** as the canonical hub for bestax's LLM-optimized docs, and wires discovery signals from the homepage, `/docs/intro`, `robots.txt`, the READMEs, `package.json`, and the scaffolded `CLAUDE.md`.

Modeled on Mantine's LLMs guide but tailored: **one** combined "AI tools" section (no per-editor split), a **Skills** section, an **MCP server (coming soon)** section (first-party only), a **how-it's-generated** summary listing all three artifacts, and a **Contributing** section.

## What's in it

**New page — `/docs/guides/llms`** (auto-added to the Guides sidebar):
- How these docs are generated → `llms.txt`, `llms-full.txt`, and (since #200) per-page `.md`.
- Using bestax with AI tools · Skills (install commands) · MCP server (coming soon) · Contributing.

**Discovery signals:**
- Homepage "AI-Ready" card repointed to the guide (`docs/src/components/AiReady/index.js`).
- "For AI Tools" section added to `/docs/intro`, the repo `README.md`, `bulma-ui/README.md`, and `create-bestax/README.md`.
- `robots.txt` now points to the llms docs.
- `"llms"` key added to `bulma-ui/package.json` and `create-bestax/package.json`.
- Scaffolded `CLAUDE_MD` (`create-bestax/src/constants.ts`) now points new projects at the llms docs; `create-bestax` README documents the `--skills`/`--no-skills` flag.

## Releases — merge as a MERGE COMMIT (not squash)

Three scoped commits so semantic-release cuts both patches:

| Commit | Publishes |
|---|---|
| `docs: add LLMs guide page + homepage/intro/robots links` | — (docs site redeploys) |
| `fix(bulma-ui): reference llms docs from README and package.json` | **bulma-ui 5.1.2** |
| `fix(create-bestax): point scaffolded CLAUDE.md at llms docs; document skills` | **create-bestax 3.1.3** |

> ⚠️ **Merge with a merge commit** so both scoped commits land on `main`. A squash would collapse to one scope and publish only one package.

## Verification

- `docs` build passes (Docusaurus fails on broken links → the new internal links resolve). New page renders at `/docs/guides/llms`, appears in the sitemap, its per-page `.md` is emitted, and it's listed in `llms.txt`.
- Rendered HTML contains all six sections; homepage card now routes to the guide (old "View llms.txt" cta gone).
- `format:check` clean; `typecheck` passes; each commit passes commitlint (`docs`/`bulma-ui`/`create-bestax` are allowed scopes).

## Not in this PR (manual follow-ups)
- Submit bestax.io to **llmstxt.site**, **llmstxthub.com**, **llms-txt.io/directory** (#198 task 6 — web-form submissions).
- #198 task 2 (verify files served) is already satisfied by #200 (verified live: `200 text/markdown`).

https://claude.ai/code/session_01MoujiGigUjNPaPpkX6KJyP
