### PR TITLE
docs: rewrite root README as AI-first monorepo overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# bestax — agent guide
+
+TypeScript-first React component library for Bulma v1 (`@allxsmith/bestax-bulma`), a project
+scaffolder (`create-bestax`), and the Docusaurus source of https://bestax.io. pnpm + Turborepo
+monorepo.
+
+- **Contributing to this repo?** Read [`CLAUDE.md`](CLAUDE.md) — toolchain, commands, quality
+  gates, and commit conventions. It applies to all agents, not just Claude.
+- **Using the library?** Fetch https://bestax.io/llms.txt (curated docs index) or
+  https://bestax.io/llms-full.txt (complete docs in one file). Every docs page is also served
+  as raw markdown — see https://bestax.io/docs/guides/llms.
+- **Agent Skills** (layout scaffolding, forms, theming, custom components) live in
+  [`skills/`](skills/README.md): `npx skills add https://github.com/allxsmith/bestax --skill <name>`

--- a/README.md
+++ b/README.md
@@ -1,131 +1,140 @@
-# @allxsmith/bestax-bulma
+# bestax
 
 [![npm version](https://img.shields.io/npm/v/@allxsmith/bestax-bulma.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
 [![npm downloads](https://img.shields.io/npm/dm/@allxsmith/bestax-bulma.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+[![create-bestax](https://img.shields.io/npm/v/create-bestax.svg?label=create-bestax)](https://www.npmjs.com/package/create-bestax)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@allxsmith/bestax-bulma.svg)](https://bundlephobia.com/package/@allxsmith/bestax-bulma)
 [![TypeScript](https://img.shields.io/badge/TypeScript-100%25-blue.svg)](https://www.typescriptlang.org/)
-[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax)
+[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax/blob/main/bulma-ui/jest.config.js)
 [![Bulma](https://img.shields.io/badge/Bulma-v1.0+-00d1b2.svg)](https://bulma.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-React Bulma components library - TypeScript-first component library for Bulma CSS framework. Build accessible, modern UIs with fully-typed React components.
+TypeScript-first React component library for the **Bulma v1** CSS framework — 80+ fully typed components — plus a project scaffolder and AI agent tooling.
 
-A modern, flexible React component library built with the latest Bulma v1 and TypeScript.
+## 📋 At a glance
+
+|                      |                                                                                                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Library**          | [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) — `npm install @allxsmith/bestax-bulma`                                                     |
+| **Scaffolder**       | [`create-bestax`](https://www.npmjs.com/package/create-bestax) — `npm create bestax@latest my-app`                                                                             |
+| **Requires**         | React `^18 \|\| ^19` (+ `react-dom`). Bulma v1 is the library's only runtime dependency — installed automatically                                                              |
+| **Styles**           | `import '@allxsmith/bestax-bulma/bestax.css';` — Bulma v1 + the bestax extras ([more flavors](#-styling-and-theming))                                                          |
+| **Icons (optional)** | Font Awesome, Material Design Icons, Ionicons, Material Icons, Material Symbols — all optional peer dependencies                                                               |
+| **Docs**             | [bestax.io](https://bestax.io) · [Storybook](https://bestax.io/storybook)                                                                                                      |
+| **LLM docs**         | [llms.txt](https://bestax.io/llms.txt) (curated index) · [llms-full.txt](https://bestax.io/llms-full.txt) (complete docs, one file)                                            |
+| **Agent Skills**     | `npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold` ([all four skills](skills/README.md))                                                      |
+| **Community**        | [Discord](https://discord.gg/zehJrQGtKu) · [Stack Overflow `bestax`](https://stackoverflow.com/questions/tagged/bestax) · [Issues](https://github.com/allxsmith/bestax/issues) |
+
+> **If you are an AI agent or LLM:** fetch **<https://bestax.io/llms.txt>** for a curated index of the full documentation, or **<https://bestax.io/llms-full.txt>** for the complete docs in a single file, before answering questions about or writing code with this library. Every page on [bestax.io](https://bestax.io) is also available as raw markdown — see the [LLMs guide](https://bestax.io/docs/guides/llms).
+
+**Full documentation, guides, and API reference: 👉 [https://bestax.io](https://bestax.io)** — the docs site is always the most complete and up-to-date resource.
 
 ---
 
-## 📚 Comprehensive Documentation
+## 🚀 Quick start
 
-**Looking for full documentation, guides, API references, and best practices?**  
-👉 **Visit our official docs at [https://bestax.io](https://bestax.io)**
+### New project
 
-> The documentation site is the best place to learn about all bestax-bulma features, usage patterns, and updates. We strongly recommend using the docs as your primary resource!
-
----
-
-## 🚀 Getting Started
-
-### 1. Install the package
+Scaffold a Vite app with everything wired up (CSS flavor, icon library, optional AI skills + `CLAUDE.md`):
 
 ```bash
-pnpm add @allxsmith/bestax-bulma
-# or
-yarn add @allxsmith/bestax-bulma
+npm create bestax@latest my-app
+# or: pnpm create bestax my-app
 ```
 
-### 2. Import Bulma CSS
+Useful flags: `-t vite|vite-ts` (template), `-b complete|prefixed|no-helpers|no-helpers-prefixed|no-dark-mode` (CSS flavor), `-i fontawesome|mdi|ionicons|material-icons|material-symbols|none` (icons), `--skills` (install the [Agent Skills](#-for-ai-tools) into `.claude/skills`), `-y` (accept defaults). See the [create-bestax README](create-bestax/README.md).
 
-You must include Bulma’s CSS in your project. The easiest way is to import it in your main JS/TS file:
-
-```js
-import 'bulma/css/bulma.min.css';
-```
-
-Or add it via CDN in your HTML:
-
-```html
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css"
-/>
-```
-
-### 3. (Optional) Add an Icon Library
-
-Many components work well with icons. We recommend [Font Awesome](https://fontawesome.com/):
+### Existing project
 
 ```bash
-pnpm add @fortawesome/fontawesome-free
+npm install @allxsmith/bestax-bulma
+# or: pnpm add @allxsmith/bestax-bulma
 ```
 
-And then import in your code as needed.
-
-### 4. Quick Example
-
-Here’s how to use the `Button` component:
+Import the bundled CSS once (Bulma v1 + the bestax extras), then use components:
 
 ```tsx
-import React from 'react';
+import '@allxsmith/bestax-bulma/bestax.css';
 import { Button } from '@allxsmith/bestax-bulma';
-import 'bulma/css/bulma.min.css';
 
 function App() {
   return (
-    <div>
-      <Button color="primary" onClick={() => alert('Clicked!')}>
-        Click Me
-      </Button>
-    </div>
+    <Button color="primary" onClick={() => alert('Clicked!')}>
+      Click Me
+    </Button>
   );
 }
-
-export default App;
 ```
 
----
+Prefer stock Bulma? `import 'bulma/css/bulma.min.css';` works too — you'll just miss the bestax-only components' styles (add `@allxsmith/bestax-bulma/extras.css` for those).
 
-## ⭐ Why Choose bestax-bulma?
+Theming, dark mode, and configuration are one wrapper away:
 
-- **Ultra-lightweight: Only 21KB gzipped** ✨
-  3-20x smaller than most popular React UI libraries (which range from 60-500KB+ gzipped)
-- **Supports the latest Bulma v1.x**
-  Other React Bulma libraries are stuck on Bulma 0.9.4 — bestax-bulma is built for the future.
-- **Just one dependency: Bulma**
-  Every Bulma library depends on it — we ship it automatically. Clean install, smaller bundle, fewer security concerns.
-- **99% unit test coverage**
-  Rigorously tested for reliability and stability.
-- **100% TypeScript**
-  Full type safety for you and your team.
-- **100% Bulma Implementation**
-  Complete bulma implementation.
-- **Active developer support**
-  Issues? Questions? PRs? Get fast responses and real improvements.
+```tsx
+import { Theme, ConfigProvider } from '@allxsmith/bestax-bulma';
 
----
+function Root() {
+  return (
+    <Theme isRoot colorMode="system">
+      {/* colorMode: 'light' | 'dark' | 'system' */}
+      <ConfigProvider iconLibrary="fa">
+        <App />
+      </ConfigProvider>
+    </Theme>
+  );
+}
+```
 
-## 📦 NPM Package
-
-View the package on npmjs:  
-👉 [https://www.npmjs.com/package/@allxsmith/bestax-bulma](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+[Installation guide](https://bestax.io/docs/guides/getting-started/installation) · [Configuration](https://bestax.io/docs/guides/features/configuration)
 
 ---
 
-## 📚 Documentation
+## 📦 What's in this repo
 
-**For full documentation, guides, and best practices, please use our official docs site:**
+| Path                               | Package                                                                            | What it is                                                                                                |
+| ---------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [`bulma-ui/`](bulma-ui/)           | [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) | The component library                                                                                     |
+| [`create-bestax/`](create-bestax/) | [`create-bestax`](https://www.npmjs.com/package/create-bestax)                     | Project scaffolder — `npm create bestax@latest`                                                           |
+| [`docs/`](docs/)                   | —                                                                                  | Docusaurus source of [bestax.io](https://bestax.io)                                                       |
+| [`skills/`](skills/)               | —                                                                                  | [Agent Skills](https://bestax.io/docs/skills/intro) for coding agents (also bundled into `create-bestax`) |
 
-👉 [https://bestax.io](https://bestax.io)
-
-> **Always refer to the [documentation site](https://bestax.io) first:**  
-> It’s the most complete and up-to-date source for everything bestax-bulma!
+The two packages are versioned and released independently.
 
 ---
 
-## 📖 Storybook
+## 🧩 Components
 
-Explore live, interactive component examples in our Storybook:
+80+ components covering all of Bulma v1, plus bestax extras (Carousel, Dialog, Sidebar, Steps, date/time pickers, and more):
 
-👉 [https://bestax.io/storybook](https://bestax.io/storybook)
+- **[Elements](https://bestax.io/docs/api/elements/button)** — Button, Table, Tag, Title, Icon, Image, Notification, Progress, Skeleton, Content, Delete, and typed HTML wrappers (Paragraph, Span, Figure, lists, …)
+- **[Components](https://bestax.io/docs/api/components/modal)** — Navbar, Modal, Card, Dropdown, Menu, Message, Pagination, Panel, Tabs, Breadcrumb, Toast, Tooltip, Steps, Sidebar, Carousel, Collapse, Dialog, Loading
+- **[Form](https://bestax.io/docs/api/form/input)** — Field/Control, Input, Select, TextArea, Checkbox(es), Radio(s), Switch, Slider, Rate, File, Numberinput, Autocomplete, Taginput, and DateInput / TimeInput / DateTimeInput pickers
+- **[Layout](https://bestax.io/docs/api/layout/container)** — Container, Section, Hero, Level, Media, Footer
+- **[Columns](https://bestax.io/docs/api/columns/columns)** & **[Grid](https://bestax.io/docs/api/grid/grid)** — classic 12-column flexbox columns and the Bulma v1 CSS Grid
+- **[Helpers](https://bestax.io/docs/api/helpers/theme)** — `Theme`, `ConfigProvider`, `useBulmaClasses`, `classNames`
+
+> Migrating from v2? Snackbar was merged into [Toast](https://bestax.io/docs/api/components/toast) in v3 — see the [migration guides](https://bestax.io/docs/guides/getting-started/migration).
+
+---
+
+## 🎨 Styling and theming
+
+Pick one CSS flavor (all shipped with the library — matching `create-bestax -b`):
+
+| Import                                                            | What you get                                                                        |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `@allxsmith/bestax-bulma/bestax.css`                              | **Default.** Bulma v1 + bestax extras                                               |
+| `@allxsmith/bestax-bulma/versions/bestax-prefixed.css`            | All classes prefixed `bestax-` — pair with `<ConfigProvider classPrefix="bestax-">` |
+| `@allxsmith/bestax-bulma/versions/bestax-no-helpers.css`          | Without Bulma helper classes                                                        |
+| `@allxsmith/bestax-bulma/versions/bestax-no-helpers-prefixed.css` | Prefixed, without helpers                                                           |
+| `@allxsmith/bestax-bulma/versions/bestax-no-dark-mode.css`        | Without dark-mode styles                                                            |
+| `@allxsmith/bestax-bulma/extras.css`                              | bestax extras only — for use alongside stock `bulma/css/bulma.min.css`              |
+| `@allxsmith/bestax-bulma/scss/*`                                  | Raw SCSS for full customization                                                     |
+
+- **Dark mode:** `<Theme colorMode="dark">` (or `"system"` to follow the OS) — [docs](https://bestax.io/docs/api/helpers/theme)
+- **Brand colors, fonts, radius:** the [`Theme`](https://bestax.io/docs/api/helpers/theme) component overrides Bulma's `--bulma-*` CSS variables (globally with `isRoot`, or scoped to a subtree). Default primary color is `#1e6b99`
+- **Class prefixing & icon defaults:** [`ConfigProvider`](https://bestax.io/docs/api/helpers/config) sets `classPrefix` and `iconLibrary` for a whole tree
+- **CSS variables reference:** [docs](https://bestax.io/docs/guides/features/css-variables)
 
 ---
 
@@ -134,12 +143,53 @@ Explore live, interactive component examples in our Storybook:
 Building with an AI agent (Claude Code, Cursor, Copilot)? bestax-bulma ships LLM-optimized docs:
 
 - 📘 **[LLMs guide](https://bestax.io/docs/guides/llms)** — how to use the library with AI tools
-- 📄 **[llms.txt](https://bestax.io/llms.txt)** — curated index · **[llms-full.txt](https://bestax.io/llms-full.txt)** — the full docs in one file
+- 📄 **[llms.txt](https://bestax.io/llms.txt)** — curated index · **[llms-full.txt](https://bestax.io/llms-full.txt)** — the full docs in one file · every docs page is also served as raw markdown
 - 🧩 **[Agent Skills](https://bestax.io/docs/skills/intro)** — teach your agent the bestax way:
+
+  | Skill                     | Use it when…                                                                     |
+  | ------------------------- | -------------------------------------------------------------------------------- |
+  | `bestax-layout-scaffold`  | Turning a high-level request (dashboard, landing page, …) into a responsive page |
+  | `bestax-form`             | Building forms — Field/Control composition and the full input inventory          |
+  | `bestax-theming`          | Customizing colors, fonts, dark mode via `Theme` and `--bulma-*` variables       |
+  | `bestax-custom-component` | Building a new custom component beyond stock Bulma, the bestax way               |
 
   ```bash
   npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
   ```
+
+  New projects get the skills automatically with `npm create bestax@latest my-app --skills` (plus a generated `CLAUDE.md`).
+
+---
+
+## ⭐ Why bestax-bulma?
+
+- **Built for Bulma v1.x** — most other React Bulma libraries are stuck on Bulma 0.9.4
+- **100% TypeScript** — every component and prop fully typed
+- **One runtime dependency: Bulma** — it ships with the library; clean install, fewer security concerns
+- **Lightweight** — see the live [bundlephobia badge](https://bundlephobia.com/package/@allxsmith/bestax-bulma); tree-shakeable ESM + CJS
+- **99% test coverage** — enforced in CI by the [jest config](bulma-ui/jest.config.js), not just claimed
+- **Active developer support** — issues, questions, and PRs get fast responses
+
+---
+
+## 💬 Community
+
+- [Discord](https://discord.gg/zehJrQGtKu)
+- [Stack Overflow — tag `bestax`](https://stackoverflow.com/questions/tagged/bestax)
+- [GitHub issues](https://github.com/allxsmith/bestax/issues)
+
+---
+
+## Contributing
+
+Want to contribute or run the project locally? See [`CONTRIBUTING.md`](CONTRIBUTING.md). In short:
+
+```bash
+corepack enable && pnpm install --frozen-lockfile
+pnpm all   # build, typecheck, test + coverage, lint — the pre-PR gate
+```
+
+This is a pnpm + Turborepo monorepo; contributor-facing AI context lives in [`CLAUDE.md`](CLAUDE.md) (mirrored for other tools in [`AGENTS.md`](AGENTS.md)).
 
 ---
 
@@ -151,16 +201,7 @@ bestax-bulma is built on top of the incredible [@jgthms/bulma](https://github.co
 
 If you find Bulma useful, please consider [sponsoring Jeremy Thomas](https://github.com/sponsors/jgthms) to support the continued development of Bulma.
 
-_Note: We are not affiliated with Bulma or Jeremy Thomas in any way...We’re just big fans of the Bulma framework!_
-
----
-
-## Contributing
-
-Want to contribute to bestax-bulma or run the project locally? See [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
-Pull requests and issues are welcome!  
-See individual package READMEs for more details.
+_Note: We are not affiliated with Bulma or Jeremy Thomas in any way...We're just big fans of the Bulma framework!_
 
 ---
 
@@ -169,7 +210,7 @@ See individual package READMEs for more details.
 - The [Bulma CSS framework](https://bulma.io) is © Jeremy Thomas and licensed under the [MIT License](https://github.com/jgthms/bulma/blob/master/LICENSE).
 - Some example content and documentation in this site is adapted from the Bulma website ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
 
-See [Bulma’s license page](https://github.com/jgthms/bulma/blob/main/LICENSE) for more details.
+See [Bulma's license page](https://github.com/jgthms/bulma/blob/main/LICENSE) for more details.
 
 ---
 

--- a/bulma-ui/CLAUDE.md
+++ b/bulma-ui/CLAUDE.md
@@ -42,5 +42,5 @@ The full worked walkthrough (including the SCSS side for extras) is
   widget) need an issue discussion first, and pair with SCSS in `src/scss/`.
 - Tests: jest + ts-jest + Testing Library, in each folder's `__tests__/`. Run one file with
   `pnpm --filter @allxsmith/bestax-bulma exec jest src/elements/__tests__/Button.test.tsx`.
-- Bundle size is marketing-visible ("~21 kB gzipped") — check `pnpm bundle:stats`
+- Bundle size is marketing-visible (the READMEs link the live bundlephobia badge) — check `pnpm bundle:stats`
   (writes `dist/stats.html`) when adding anything with real runtime weight.

--- a/bulma-ui/README.md
+++ b/bulma-ui/README.md
@@ -4,13 +4,15 @@
 [![npm downloads](https://img.shields.io/npm/dm/@allxsmith/bestax-bulma.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@allxsmith/bestax-bulma.svg)](https://bundlephobia.com/package/@allxsmith/bestax-bulma)
 [![TypeScript](https://img.shields.io/badge/TypeScript-100%25-blue.svg)](https://www.typescriptlang.org/)
-[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax)
+[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax/blob/main/bulma-ui/jest.config.js)
 [![Bulma](https://img.shields.io/badge/Bulma-v1.0+-00d1b2.svg)](https://bulma.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-React Bulma components library - TypeScript-first component library for Bulma CSS framework. Build accessible, modern UIs with fully-typed React components.
+TypeScript-first React component library for the **Bulma v1** CSS framework — 80+ fully typed, tree-shakeable components, including extras like Carousel, Dialog, Sidebar, Steps, and date/time pickers.
 
-A modern, flexible React component library built with the latest Bulma v1 and TypeScript.
+**Requires React `^18 || ^19`.** Bulma v1 is the only runtime dependency and installs automatically.
+
+Part of the [bestax monorepo](https://github.com/allxsmith/bestax) — see also [`create-bestax`](https://www.npmjs.com/package/create-bestax) for scaffolding new projects.
 
 ---
 
@@ -25,79 +27,91 @@ A modern, flexible React component library built with the latest Bulma v1 and Ty
 
 ## 🚀 Getting Started
 
+Starting fresh? Scaffold a ready-to-go app instead: `npm create bestax@latest my-app`.
+
 ### 1. Install the package
 
 ```bash
 npm install @allxsmith/bestax-bulma
 # or
-yarn add @allxsmith/bestax-bulma
+pnpm add @allxsmith/bestax-bulma
 ```
 
-### 2. Import Bulma CSS
+### 2. Import the CSS
 
-You must include Bulma’s CSS in your project. The easiest way is to import it in your main JS/TS file:
+The library bundles its own CSS (Bulma v1 + the bestax extras). Import it once in your main JS/TS file:
+
+```js
+import '@allxsmith/bestax-bulma/bestax.css';
+```
+
+Prefer stock Bulma? That works too — add `extras.css` for the bestax-only components' styles:
 
 ```js
 import 'bulma/css/bulma.min.css';
+import '@allxsmith/bestax-bulma/extras.css';
 ```
 
-Or add it via CDN in your HTML:
-
-```html
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css"
-/>
-```
+More flavors are shipped as subpath exports — prefixed classes (`versions/bestax-prefixed.css` + `<ConfigProvider classPrefix="bestax-">`), no-helpers, no-dark-mode, and raw SCSS at `@allxsmith/bestax-bulma/scss/*`. See the [installation guide](https://bestax.io/docs/guides/getting-started/installation).
 
 ### 3. (Optional) Add an Icon Library
 
-Many components work well with icons. We recommend [Font Awesome](https://fontawesome.com/):
+Five icon libraries are supported as optional peer dependencies: [Font Awesome](https://fontawesome.com/) (`@fortawesome/fontawesome-free`), Material Design Icons (`@mdi/font`), `ionicons`, `material-icons`, and `material-symbols`.
 
 ```bash
 npm install @fortawesome/fontawesome-free
 ```
 
-And then import in your code as needed.
+Set the default for your whole app with [`ConfigProvider`](https://bestax.io/docs/api/helpers/config), e.g. `<ConfigProvider iconLibrary="fa">`.
 
 ### 4. Quick Example
 
-Here’s how to use the `Button` component:
-
 ```tsx
-import React from 'react';
+import '@allxsmith/bestax-bulma/bestax.css';
 import { Button } from '@allxsmith/bestax-bulma';
-import 'bulma/css/bulma.min.css';
 
 function App() {
   return (
-    <div>
-      <Button color="primary" onClick={() => alert('Clicked!')}>
-        Click Me
-      </Button>
-    </div>
+    <Button color="primary" onClick={() => alert('Clicked!')}>
+      Click Me
+    </Button>
   );
 }
 
 export default App;
 ```
 
+### 5. Theming and Dark Mode
+
+Wrap your app in [`Theme`](https://bestax.io/docs/api/helpers/theme) to override Bulma's `--bulma-*` CSS variables and control the color scheme:
+
+```tsx
+import { Theme } from '@allxsmith/bestax-bulma';
+
+<Theme isRoot colorMode="system">
+  {/* colorMode: 'light' | 'dark' | 'system' */}
+  <App />
+</Theme>;
+```
+
 ---
 
 ## ⭐ Why Choose bestax-bulma?
 
-- **Ultra-lightweight: Only 21KB gzipped** ✨
-  3-20x smaller than most popular React UI libraries (which range from 60-500KB+ gzipped)
 - **Supports the latest Bulma v1.x**
   Other React Bulma libraries are stuck on Bulma 0.9.4 — bestax-bulma is built for the future.
+- **80+ components**
+  All of Bulma v1, plus extras: Carousel, Dialog, Sidebar, Steps, Autocomplete, Taginput, DateInput/TimeInput/DateTimeInput pickers, and more. (Migrating from v2? Snackbar merged into [Toast](https://bestax.io/docs/api/components/toast).)
+- **Dark mode & theming built in**
+  `Theme colorMode`, `--bulma-*` variable overrides, and prefixed-class builds via `ConfigProvider`.
 - **Just one dependency: Bulma**
-  Every Bulma library depends on it — we ship it automatically. Clean install, smaller bundle, fewer security concerns.
+  Every Bulma library depends on it — we ship it automatically. Clean install, fewer security concerns.
+- **Tree-shakeable ESM + CJS**
+  Import only what you use — see the live [bundle size](https://bundlephobia.com/package/@allxsmith/bestax-bulma).
 - **99% unit test coverage**
-  Rigorously tested for reliability and stability.
+  Enforced in CI by the [jest config](https://github.com/allxsmith/bestax/blob/main/bulma-ui/jest.config.js) — not just claimed.
 - **100% TypeScript**
   Full type safety for you and your team.
-- **100% Bulma Implementation**
-  Complete bulma implementation.
 - **Active developer support**
   Issues? Questions? PRs? Get fast responses and real improvements.
 
@@ -117,7 +131,7 @@ View the package on npmjs:
 👉 [https://bestax.io](https://bestax.io)
 
 > **Always refer to the [documentation site](https://bestax.io) first:**  
-> It’s the most complete and up-to-date source for everything bestax-bulma!
+> It's the most complete and up-to-date source for everything bestax-bulma!
 
 ---
 
@@ -134,12 +148,21 @@ Explore live, interactive component examples in our Storybook:
 Building with an AI agent (Claude Code, Cursor, Copilot)? bestax-bulma ships LLM-optimized docs:
 
 - 📘 **[LLMs guide](https://bestax.io/docs/guides/llms)** — how to use the library with AI tools
-- 📄 **[llms.txt](https://bestax.io/llms.txt)** — curated index · **[llms-full.txt](https://bestax.io/llms-full.txt)** — the full docs in one file
+- 📄 **[llms.txt](https://bestax.io/llms.txt)** — curated index · **[llms-full.txt](https://bestax.io/llms-full.txt)** — the full docs in one file · every docs page is also served as raw markdown
 - 🧩 **[Agent Skills](https://bestax.io/docs/skills/intro)** — teach your agent the bestax way:
+
+  | Skill                     | Use it when…                                                                     |
+  | ------------------------- | -------------------------------------------------------------------------------- |
+  | `bestax-layout-scaffold`  | Turning a high-level request (dashboard, landing page, …) into a responsive page |
+  | `bestax-form`             | Building forms — Field/Control composition and the full input inventory          |
+  | `bestax-theming`          | Customizing colors, fonts, dark mode via `Theme` and `--bulma-*` variables       |
+  | `bestax-custom-component` | Building a new custom component beyond stock Bulma, the bestax way               |
 
   ```bash
   npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
   ```
+
+  New projects get the skills automatically with `npm create bestax@latest my-app --skills` (plus a generated `CLAUDE.md`).
 
 ---
 
@@ -151,7 +174,7 @@ bestax-bulma is built on top of the incredible [@jgthms/bulma](https://github.co
 
 If you find Bulma useful, please consider [sponsoring Jeremy Thomas](https://github.com/sponsors/jgthms) to support the continued development of Bulma.
 
-_Note: We are not affiliated with Bulma or Jeremy Thomas in any way...We’re just big fans of the Bulma framework!_
+_Note: We are not affiliated with Bulma or Jeremy Thomas in any way...We're just big fans of the Bulma framework!_
 
 ---
 
@@ -160,7 +183,7 @@ _Note: We are not affiliated with Bulma or Jeremy Thomas in any way...We’re ju
 - The [Bulma CSS framework](https://bulma.io) is © Jeremy Thomas and licensed under the [MIT License](https://github.com/jgthms/bulma/blob/master/LICENSE).
 - Some example content and documentation in this site is adapted from the Bulma website ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
 
-See [Bulma’s license page](https://github.com/jgthms/bulma/blob/main/LICENSE) for more details.
+See [Bulma's license page](https://github.com/jgthms/bulma/blob/main/LICENSE) for more details.
 
 ## License
 


### PR DESCRIPTION
# 📝 Documentation Update Pull Request

## Description

Rewrites the root `README.md` as the **project** README — optimized first for AI agents/LLMs that land on the repo from GitHub/npm, second for humans, with both funneled to https://bestax.io — and syncs the npm-facing `bulma-ui/README.md` to current 5.x facts.

**Root `README.md`** (was a stale near-duplicate of the bulma-ui package README):

- Retitled to `# bestax` with a project-level tagline; added a `create-bestax` npm badge.
- New "At a glance" fact table directly under the badges: install commands for both packages, React `^18 || ^19` requirement, CSS import, docs/Storybook URLs, llms.txt / llms-full.txt links, and the `npx skills add` command — followed by an explicit above-the-fold instruction telling AI agents to fetch https://bestax.io/llms.txt before writing code with the library.
- Quick start for both paths: `npm create bestax@latest` (with `-t`/`-b`/`-i`/`--skills` flags) and existing projects (leading with `import '@allxsmith/bestax-bulma/bestax.css'`, plus a `Theme`/`ConfigProvider` example with `colorMode` dark mode).
- Monorepo package map (`bulma-ui`, `create-bestax`, `docs`, `skills/`), an 80+ component inventory by category (including the 3.0.0+ additions and the Snackbar→Toast note), and a CSS flavor / theming quick reference.
- Expanded 🤖 For AI Tools section with a table of the four Agent Skills, kept identical in both READMEs.

**`bulma-ui/README.md`** (rendered on npmjs.com — stays library-focused):

- CSS instructions now lead with the bundled flavors (`bestax.css`, `extras.css`, `versions/*`, `scss/*`); states the React `^18 || ^19` requirement; documents all five optional icon peers and `ConfigProvider iconLibrary`; adds a theming/dark-mode section and a monorepo backlink.

**Claims cleanup:** the "Only 21KB gzipped" / "3-20x smaller" claims were stale — a fresh 5.1.2 build measures ~62 KB gzipped — so both READMEs now rely on the live bundlephobia badge instead (the matching stale figure in `bulma-ui/CLAUDE.md` is also corrected). The 99% coverage badge now links to the CI-enforced threshold in `bulma-ui/jest.config.js`.

**New `AGENTS.md`** at the repo root: a short pointer file so non-Claude agent harnesses (Cursor, Copilot, Codex) find `CLAUDE.md`, the llms.txt docs, and the skills.

## Related Issue(s)

Refs #208
See #66, #198, #205

## Checklist

- [x] Only documentation files are affected
- [x] I have checked formatting and spelling
- [ ] Screenshots or previews added if relevant

## Additional Context

- Every factual claim was verified against the code: peer deps/engines/exports from `bulma-ui/package.json` and `create-bestax/package.json`, CSS flavors against an actual `dist/` build, component inventory against `src/index.ts` (no `Snackbar` export; pickers are `DateInput`/`TimeInput`/`DateTimeInput`), CLI flags against `create-bestax/src/cli.ts`, and docs URLs derived from the corresponding source files under `docs/docs/`.
- `pnpm format:check` passes repo-wide.
- bestax.io URLs could not be live-checked from the sandbox (network policy blocks the domain) — worth a click-through during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdubeykmYnn5RU6t6vJJs2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdubeykmYnn5RU6t6vJJs2)_