### PR TITLE
ci: add on-slop workflow to auto-close flagged AI PRs

### DIFF
--- a/.github/workflows/on-slop.yml
+++ b/.github/workflows/on-slop.yml
@@ -1,0 +1,69 @@
+name: On Slop
+
+# A maintainer flags a low-quality AI-generated PR by applying the `slop`
+# label; this workflow posts a standardized explanation and closes the PR.
+# Mirrors oven-sh/bun's on-slop.yml. GitHub only lets triage+ users apply
+# labels; the permission step re-verifies the labeler as belt-and-braces.
+# This never checks out PR code, so `pull_request_target` is safe here.
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+# No workflow-level grants; the single job takes exactly what it needs.
+permissions: {}
+
+concurrency:
+  group: on-slop-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  close:
+    if: |
+      github.event.label.name == 'slop' &&
+      github.event.sender.type == 'User' &&
+      github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write # comment, label, close
+      issues: write # issue-comment API for the PR conversation
+    steps:
+      - name: Verify labeler has triage+ and close
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          set -euo pipefail
+          # GitHub already restricts labeling to triage+; re-verify defensively
+          # so an automated/template label can never trigger an auto-close.
+          ROLE=$(gh api "repos/$REPO/collaborators/$SENDER/permission" \
+            --jq '.role_name' || echo none)
+          case "$ROLE" in
+            admin|maintain|write|triage)
+              echo "$SENDER has $ROLE access — closing PR #$PR as slop" ;;
+            *)
+              echo "$SENDER lacks triage access ($ROLE) — ignoring"; exit 0 ;;
+          esac
+
+          gh pr comment "$PR" --repo "$REPO" --body "**Flagged as AI slop** by @$SENDER and closed.
+
+          This PR was flagged as a low-quality AI-generated change. Common reasons:
+          - Fails to verify the reported problem actually exists.
+          - Fails to test that the fix works (no failing→passing regression test).
+          - Makes incorrect assumptions about the codebase or the fix's scope.
+
+          If the underlying issue is real, please open (or re-open) an issue with a
+          reproduction and it will get a proper fix. The AI loop never merges — a
+          human always rules."
+
+          # Strip loop labels so the PR leaves the loop cleanly; ignore any that
+          # are not present.
+          gh pr edit "$PR" --repo "$REPO" \
+            --remove-label ai-loop \
+            --remove-label ai-loop-paused \
+            --remove-label needs-human-review || true
+
+          gh pr close "$PR" --repo "$REPO"


### PR DESCRIPTION
## Description

**Item 2 of 3** — a one-click human kill switch for low-quality AI PRs, mirroring [oven-sh/bun's `on-slop.yml`](https://github.com/oven-sh/bun/pull/30680).

When a **triage+ maintainer applies the `slop` label** to an open PR, this workflow:
1. re-verifies the labeler has triage+ (defensive; GitHub already restricts labeling),
2. posts a standardized message citing the common AI-PR failure modes (didn't verify the problem exists / didn't test the fix / bad assumptions),
3. strips the loop labels and **closes** the PR.

It never checks out PR code, so `pull_request_target` is safe.

Affected package(s):

- [x] Other: CI / GitHub Actions (`.github/workflows/on-slop.yml`)

## Related Issue(s)

Refs #188

## Type of Change

- [x] Build tooling

## ⚠️ Required setup (human, one-time)

Create a **`slop`** label in the repo (Issues → Labels → New label) — e.g. color `#b60205`, description "Low-quality AI-generated PR; auto-closed by on-slop.yml". Until the label exists, there's nothing to apply and the workflow simply never fires (safe no-op). GitHub will also auto-create it the first time you type `slop` in the label picker.

## Checklist

- [x] Self-reviewed; YAML validated (`pull_request_target` labeled → single `close` job)
- [x] Least-privilege: `pull-requests: write` + `issues: write` only; no code checkout
- [x] Triage-gated so an automated/template label can't trigger an auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated handling for pull requests marked with a specific review label.
  * Eligible pull requests now receive a standardized comment and may be closed automatically when flagged.
  * The process now checks that the label was added by a human and only acts on open pull requests.
  * Related review labels are removed before the pull request is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->