### PR TITLE
docs(docs): add usage tip to Notification docs

### DIFF
--- a/docs/docs/api/elements/notification.md
+++ b/docs/docs/api/elements/notification.md
@@ -9,6 +9,10 @@ sidebar_label: Notification
 
 The `Notification` component is a Bulma-styled alert/message area for providing feedback, warnings, or information to users. It supports color themes, light variants, an optional close (delete) button, custom content, and all Bulma helper props for spacing, etc.
 
+:::tip
+`Notification` renders Bulma's colored message block, and supports a `hasDelete`/`onDelete` dismiss affordance plus the standard color helper props (`color`, `textColor`, `isLight`).
+:::
+
 :::info
 Notifications are perfect for status updates, alerts, and dismissible feedback in your UI.
 :::


### PR DESCRIPTION
## Summary
- Adds a `:::tip` admonition under the Overview on the Notification API docs page noting it renders Bulma's colored message block and supports a `hasDelete`/`onDelete` dismiss affordance plus the standard color helper props.

## Test plan
- [x] `pnpm exec prettier --check docs/docs/api/elements/notification.md` passes
- [x] `pnpm run format:check` passes repo-wide
- [x] Docs-only change; no component/API code touched

Fixes #235

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a helpful tip in the Notification API overview describing its visual behavior, dismiss support, and available color-related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->