### PR TITLE
fix: ship patch releases to publish updated READMEs

### DIFF
--- a/create-bestax/README.md
+++ b/create-bestax/README.md
@@ -1,6 +1,12 @@
 # create-bestax
 
-CLI tool for scaffolding new bestax-bulma projects.
+[![npm version](https://img.shields.io/npm/v/create-bestax.svg)](https://www.npmjs.com/package/create-bestax)
+[![npm downloads](https://img.shields.io/npm/dm/create-bestax.svg)](https://www.npmjs.com/package/create-bestax)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+The scaffolder for [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) — spin up a Vite app pre-wired for the **Bulma v1** React component library in one command. Picks your framework (JS or TypeScript), CSS flavor, and icon library, and can drop in the bestax **AI skills** so an agent like Claude Code knows the library from the first prompt.
+
+Part of the [bestax monorepo](https://github.com/allxsmith/bestax) — see also [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) for the components themselves.
 
 ## Usage
 
@@ -32,6 +38,8 @@ You'll be asked to:
 3. Choose a Bulma CSS flavor (Complete or Minimal)
 4. Select an icon library (Font Awesome, Material Icons, etc.)
 5. Choose whether to install the bestax AI skills into `.claude/skills/`
+
+Every prompt has a flag equivalent, so the whole flow is scriptable and CI-friendly — see the options below.
 
 ### Command Line Options
 
@@ -91,8 +99,8 @@ Available templates:
 
 Each template includes:
 
-- Pre-configured bestax-bulma integration
-- Bulma CSS v1.0.4
+- Pre-configured bestax-bulma integration (React 19)
+- The latest `@allxsmith/bestax-bulma`, which ships Bulma v1 automatically
 - Icon library support (Font Awesome, Material Design, etc.)
 - Sample components demonstrating library usage
 - Development and build scripts
@@ -100,10 +108,11 @@ Each template includes:
 ## For AI Tools
 
 Scaffolding for an AI agent? Pass `--skills` (or accept the prompt) to drop the bestax
-Agent Skills and a `CLAUDE.md` into the new project. The library also ships LLM-optimized
-docs:
+Agent Skills and a `CLAUDE.md` into the new project so Claude Code, Cursor, or Copilot
+build the bestax way from the start. The library also ships LLM-optimized docs:
 
 - [LLMs guide](https://bestax.io/docs/guides/llms) — using bestax with Claude Code, Cursor, Copilot
+- [Agent Skills](https://bestax.io/docs/skills/intro) — teach your agent the bestax conventions
 - [llms.txt](https://bestax.io/llms.txt) (curated index) · [llms-full.txt](https://bestax.io/llms-full.txt) (full docs)
 
 ## Development

--- a/create-bestax/templates/vite-ts/package.json
+++ b/create-bestax/templates/vite-ts/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "^4.0.0",
+    "@allxsmith/bestax-bulma": "^5.0.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },

--- a/create-bestax/templates/vite/package.json
+++ b/create-bestax/templates/vite/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@allxsmith/bestax-bulma": "^4.0.0",
+    "@allxsmith/bestax-bulma": "^5.0.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },


### PR DESCRIPTION
# Pull Request

## Description

The recent README rewrites never reached npm. `bulma-ui/README.md` was rewritten in b0fc62a (#208) as a `docs:` commit, which the release config treats as non-releasing, so npm still serves the old README. `create-bestax`'s README was stale in style/facts and its templates still pinned `bestax-bulma ^4.0.0`. This PR ships a patch release of each package to publish the current READMEs.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

**Changes**

- `fix(bulma-ui)` — empty trigger commit; the README rewrite is already in the tree from #208, this fires the patch release (→ 5.1.3) so it reaches the npm package page.
- `fix(create-bestax)` — refresh the README (npm badges, monorepo cross-links, AI-skills note, drop hardcoded Bulma patch version) and bump the `vite`/`vite-ts` templates from `bestax-bulma ^4.0.0` to `^5.0.0` so new projects scaffold on the current major (→ 3.1.4).

## Related Issue(s)

Closes #210

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

N/A — README/text and template dependency changes only.

## Additional Context

`create-bestax` unit tests pass (178/178) after the template bump, and `prettier --check` passes for all changed files. No test or snapshot referenced the old `^4.0.0` pin. Templates are excluded from linting per package convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_017hfB3ZQTLwjN3Cg5TsPLM7)_