### PR TITLE
ci: raise claude-implement max-turns to 150 and widen allowedTools

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -91,9 +91,9 @@ jobs:
           track_progress: true
           use_commit_signing: true
           claude_args: |
-            --max-turns 50
+            --max-turns 150
             --model claude-sonnet-5
-            --allowedTools "Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(gh issue view:*),Bash(gh pr create:*),Bash(gh pr view:*)"
+            --allowedTools "Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Description

Tunes the autonomous implement loop (`.github/workflows/claude-implement.yml`) so a single combined multi-component run can actually finish. Two changes to the `Run Claude (implement issue)` step's `claude_args`:

1. **`--max-turns 50` → `150`** (tripled). The run on #188 ended with `error_max_turns` at 51 turns / 6m10s with no branch or PR produced.
2. **Widen `--allowedTools`** with a curated set of low-risk commands. The same run logged `permission_denials_count: 10` (~20% of turns wasted on denied calls). Added:
   - read-only git inspection: `git status`, `git diff`, `git log`, `git show`
   - read-only deps: `pnpm ls`, `pnpm why`
   - `mkdir` (new component/test/docs folders)
   - scoped GitHub CLI: `gh issue comment`, `gh pr edit`, `gh pr diff`, `gh pr checks`

Affected package(s):

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: CI / GitHub Actions (`.github/workflows/claude-implement.yml`)

## Related Issue(s)

Closes #217
Refs #188

## Type of Change

- [x] Build tooling

## Security notes

This **keeps the allowlist model** — no bypass / `--dangerously-skip-permissions` / "auto mode" flag is added. The loop runs on untrusted issue input while holding `contents:write` + `pull-requests:write` + `issues:write` + an app token, so the additions are deliberately limited to read-only and narrowly-scoped write commands. Explicitly kept **out**: `git push/reset/checkout/rebase/merge`, `curl`/`wget`, `pnpm dlx`/`npx`/dep-adding, `gh api`/`secret`/`workflow`/`pr merge`, `rm -rf`. `--disallowedTools "WebSearch,WebFetch"` and the `.github/**` / release-config guardrails are unchanged.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] All new and existing tests passed (no test surface — config-only change; YAML validated with `yaml.safe_load`)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (N/A — no command/convention change)

## Additional Context

This is a `.github/**` change, which the AI loop's own gate refuses to author — so it is intentionally done as a direct human-reviewed PR rather than through the `claude-fix` loop. It unblocks the combined Button/Link/LinkButton work in #188 (kept as one issue by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the automated coding workflow’s allowed commands to support more common Git and package-manager checks.
  * Increased the workflow’s conversation limit, allowing longer-running assistance sessions before timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->