### PR TITLE
docs: fix stale versioning and coverage docs; drop CLAUDE.md stale-docs flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ pnpm exec turbo run test --filter=@allxsmith/bestax-bulma   # scope any task to 
 Enforced by CI (`.github/workflows/ci.yml`):
 
 - Coverage thresholds from the jest configs: **bulma-ui 99%** (all metrics),
-  create-bestax 95% (78% branches). Don't quote the stale 95% figure in CONTRIBUTING.md.
+  create-bestax 95% (78% branches).
 - Stale skill catalog fails (`gen:catalog:check`); build, typecheck, lint, format, audit.
 
 Enforced in review (a green CI does **not** check these):
@@ -60,9 +60,7 @@ fix(create-bestax): handle missing TTY   → patch release of create-bestax only
 docs: fix typo in contributing guide     → no release; scope optional
 ```
 
-Stale-docs warning: `VERSIONING.md` describes an older _synchronized_ versioning scheme, and
-CONTRIBUTING.md's "Commit Message Guidelines" section shows a type-less format commitlint would
-reject. The commitlint config and release configs are authoritative.
+Full versioning details (breaking-change footers, tag formats): `VERSIONING.md`.
 
 ## Dependencies are a deliberate act
 
@@ -75,8 +73,8 @@ reject. The commitlint config and release configs are authoritative.
 ## Workflow
 
 PRs target `main`; direct pushes to `main` are not allowed. Full contributor guide:
-`CONTRIBUTING.md` (commit-format section aside — see above). New components should stay within
-the Bulma spec — propose anything beyond it in an issue first.
+`CONTRIBUTING.md`. New components should stay within the Bulma spec — propose anything beyond
+it in an issue first.
 
 AI/LLM surfaces: the docs build publishes an LLM index (see `docs/CLAUDE.md`); the skills are a
 shipped product (see `skills/CLAUDE.md`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,9 @@ This project is a modern, flexible React component library built on top of Bulma
 Before contributing, your PR **must** satisfy the following:
 
 - **All tests pass** (`pnpm test` & `pnpm test:coverage`)
-  - Coverage must remain **95% or higher**
+  - Coverage thresholds are enforced per package by jest: **bulma-ui 99%** on all metrics
+    ([`bulma-ui/jest.config.js`](./bulma-ui/jest.config.js)), **create-bestax 95%**
+    (78% branches, [`create-bestax/jest.config.mjs`](./create-bestax/jest.config.mjs))
 - **Linting and formatting pass** (`pnpm lint`, `pnpm format:check`)
 - **Type checks pass** (`pnpm typecheck`)
 - **Storybook runs and covers UI changes** (`pnpm storybook`)
@@ -134,7 +136,7 @@ pnpm run all
 pnpm run build          # turbo build all packages
 pnpm run typecheck
 pnpm run test           # jest (bulma-ui + create-bestax)
-pnpm run test:coverage  # coverage (must stay >= 95%)
+pnpm run test:coverage  # coverage (bulma-ui: 99%; create-bestax: 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
 pnpm run bundle:stats   # writes bulma-ui/dist/stats.html
@@ -230,7 +232,7 @@ no `npm publish`, no tag, no GitHub release.
    pnpm install
    ```
 4. **Make your changes** in the appropriate workspace (`bulma-ui` for components, `docs` for documentation).
