### PR TITLE
ci: raise claude-review max-turns to 60

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -93,7 +93,7 @@ jobs:
           # The PR opener/labeler is claude[bot] (the implementer) by design.
           allowed_bots: 'claude'
           claude_args: |
-            --max-turns 20
+            --max-turns 60
             --model claude-opus-4-8
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*)"
           prompt: |


### PR DESCRIPTION
## Description

Raises `--max-turns` in `claude-review.yml` from **20 → 60**.

The Claude Deep Review job hit `error_max_turns` (20-turn cap) reviewing PR #222 (11 files, +225 lines): it read the diff and began verifying findings but ran out before posting its `<!-- claude-deep-review -->` certification marker. Because `claude-pr-loop`'s gate requires that marker before it can hand a PR to a human, a capped-out review **silently blocks the whole convergence loop** (the `gate`/`verify`/`handoff` jobs all showed skipped on #222).

Same class of issue as #218 (the implementer's turn cap). The reviewer does less work than the 150-turn implementer, so 60 (tripled) is a comfortable margin for an adversarial pass with test verification without being wasteful.

Affected package(s):

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: CI / GitHub Actions (`.github/workflows/claude-review.yml`)

## Related Issue(s)

Refs #188

## Type of Change

- [x] Build tooling

## Checklist

- [x] Self-reviewed
- [x] YAML validated (`yaml.safe_load`)
- [x] Turns-only change; allowlist unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated review process to allow more thorough analysis during workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->