### PR TITLE
ci: require a failing→passing repro test for bug-fix loop PRs

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -123,6 +123,16 @@ jobs:
                - Never touch .github/**, jest configs, commitlint/release
                  configs, pnpm-workspace.yaml, .npmrc, .coderabbit.yaml, or
                  turbo.json (the loop's gate rejects PRs that do).
+               - REGRESSION-TEST GATE (bug fixes): if the issue reports a
+                 BUG, FIRST write a test that reproduces it and FAILS against
+                 the current code; run it and confirm it fails for the
+                 reported reason. THEN implement the fix and confirm that
+                 same test now passes. Include both in the PR. If you cannot
+                 produce a failing→passing reproduction — the bug does not
+                 reproduce, or it is not a code defect — do NOT open a PR:
+                 comment on the issue explaining what you found, and stop.
+                 (For feature/enhancement issues, add tests that exercise the
+                 new behavior; a pre-fix failing test is not required.)
             3. Before opening the PR, run the gates for what you touched:
                `pnpm --filter <pkg> run lint`, `... typecheck`,
                `... test:coverage`, `pnpm run format:check`,


### PR DESCRIPTION
## Description

**Item 3 of 3** — the biggest quality lever, from the Bun/robobun model.

Bun only opens a PR once a generated regression test goes **failing→passing** — the enforcement behind their "verify the problem is real / test that the fix works" bar, and a direct counter to the documented failure mode where AI fixes were merged that *didn't* actually resolve the bug ([oven-sh/bun#26660](https://github.com/oven-sh/bun/issues/26660)).

**Change:** add a `REGRESSION-TEST GATE` to `claude-implement.yml`'s prompt. For **bug** issues the agent must:
1. FIRST write a test that reproduces the bug and **fails** on current code (confirm it fails for the reported reason),
2. THEN implement the fix and confirm that **same test passes**,
3. include both in the PR.

If it **cannot** produce a failing→passing reproduction (doesn't reproduce, or isn't a code defect), it must **comment on the issue and NOT open a PR**. Feature/enhancement issues (like #188) are exempt from the pre-fix failing test but still add behavior tests.

Affected package(s):

- [x] Other: CI / GitHub Actions (`.github/workflows/claude-implement.yml`)

## Related Issue(s)

Refs #188

## Type of Change

- [x] Build tooling

## Checklist

- [x] Self-reviewed; YAML validated
- [x] Prompt-only change; feature issues explicitly exempted from the pre-fix failing test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a stronger regression-check requirement for bug fixes, ensuring issues are reproduced with a failing test before any fix is accepted.
  * Fixes now must be verified against the original failing test before changes can be finalized, helping prevent reintroducing the same problem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->