### PR TITLE
ci: author implement-loop PRs as bestaxbot machine account

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -87,6 +87,13 @@ jobs:
         if: steps.perm.outputs.allowed == 'true'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
+          # Run GitHub operations as the bestaxbot machine account (like Bun's
+          # robobun) so PRs are authored by bestaxbot, not the shared
+          # claude[bot]. AI_LOOP_PAT is bestaxbot's PAT. The model still runs
+          # on the subscription via claude_code_oauth_token below. The
+          # independent deep review keeps posting as claude[bot] (see
+          # claude-review.yml), preserving reviewer separation.
+          github_token: ${{ secrets.AI_LOOP_PAT }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           use_commit_signing: true


### PR DESCRIPTION
## Description

**Stage 1 of 2** — give the loop a Bun/robobun-style machine identity.

Wires the **bestaxbot** PAT (`secrets.AI_LOOP_PAT`) into the implement action's `github_token`, so implement-loop PRs/commits are **authored by bestaxbot** instead of the shared `claude[bot]`. The model still runs on the subscription via `claude_code_oauth_token`.

**Reviewer separation preserved (matches Bun):** the deep review (`claude-review.yml`) keeps posting as `claude[bot]`, so the loop's `^claude` thread/state-machine filters in `claude-pr-loop.yml` stay intact — and it mirrors Bun's actual setup, where **robobun authors** and a **distinct `claude[bot]` reviews**.

Affected package(s):

- [x] Other: CI / GitHub Actions (`.github/workflows/claude-implement.yml`)

## Related Issue(s)

Refs #188

## Type of Change

- [x] Build tooling

## ⚠️ Validation needed after merge

Passing a **user PAT** to `github_token` is slightly off claude-code-action's documented path (that input is intended for a custom GitHub App). This is Stage 1 precisely so we can confirm on a live run that a bestaxbot-authored PR is produced (and CI still triggers) **before** wiring the fix job (Stage 2). If the action rejects the PAT, revert this one file.

Requires: bestaxbot is a Write collaborator (✅ done earlier) and `AI_LOOP_PAT` is set (✅).

## Checklist

- [x] Self-reviewed; YAML validated; `github_token` confirmed on the Run Claude step
- [x] Deep-review identity unchanged (claude[bot]) → state machine intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated issue-implementation flow to use a dedicated GitHub identity for repository actions.
  * PRs created by the automation will now be attributed to the correct machine account instead of the shared bot identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->