### PR TITLE
ci: grant claude-pr-loop gate pull-requests:write for its PR comment

### DIFF
--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -107,8 +107,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read # commits API (head age)
-      pull-requests: read # pr view / checks / reviews / threads
-      issues: write # the ai-loop-state marker comment
+      pull-requests: write # pr reads + POST the ai-loop-state marker comment (a PR comment needs pull-requests:write, not issues:write)
+      issues: write # issue-comment reads
       checks: read # gh pr checks (check runs)
       statuses: read # gh pr checks + CodeRabbit commit status
       actions: read # gh run list (deep-review conclusion)


### PR DESCRIPTION
## Description

Fixes the `gate` job in `claude-pr-loop.yml` failing with **`gh: Resource not accessible by integration` (HTTP 403)** (seen on #225, [run](https://github.com/allxsmith/bestax/actions/runs/28788982194/job/85362569409)).

**Root cause:** the gate posts its `<!-- ai-loop-state -->` marker comment via `POST /repos/.../issues/{pr}/comments`. On a **pull request**, that endpoint requires **`pull-requests: write`** — but the gate job declared only `pull-requests: read` (plus `issues: write`, which covers plain issues, not PR comments). So the POST 403s.

This path only runs in `fix-ci`/`fix-reviews` mode. Every prior gate run resolved to `skip` (CodeRabbit not done yet), so the comment-posting code had never executed — the bug was latent until CodeRabbit posted actionable findings on #225 and the gate first entered `fix-reviews`.

**Fix:** bump the gate's `pull-requests` permission to `write`. This aligns it with the `fix`/`verify`/`handoff`/`halt` jobs, which already declare `pull-requests: write` for their `gh pr comment`/`gh pr edit` calls.

Affected package(s):

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: CI / GitHub Actions (`.github/workflows/claude-pr-loop.yml`)

## Related Issue(s)

Refs #188

## Type of Change

- [x] Build tooling

## Checklist

- [x] Self-reviewed
- [x] YAML validated; gate perms now include `pull-requests: write`
- [x] Least-privilege preserved — only the gate's PR-read is raised to write; all other scopes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_