-5. **Update/add unit tests** (coverage must remain at 95% or higher).
+5. **Update/add unit tests** (coverage must stay above each package's jest threshold — 99% for bulma-ui, 95% for create-bestax).
 6. **Add or update Storybook stories** for UI-related changes.
 7. **Update documentation** in `/docs` as needed.
 8. **Run all checks**:
@@ -258,10 +260,10 @@ no `npm publish`, no tag, no GitHub release.
 
 ## Semantic Release & Publishing
 
-We use [Semantic Release](https://semantic-release.gitbook.io/) to automate publishing of the `bulma-ui` package as `bulma-bestax` on npm.
+We use [Semantic Release](https://semantic-release.gitbook.io/) to automate publishing of both packages to npm: `bulma-ui` as [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) and [`create-bestax`](https://www.npmjs.com/package/create-bestax).
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) to trigger releases.
-- The PR title and commit messages should reflect the type of release (fix, feat, BREAKING CHANGE, etc.).
+- Use [Conventional Commits](https://www.conventionalcommits.org/) to trigger releases — see [Commit Message Guidelines](#commit-message-guidelines).
+- **Packages version and release independently, keyed off the commit scope** — `feat(bulma-ui)` releases only bestax-bulma. See [`VERSIONING.md`](./VERSIONING.md).
 - Only the `main` branch is published.
 
 ### npm authentication (OIDC trusted publishing)
@@ -282,7 +284,7 @@ The CI `publish` job grants `id-token: write` and upgrades npm to a version that
 ## Code Quality Standards
 
 - **Unit tests** required for all new features and bug fixes.
-- **Coverage must not drop below 95%.**
+- **Coverage must not drop below the per-package jest thresholds** (bulma-ui 99%, create-bestax 95%).
 - **Linting, formatting, and type checks** must all pass.
 - **Storybook stories** required for any visible or interactive UI change.
 - **Documentation** must be updated to reflect your changes (see [Documentation](#documentation)).
@@ -291,16 +293,22 @@ The CI `publish` job grants `id-token: write` and upgrades npm to a version that
 
 ## Commit Message Guidelines
 
-- **Format all commit messages as follows:**
-  - **Subject line:** Imperative mood, ≤ 80 chars
-  - **Blank line**
-  - **List of changes (bullet points or short sentences)**
-  - **Optional paragraph describing the motivation or context**
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/), enforced by
+commitlint via the husky `commit-msg` hook ([`commitlint.config.js`](./commitlint.config.js)):
+
+- **Format:** `<type>(<scope>): <subject>` — imperative subject, blank line, then an optional
+  body with bullet points and context.
+- **Release types need a scope:** commits of type `feat`, `fix`, `perf`, `refactor`, or `style`
+  **must** use a scope of `bulma-ui`, `docs`, or `create-bestax` (repo-specific commitlint
+  rule — the scope decides which package releases, see [`VERSIONING.md`](./VERSIONING.md)).
+- **Breaking changes** need a `BREAKING CHANGE:` footer in the body — a `!` after the type is
+  **not** picked up by our release tooling.
+- Non-releasing types (`docs`, `chore`, `ci`, `test`, `build`) may omit the scope.
 
 **Example:**
 
 ```
-Add support for Bulma breadcrumb component
+feat(bulma-ui): add support for Bulma breadcrumb component
 
 - Implement Breadcrumb component and tests
 - Add Storybook stories

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,149 +1,75 @@
-# Synchronized Versioning Strategy
+# Independent Versioning Strategy
 
-This monorepo uses **synchronized versioning** between `@allxsmith/bestax-bulma` and `create-bestax` packages.
+`@allxsmith/bestax-bulma` and `create-bestax` are versioned and released **independently**.
+Each package releases only when a commit is scoped to it — the two version numbers are
+unrelated (e.g. bestax-bulma 5.x alongside create-bestax 3.x).
 
-## How It Works
+The source of truth is the `releaseRules` in each package's semantic-release config:
+[`bulma-ui/release.config.js`](./bulma-ui/release.config.js) and
+[`create-bestax/release.config.js`](./create-bestax/release.config.js).
 
-Both packages maintain **identical version numbers** and are released together whenever either package has changes.
+## Release Rules
 
-### Release Rules
+A commit releases **only** the package its scope names:
 
-Both packages analyze commits with the following scopes:
+| Commit                                                            | bestax-bulma | create-bestax |
+| ----------------------------------------------------------------- | ------------ | ------------- |
+| `feat(bulma-ui): …`                                               | minor        | —             |
+| `fix(bulma-ui): …`                                                | patch        | —             |
+| `perf/refactor/style(bulma-ui): …`                                | patch        | —             |
+| `feat(create-bestax): …`                                          | —            | minor         |
+| `fix(create-bestax): …`                                           | —            | patch         |
+| `feat(bulma-ui): …` + `BREAKING CHANGE:` footer                   | major        | —             |
+| `docs: …`, `chore: …`, `ci: …`, `test: …`, `build: …` (any scope) | —            | —             |
 
-- `feat(bulma-ui)` or `feat(create-bestax)` → **Minor version bump** (e.g., 1.0.0 → 1.1.0)
-- `fix(bulma-ui)` or `fix(create-bestax)` → **Patch version bump** (e.g., 1.0.0 → 1.0.1)
-- Breaking changes in either → **Major version bump** (e.g., 1.0.0 → 2.0.0)
+Notes:
 
-### Ignored Scopes
+- **Breaking changes require a `BREAKING CHANGE:` footer** in the commit body. The angular
+  commit-analyzer preset does **not** parse `feat(bulma-ui)!:` bang headers.
+- Commits of a releasing type (`feat`, `fix`, `perf`, `refactor`, `style`) **must** carry a
+  scope of `bulma-ui`, `docs`, or `create-bestax` — enforced by commitlint
+  ([`commitlint.config.js`](./commitlint.config.js)) via the husky `commit-msg` hook. This is
+  what guarantees the per-scope release rules can't be bypassed by an unscoped commit.
+- A commit scoped to `docs` never releases either package.
 
-The following scopes do NOT trigger releases:
+## Tags & Changelogs
 
-- `docs` - Documentation changes
-- `chore` - Maintenance tasks
-- `ci` - CI/CD configuration
-- `test` - Test updates
-- `build` - Build system changes
+Each package tags and logs its own releases:
 
-## Example Scenarios
-
-### Scenario 1: bulma-ui Feature
-
-```bash
-git commit -m "feat(bulma-ui): add new Modal component"
-```
-
-**Result:**
-
-- ✅ `@allxsmith/bestax-bulma`: 1.0.0 → 1.1.0
-- ✅ `create-bestax`: 1.0.0 → 1.1.0
-- Both packages published with version 1.1.0
-
-### Scenario 2: create-bestax Fix
-
-```bash
-git commit -m "fix(create-bestax): correct template scaffolding issue"
-```
-
-**Result:**
-
-- ✅ `@allxsmith/bestax-bulma`: 1.1.0 → 1.1.1
-- ✅ `create-bestax`: 1.1.0 → 1.1.1
-- Both packages published with version 1.1.1
-
-### Scenario 3: Documentation Update
-
-```bash
-git commit -m "docs: update README"
-```
-
-**Result:**
-
-- ❌ No version bump
-- ❌ No packages published
-
-### Scenario 4: Mixed Changes
-
-```bash
-git commit -m "feat(bulma-ui): add Button variants"
-git commit -m "fix(create-bestax): fix icon library setup"
-```
-
-**Result:**
-
-- ✅ `@allxsmith/bestax-bulma`: 1.1.1 → 1.2.0 (minor wins over patch)
-- ✅ `create-bestax`: 1.1.1 → 1.2.0
-- Both packages published with version 1.2.0
-
-## Why Synchronized Versioning?
-
-1. **User Clarity**: Users always know which versions work together
-2. **Simplified Dependency Management**: create-bestax templates always use the matching bulma-ui version
-3. **Consistent Releases**: Both packages stay in lockstep, reducing confusion
-
-## Version Determination
-
-When commits affect both packages, the **highest semantic level** determines the bump:
-
-- Major > Minor > Patch
-- Breaking change > feat > fix
+- `@allxsmith/bestax-bulma@X.Y.Z` tags, changelog at `bulma-ui/CHANGELOG.md`
+- `create-bestax@X.Y.Z` tags, changelog at `create-bestax/CHANGELOG.md`
 
 ## Release Process
 
-The CI workflow (`ci.yml`) handles releases automatically:
+On merge to `main`, CI (`.github/workflows/ci.yml`) runs semantic-release in each package:
 
-1. Analyzes all commits since last release
-2. Determines version bump based on commit scopes
-3. Publishes `@allxsmith/bestax-bulma` first
-4. Publishes `create-bestax` with the same version
-5. Creates git tags for both packages
-6. Updates CHANGELOGs
-7. Creates GitHub releases
+1. Each package analyzes the commits since **its own** last tag against its `releaseRules`.
+2. If a release is due: version bump, `CHANGELOG.md` update, npm publish (OIDC trusted
+   publishing — no `NPM_TOKEN`), a signed `chore(release): X.Y.Z [skip ci]` commit, git tag,
+   and GitHub release.
+3. A push may release one package, both, or neither — they never bump each other.
 
-## Commit Message Format
+Preview locally without publishing: see "semantic-release dry-run" in
+[`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
-Follow conventional commits with scopes:
-
-```bash
-<type>(<scope>): <subject>
-
-# Examples:
-feat(bulma-ui): add new component
-fix(create-bestax): resolve scaffolding bug
-docs: update API documentation
-chore(bulma-ui): refactor tests
-```
-
-## Initial Setup
-
-The packages were manually synchronized to version **2.3.3** to establish the baseline for synchronized versioning.
-
-Commit used:
+## Example Scenarios
 
 ```bash
-git commit -m "chore: synchronize package versions to 2.3.3 [skip ci]"
+git commit -m "feat(bulma-ui): add new Modal variant"
+# → bestax-bulma minor bump; create-bestax untouched
+
+git commit -m "fix(create-bestax): correct template scaffolding issue"
+# → create-bestax patch bump; bestax-bulma untouched
+
+git commit -m "docs: update README"
+# → no release
+
+git commit -m "feat(bulma-ui): rename Theme props" -m "BREAKING CHANGE: bulmaVars renamed to vars"
+# → bestax-bulma major bump
 ```
 
-## Manual Version Sync
+## History
 
-In rare cases where versions drift (e.g., after manual intervention), you can manually sync by:
-
-1. Updating both `package.json` files to the same version
-2. Committing with `chore: sync package versions to X.X.X [skip ci]`
-3. Creating matching git tags if needed (usually not necessary)
-
-## Troubleshooting
-
-**Q: What if I only want to release one package?**
-A: Not supported with this strategy. Both packages always release together to maintain version parity.
-
-**Q: Can I still use docs commits?**
-A: Yes! Commits with `scope: docs` or `type: docs` won't trigger releases.
-
-**Q: What about pre-releases?**
-A: Configure pre-release branches in both `release.config.js` files identically.
-
-## Related Files
-
-- `bulma-ui/release.config.js` - Semantic release config for bulma-ui
-- `create-bestax/release.config.js` - Semantic release config for create-bestax
-- `.github/workflows/ci.yml` - CI/CD workflow with release steps
+Versions 2.x and earlier used a synchronized scheme where both packages released together with
+identical version numbers. That was removed — the per-scope `release: false` rules in each
+config exist precisely so a `feat(bulma-ui)` commit no longer bumps `create-bestax`.


### PR DESCRIPTION
# Pull Request

## Description

Fixes the three stale-docs findings surfaced by the adversarial review in #204 (PR #205's follow-up list), then removes the temporary "stale-docs warning" from the root `CLAUDE.md` since the underlying docs are now correct.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): repo-root contributor docs (`VERSIONING.md`, `CONTRIBUTING.md`, `CLAUDE.md`)

**`VERSIONING.md` — rewritten** from "Synchronized Versioning" to "Independent Versioning": per-scope `releaseRules` table, per-package tag formats, the `BREAKING CHANGE:` footer requirement (the angular preset doesn't parse `!` headers), the commitlint scope rule, the actual CI release process, and a short History note about the removed synchronized scheme. Points at the release configs as source of truth.

**`CONTRIBUTING.md` — corrected in place:**
- Commit Message Guidelines now documents the conventional format + repo-specific scope rule, with an example that **passes commitlint** (verified by piping it through `commitlint --config commitlint.config.js` — exit 0; the old type-less example was rejected by the repo's own hook).
- All four coverage mentions updated from the stale flat "95%" to the real jest thresholds: bulma-ui **99%** (all metrics), create-bestax 95% (78% branches), linking the configs.
- Semantic Release section: fixed the npm package name (`bulma-bestax` → `@allxsmith/bestax-bulma`), noted both packages publish, and linked `VERSIONING.md` for the independent-release model.

**`CLAUDE.md` — cleanup:** removed the stale-docs warning paragraph, the "don't quote the stale 95% figure" aside, and the "(commit-format section aside)" caveat — all existed only to route agents around the errors fixed here.

## Related Issue(s)

Closes #206

Refs #204

## Type of Change

- [x] Documentation

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a — markdown only; the commit example was verified against commitlint)
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui) (n/a)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed (markdown-only; formatted with the pinned prettier 3.9.4)
- [ ] Any relevant dependencies are updated (n/a)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

n/a

## Additional Context

Acceptance criteria from #206 all verified: no doc claims synchronized versioning or a 95% bulma-ui gate (grepped repo-wide, excluding changelogs); the CONTRIBUTING example passes commitlint as-is; `CLAUDE.md` no longer flags any repo doc as stale. The commit itself was validated by the husky commitlint hook on the way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131uD6QKmAij7Byk3SByyLh

---
_Generated by [Claude Code](https://claude.ai/code/session_0131uD6QKmAij7Byk3SByyLh)_