### PR TITLE
docs: reorg + collapse the LLMs guide in the sidebar

### DIFF
--- a/docs/docs/guides/library/_category_.json
+++ b/docs/docs/guides/library/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Library",
-  "position": 3,
+  "position": 4,
   "link": {
     "type": "doc",
     "id": "guides/library/index"

--- a/docs/docs/guides/llms/_category_.json
+++ b/docs/docs/guides/llms/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "LLMs",
+  "position": 3,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "guides/llms/index"
+  }
+}

--- a/docs/docs/guides/llms/index.md
+++ b/docs/docs/guides/llms/index.md
@@ -1,7 +1,6 @@
 ---
 title: LLMs
 sidebar_label: LLMs
-sidebar_position: 4
 ---
 
 # bestax-bulma with LLMs
@@ -9,22 +8,6 @@ sidebar_position: 4
 `@allxsmith/bestax-bulma` ships LLM-optimized documentation so AI coding agents —
 Claude Code, Cursor, GitHub Copilot, ChatGPT — can read the docs in full and build
 with the library correctly. This page explains what's published and how to use it.
-
-## How these docs are generated
-
-The LLM docs are generated at build time by
-[`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms)
-(configured in `docs/docusaurus.config.js`), following the
-[llmstxt.org](https://llmstxt.org) standard. Three artifacts are produced and served
-from the site root:
-
-| File                                                | What it is                                                                                                                          |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [`/llms.txt`](https://bestax.io/llms.txt)           | Curated **index** — a table of contents linking every doc page (per the llmstxt.org spec).                                          |
-| [`/llms-full.txt`](https://bestax.io/llms-full.txt) | The **entire documentation** concatenated into a single plain-text file.                                                            |
-| Per-page `.md`                                      | Every page is also served as clean Markdown at `<page>.md`, e.g. [`/docs/guides/intro.md`](https://bestax.io/docs/guides/intro.md). |
-
-All three are regenerated on every docs build, so they always match the deployed site.
 
 ## Using bestax docs with AI tools
 
@@ -68,3 +51,19 @@ Found the LLM docs unclear, incomplete, or wrong for your agent? Please
 [open an issue](https://github.com/allxsmith/bestax/issues/new/choose) describing what
 you expected and what happened — feedback on how well the docs work with AI tools is
 especially welcome.
+
+## How these docs are generated
+
+The LLM docs are generated at build time by
+[`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms)
+(configured in `docs/docusaurus.config.js`), following the
+[llmstxt.org](https://llmstxt.org) standard. Three artifacts are produced and served
+from the site root:
+
+| File                                                | What it is                                                                                                                          |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [`/llms.txt`](https://bestax.io/llms.txt)           | Curated **index** — a table of contents linking every doc page (per the llmstxt.org spec).                                          |
+| [`/llms-full.txt`](https://bestax.io/llms-full.txt) | The **entire documentation** concatenated into a single plain-text file.                                                            |
+| Per-page `.md`                                      | Every page is also served as clean Markdown at `<page>.md`, e.g. [`/docs/guides/intro.md`](https://bestax.io/docs/guides/intro.md). |
+
+All three are regenerated on every docs build, so they always match the deployed site.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -170,6 +170,10 @@ const config = {
             position: 'left',
             label: 'Components',
           },
+          // TODO(nav refactor): rework the AI-docs nav — Skills gets its own
+          // top-nav dropdown while the LLMs guide is buried inside the
+          // "Getting Started" (guideSidebar) side menu. Plan: surface the LLMs
+          // guide in a dedicated side menu and keep Skills at the top. Another day.
           {
             type: 'docSidebar',
             sidebarId: 'skillsSidebar',


### PR DESCRIPTION
Guide-page polish (no release; docs deploys on merge).

## Changes
- **LLMs moved right under Getting Started** in the guides side menu, as a **collapsed category** (`guides/llms/` with `_category_.json`) — ready to hold future LLM pages. Renders as a link today (single page); becomes a real collapsible group when more pages are added.
- **"How these docs are generated" moved to the last section** of the guide, so the how-to-use content leads.
- **`TODO(nav refactor)` comment** in the navbar config: future move of Skills to the top navbar and the LLMs guide to its own side menu.

## Route safety
The page route `/docs/guides/llms` is **unchanged** (folder `index.md`, mirrors the existing `guides/library/index.md` pattern), so nothing linking the guide breaks. Only the internal per-page markdown mirror shifts `/docs/guides/llms.md` → `/docs/guides/llms/index.md` (auto-updated in `llms.txt`; nothing hardcodes it).

## On #203 (convergence)
Dropped and closed. Research (Mantine, MUI, Vuetify, Chakra, shadcn) showed no library converges discovery surfaces on one canonical entrypoint or uses an `llms` package.json key — and discovery already resolves in **1–2 hops** from every entrypoint. Not worth the effort/release churn.

## Verification
- `docs` build passes (fails on broken links). Route preserved; section order ends with "How these docs are generated".
- Browser-validated: LLMs sits under Getting Started; TOC order correct.
- `format:check` clean.

https://claude.ai/code/session_01MoujiGigUjNPaPpkX6KJyP