### PR TITLE
ci: sign bestaxbot commits (SSH) and run the fix agent as bestaxbot

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -94,6 +94,12 @@ jobs:
           # independent deep review keeps posting as claude[bot] (see
           # claude-review.yml), preserving reviewer separation.
           github_token: ${{ secrets.AI_LOOP_PAT }}
+          # SSH-sign commits as bestaxbot so they are Verified (branch
+          # protection requires signed commits). ssh_signing_key takes
+          # precedence over use_commit_signing.
+          ssh_signing_key: ${{ secrets.AI_LOOP_SSH_SIGNING_KEY }}
+          bot_name: bestaxbot
+          bot_id: "300268469"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           use_commit_signing: true

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -322,6 +322,15 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
+          # Fix/refute as the bestaxbot machine account (Stage 2): its
+          # refutation replies come from a real *user*, so CodeRabbit engages
+          # with them instead of skipping bot comments. SSH-signs commits as
+          # bestaxbot so they are Verified. The deep review + verify stay
+          # claude[bot], preserving the loop's ^claude state machine.
+          github_token: ${{ secrets.AI_LOOP_PAT }}
+          ssh_signing_key: ${{ secrets.AI_LOOP_SSH_SIGNING_KEY }}
+          bot_name: bestaxbot
+          bot_id: "300268469"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Trigger actors are bots by design: coderabbitai[bot] (reviews),
           # claude[bot] (CI workflow_run after its own pushes), and


### PR DESCRIPTION
## Description

Completes the robobun-style machine identity for the loop.

**1. SSH commit signing as bestaxbot (implement job)** — Stage 1 flipped authorship to bestaxbot, but its user-PAT commits landed **Unverified** (committer `bestaxbot@bestax.io` isn't a GitHub-verifiable email), which blocks merges under "require signed commits". Adds `ssh_signing_key` + `bot_name`/`bot_id` so commits are signed as `bestaxbot <300268469+bestaxbot@users.noreply.github.com>` → **Verified**. (`ssh_signing_key` takes precedence over `use_commit_signing`.)

**2. Stage 2 — run the fix agent as bestaxbot** (`claude-pr-loop.yml`) — same `github_token` + SSH signing. The payoff: the fixer's refutation replies now come from a **real user account**, so **CodeRabbit engages** with them instead of *"Skipped: comment is from another GitHub bot"* — potentially auto-resolving contested threads rather than always escalating.

**Reviewer separation preserved:** deep review + verify stay `claude[bot]`, keeping the `^claude` state-machine filters intact — the exact robobun (author/fix) + claude[bot] (review) split Bun uses.

Affected package(s):

- [x] Other: CI / GitHub Actions (`claude-implement.yml`, `claude-pr-loop.yml`)

## Related Issue(s)

Refs #188

## Type of Change

- [x] Build tooling

## Requires

- Secret **`AI_LOOP_SSH_SIGNING_KEY`** = bestaxbot's SSH **signing** private key (✅ added by owner).
- bestaxbot's SSH **Signing Key** (public) on its account (✅).

## Checklist

- [x] Self-reviewed; both YAMLs validated; `ssh_signing_key`/`bot_name`/`bot_id` confirmed on implement + fix steps
- [x] Deep-review/verify identity unchanged (claude[bot]) → state machine intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Claude workflows to use a consistent bot identity and signed commits.
  * Improved attribution for AI-generated commits so they appear under the same machine user across runs.
  * Added configuration to help automation interact more reliably during review and fix loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->