### PR TITLE
docs(docs): add usage tip to Box docs

### DIFF
--- a/docs/docs/api/elements/box.md
+++ b/docs/docs/api/elements/box.md
@@ -9,6 +9,10 @@ sidebar_label: Box
 
 The `Box` component renders a bordered, padded container with an optional shadow using Bulma's `.box` class. It's useful for visually separating content, callouts, or emphasizing important UI elements. Supports all Bulma helper props for color, spacing, and more.
 
+:::tip
+`Box` is a simple container: it applies Bulma's `box` styling (padding, rounded corners, subtle shadow) and forwards standard helper props like any other element.
+:::
+
 :::info
 By default, `Box` includes a subtle shadow. You can disable the shadow with `hasShadow={false}`.
 :::


### PR DESCRIPTION
## Summary
- Adds a short `:::tip` admonition under the Overview section of the Box component docs page, noting that `Box` is a simple container that applies Bulma's `box` styling (padding, rounded corners, subtle shadow) and forwards standard helper props like any other element.

## Scope
Docs-only change to `docs/docs/api/elements/box.md`. No component or API changes.

Fixes #232

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `Box` overview with a new tip highlighting its built-in styling, including padding, rounded corners, and a subtle shadow.
  * Clarified that `Box` supports standard helper props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->