### PR TITLE
ci: strengthen PR-creation step and drop inert GH_TOKEN env

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -85,16 +85,6 @@ jobs:
 
       - name: Run Claude (implement issue)
         if: steps.perm.outputs.allowed == 'true'
-        # Authenticate the `gh` CLI inside the agent's Bash sandbox so step 5's
-        # `gh pr create` can actually open the PR. Without a token here, gh is
-        # unauthenticated and PR creation silently fails (the branch still gets
-        # pushed via the signed-commit MCP, but no PR is opened). AI_LOOP_PAT is
-        # the bestaxbot machine account's fine-grained PAT (scoped to this repo,
-        # Contents + Pull requests: write). Using a real account's PAT — rather
-        # than the automatic GITHUB_TOKEN — means the PR is authored by bestaxbot
-        # and therefore triggers CI, which the claude-pr-loop convergence needs.
-        env:
-          GH_TOKEN: ${{ secrets.AI_LOOP_PAT }}
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -143,12 +133,20 @@ jobs:
                scope of bulma-ui, docs, or create-bestax. The PR title
                becomes the squash commit and drives semantic-release — this
                is release-critical.
-            5. Open the PR yourself:
+            5. Open the PR yourself. This is REQUIRED and is the definition
+               of "done" — the task is NOT complete until a real PR exists.
+               Do NOT merely post a "Create a PR" / compare link; a link does
+               not count and is an explicit failure of this step. You MUST
+               actually run `gh pr create` and it MUST return a PR URL:
                gh pr create --base main \
                  --title "<type>(<scope>): <description>" \
                  --label ai-loop \
                  --body "<summary; fill the PR template checklist; the body
                  MUST contain the literal line: Fixes #${{ github.event.issue.number }}>"
+               Then confirm it exists with `gh pr view --json url,number` and
+               put that PR URL in your final comment. If `gh pr create` errors,
+               report the exact error in your comment and STOP — never fall
+               back to a compare link and never claim the PR step is done.
             6. Never merge or close PRs, never enable auto-merge, never push
                to main, and never write "@claude" or "@coderabbitai" in any
                comment, commit message, or PR text.


### PR DESCRIPTION
## Description

Two changes to `.github/workflows/claude-implement.yml`, keeping the loop on the **`claude[bot]`** identity for now:

1. **Strengthen step 5 (open the PR).** The base `claude-code-action` instructions tell the agent to just post a "Create a PR" link, which competes with our instruction to actually run `gh pr create`. That made PR creation non-deterministic — run #28758428702 only posted a link (no PR), run #28760459129 opened one (#220). Step 5 now: declares a link an explicit failure, requires `gh pr create` to return a PR URL, requires confirming with `gh pr view`, and forbids falling back to a compare link.

2. **Remove the inert `env: GH_TOKEN: ${{ secrets.AI_LOOP_PAT }}`.** The action manages the agent's git/`gh` credentials itself and uses the Claude GitHub App token, so that step-level env never controlled PR authorship (PRs are authored by `claude[bot]` regardless). Removing it so `AI_LOOP_PAT` has demonstrably zero involvement.

The **`bestaxbot` account and `AI_LOOP_PAT` secret are left in place** — untouched — for a future `github_token:` change if we decide we want bestaxbot authorship. This PR does not pursue that.

Affected package(s):

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: CI / GitHub Actions (`.github/workflows/claude-implement.yml`)

## Related Issue(s)

Refs #188

## Type of Change

- [x] Build tooling

## Verification plan

After merge: close #220 + delete its branch, then re-cycle the `claude-fix` label on #188. Expected: the run reliably opens a fresh PR authored by `claude[bot]` — proving `AI_LOOP_PAT` had nothing to do with PR creation, and that the strengthened step 5 makes PR creation dependable.

## Checklist

- [x] Self-reviewed
- [x] YAML validated (`yaml.safe_load`); `env` block confirmed removed from the Run Claude step
- [x] `bestaxbot` / `AI_LOOP_PAT` intentionally left in place for later

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened the automated PR creation flow to require a successfully created pull request with a verified PR link.
  * Added stricter failure handling so the process now stops and reports the exact error if PR creation fails.
  * Improved the final status comment to always include the confirmed pull request URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->