### PR TITLE
ci: allow git-CLI write commands for ssh_signing_key commit path

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -106,7 +106,7 @@ jobs:
           claude_args: |
             --max-turns 150
             --model claude-sonnet-5
-            --allowedTools "Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
+            --allowedTools "Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -342,7 +342,7 @@ jobs:
           claude_args: |
             --max-turns 80
             --model claude-sonnet-5
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh api:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh api:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.gate.outputs.pr }}


### PR DESCRIPTION
## What

Adds the git-CLI write verbs — `checkout` / `switch` / `branch` / `add` / `commit` / `push` / `config` — to the `--allowedTools` of both the **implement** job (`claude-implement.yml`) and the **fix** job (`claude-pr-loop.yml`).

## Why

Setting `ssh_signing_key` (added in #234, so bestaxbot's commits are Verified for branch protection) switches the action's commit mechanism from the GitHub API (`mcp__github_file_ops__commit_files`) to the **local git CLI**. But both allowlists only carried read-only git verbs (`status`/`diff`/`log`/`show`).

Result on the dummy validation run (#10, issue #235): the agent's `git commit` / `git branch` / `git push` calls were all **denied**, so the run finished green but produced **no commit and no PR** — bestaxbot's own comment reported the denials.

This restores the commit path. It is **not** new authority: the agent already had commit + push to its own `claude/*` branch via the file-ops MCP; `ssh_signing_key` only changed the mechanism to local git.

## Scope

Two one-line allowlist edits. No prompt, permission, or logic changes. The fix prompt already instructs "Commit … and push to BRANCH", which is git-CLI native.

## Testing

- [ ] Re-run a dummy `claude-fix` validation and confirm bestaxbot's commit shows **Verified** and a PR is opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated development workflow permissions to support a broader set of repository actions during fix-related automation.
  * Improved the automation’s ability to work with branches and commits, which may help streamline issue resolution and turnaround time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->