### PR TITLE
feat(bulma-ui): make Button and Link as prop polymorphic (React.ElementType)

### DIFF
--- a/bulma-ui/src/elements/Button.stories.tsx
+++ b/bulma-ui/src/elements/Button.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Button, ButtonProps } from './Button';
 import { Buttons } from './Buttons'; // Added import
@@ -410,4 +411,21 @@ export const WithHTMLAttributes: Story = {
     className: 'custom-class',
     children: 'Submit Button',
   },
+};
+
+// Polymorphic `as` — render as a custom component (e.g. a router Link)
+const RouterLikeLink = ({
+  to,
+  ...rest
+}: { to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a data-to={to} {...rest} />
+);
+
+export const PolymorphicAs: Story = {
+  render: () => (
+    <Button as={RouterLikeLink} to="/visit" color="primary">
+      Book a visit
+    </Button>
+  ),
+  name: 'Polymorphic `as` (Router Link)',
 };

--- a/bulma-ui/src/elements/Button.tsx
+++ b/bulma-ui/src/elements/Button.tsx
@@ -25,7 +25,7 @@ import {
  * @property {string} [className] - Additional CSS classes to apply.
  * @property {(typeof validColors)[number] | 'inherit' | 'current'} [textColor] - Text color (Bulma color, 'inherit', or 'current').
  * @property {(typeof validColors)[number] | 'inherit' | 'current'} [bgColor] - Background color (Bulma color, 'inherit', or 'current').
- * @property {'a' | 'button'} [as] - Render as an anchor or button element.
+ * @property {React.ElementType} [as] - Render as a `<button>`, `<a>`, or a custom component (e.g. a router `Link`). Defaults to `'button'`; anything else (including `'a'`) uses anchor-style prop handling.
  * @property {string} [href] - Specifies the URL for anchor buttons.
  * @property {React.MouseEventHandler<HTMLButtonElement> | React.MouseEventHandler<HTMLAnchorElement>} [onClick] - Click handler for the button or anchor.
  * @property {string} [target] - Target for anchor element.
@@ -64,7 +64,7 @@ export interface ButtonProps
   className?: string;
   textColor?: (typeof validColors)[number] | 'inherit' | 'current';
   bgColor?: (typeof validColors)[number] | 'inherit' | 'current';
-  as?: 'a' | 'button';
+  as?: React.ElementType;
   href?: string;
   onClick?:
     | React.MouseEventHandler<HTMLButtonElement>
@@ -104,7 +104,7 @@ export const Button: React.FC<ButtonProps> = ({
   children,
   textColor,
   bgColor,
-  as = 'button',
+  as: Component = 'button',
   href,
   onClick,
   target,
@@ -139,8 +139,10 @@ export const Button: React.FC<ButtonProps> = ({
   // Combine prefixed Bulma classes with unprefixed user className and prefixed helper classes
   const buttonClasses = classNames(bulmaClasses, bulmaHelperClasses, className);
 
-  if (as === 'a') {
-    // Create anchor-specific props by excluding button-specific ones
+  if (Component !== 'button') {
+    // Create anchor-specific props by excluding button-specific ones, so
+    // native/custom link-like elements (an <a>, a router Link, ...) don't
+    // receive button-only HTML attributes.
     const {
       type: _type,
       disabled: _disabled,
@@ -157,7 +159,7 @@ export const Button: React.FC<ButtonProps> = ({
     } = rest as React.ButtonHTMLAttributes<HTMLButtonElement>;
 
     return (
-      <a
+      <Component
         className={buttonClasses}
         href={href}
         target={target}
@@ -173,7 +175,7 @@ export const Button: React.FC<ButtonProps> = ({
         {...(anchorRest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
       >
         {children}
-      </a>
+      </Component>
     );
   }
 

--- a/bulma-ui/src/elements/Link.stories.tsx
+++ b/bulma-ui/src/elements/Link.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Link } from './Link';
 
@@ -189,4 +190,21 @@ export const InlineWithText: Story = {
     </p>
   ),
   name: 'Inline with Text',
+};
+
+// Polymorphic `as` — render as a custom component (e.g. a router Link)
+const RouterLikeLink = ({
+  to,
+  ...rest
+}: { to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a data-to={to} {...rest} />
+);
+
+export const PolymorphicAs: Story = {
+  render: () => (
+    <Link as={RouterLikeLink} to="/about" textColor="primary">
+      Router-powered Link
+    </Link>
+  ),
+  name: 'Polymorphic `as` (Router Link)',
 };

--- a/bulma-ui/src/elements/Link.tsx
+++ b/bulma-ui/src/elements/Link.tsx
@@ -16,6 +16,7 @@ import {
  * @property {string} [target] - Where to open the linked document.
  * @property {string} [rel] - Relationship between the current and linked document.
  * @property {boolean} [isActive] - Whether the link appears active.
+ * @property {React.ElementType} [as] - Render as a custom component (e.g. a router `Link`) instead of `<a>`. Defaults to `'a'`.
  * @property {React.ReactNode} [children] - Content to be rendered inside the link.
  */
 export interface LinkProps
@@ -26,6 +27,7 @@ export interface LinkProps
   textColor?: (typeof validColors)[number] | 'inherit' | 'current';
   bgColor?: (typeof validColors)[number] | 'inherit' | 'current';
   isActive?: boolean;
+  as?: React.ElementType;
   children?: React.ReactNode;
 }
 
@@ -45,6 +47,7 @@ export const Link: React.FC<LinkProps> = ({
   textColor,
   bgColor,
   isActive,
+  as: Component = 'a',
   children,
   ...props
 }) => {
@@ -63,8 +66,8 @@ export const Link: React.FC<LinkProps> = ({
   const linkClasses = classNames(bulmaClasses, bulmaHelperClasses, className);
 
   return (
-    <a className={linkClasses || undefined} {...rest}>
+    <Component className={linkClasses || undefined} {...rest}>
       {children}
-    </a>
+    </Component>
   );
 };

--- a/bulma-ui/src/elements/LinkButton.stories.tsx
+++ b/bulma-ui/src/elements/LinkButton.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { LinkButton } from './LinkButton';
 import { Buttons } from './Buttons';
@@ -277,4 +277,21 @@ const LinkButtonInFormDemo = () => {
 export const InFormContext: Story = {
   render: () => <LinkButtonInFormDemo />,
   name: 'In Form Context',
+};
+
+// Polymorphic `as` — render as a custom component (e.g. a router Link)
+const RouterLikeLink = ({
+  to,
+  ...rest
+}: { to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a data-to={to} {...rest} />
+);
+
+export const PolymorphicAs: Story = {
+  render: () => (
+    <LinkButton as={RouterLikeLink} to="/dashboard" variant="underline">
+      Go to Dashboard
+    </LinkButton>
+  ),
+  name: 'Polymorphic `as` (Router Link)',
 };

--- a/bulma-ui/src/elements/__tests__/Button.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Button.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Button } from '../Button';
@@ -115,6 +116,40 @@ describe('Button Component', () => {
       expect(handleClick).not.toHaveBeenCalled();
       expect(link).toHaveAttribute('aria-disabled', 'true');
       expect(link).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('as={Component} custom component rendering', () => {
+    it('renders as a custom component and forwards link-like props', () => {
+      const CustomLink = ({
+        to,
+        ...rest
+      }: { to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a data-to={to} {...rest} />
+      );
+      render(
+        <Button as={CustomLink} to="/visit" color="primary">
+          Book a visit
+        </Button>
+      );
+      const link = screen.getByText('Book a visit');
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveClass('button', 'is-primary');
+      expect(link).toHaveAttribute('data-to', '/visit');
+    });
+
+    it('does not forward button-only attributes to a custom component', () => {
+      const CustomLink = (
+        props: React.AnchorHTMLAttributes<HTMLAnchorElement>
+      ) => <a {...props} />;
+      render(
+        <Button as={CustomLink} href="#" type="submit" name="foo">
+          Custom
+        </Button>
+      );
+      const link = screen.getByRole('link');
+      expect(link).not.toHaveAttribute('type');
+      expect(link).not.toHaveAttribute('name');
     });
   });
 

--- a/bulma-ui/src/elements/__tests__/Link.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Link.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Link } from '../Link';
 import { ConfigProvider } from '../../helpers/Config';
@@ -145,6 +146,31 @@ describe('Link Component', () => {
     render(<Link href="#">Plain Link</Link>);
     const link = screen.getByRole('link');
     expect(link.getAttribute('class')).toBeNull();
+  });
+
+  describe('as prop (polymorphic rendering)', () => {
+    it('renders as <a> by default', () => {
+      render(<Link href="#">Default</Link>);
+      expect(screen.getByRole('link').tagName).toBe('A');
+    });
+
+    it('renders as a custom component and forwards props', () => {
+      const CustomLink = ({
+        to,
+        ...rest
+      }: { to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a data-to={to} {...rest} />
+      );
+      render(
+        <Link as={CustomLink} to="/about" textColor="primary">
+          Router Link
+        </Link>
+      );
+      const link = screen.getByText('Router Link');
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('data-to', '/about');
+      expect(link).toHaveClass('has-text-primary', { exact: false });
+    });
   });
 
   describe('ClassPrefix', () => {

--- a/bulma-ui/src/elements/__tests__/LinkButton.test.tsx
+++ b/bulma-ui/src/elements/__tests__/LinkButton.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { LinkButton } from '../LinkButton';
@@ -114,6 +115,24 @@ describe('LinkButton Component', () => {
     const link = screen.getByRole('link');
     expect(link.tagName).toBe('A');
     expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveClass('link-button');
+  });
+
+  it('renders as a custom component and forwards link-like props', () => {
+    const CustomLink = ({
+      to,
+      ...rest
+    }: { to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+      <a data-to={to} {...rest} />
+    );
+    render(
+      <LinkButton as={CustomLink} to="/dashboard">
+        Dashboard
+      </LinkButton>
+    );
+    const link = screen.getByText('Dashboard');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('data-to', '/dashboard');
     expect(link).toHaveClass('link-button');
   });
 

--- a/docs/docs/api/elements/button.md
+++ b/docs/docs/api/elements/button.md
@@ -9,6 +9,10 @@ sidebar_label: Button
 
 The `Button` component provides a flexible and highly customizable button for your Bulma React UI. It supports all Bulma color, size, and state modifiers, as well as additional helper classes for text, spacing, and more.
 
+:::caution Accessibility
+Use `Button` for real button actions (submit, toggle, open a dialog). For a link-styled click target or client-side navigation, prefer [`LinkButton`](./linkbutton.md) — using `Button` as a fake link/`<div onClick>` loses proper anchor and a11y semantics.
+:::
+
 :::tip
 Make sure to provide meaningful text or accessible content for screen readers.
 :::
@@ -40,7 +44,7 @@ import { Button } from '@allxsmith/bestax-bulma';
 | `isActive`    | `boolean`                                                                                                                             | Applies active styling (visual only).                                                                              |
 | `isHovered`   | `boolean`                                                                                                                             | Applies hovered styling (visual only).                                                                             |
 | `isDisabled`  | `boolean`                                                                                                                             | Applies disabled styling.                                                                                          |
-| `as`          | `'button' \| 'a'`                                                                                                                     | Render as a `<button>` or `<a>`.                                                                                   |
+| `as`          | `React.ElementType`                                                                                                                   | Render as a `<button>`, `<a>`, or a custom component (e.g. a router `Link`). Defaults to `'button'`.               |
 | `href`        | `string`                                                                                                                              | Href value (if rendering as `<a>`).                                                                                |
 | `onClick`     | `function`                                                                                                                            | Click event handler.                                                                                               |
 | `target`      | `string`                                                                                                                              | Anchor tag target.                                                                                                 |
@@ -284,6 +288,21 @@ You can pass any standard HTML attributes to the Button component, such as `type
   Submit Button
 </Button>
 ```
+
+### Polymorphic `as` (Router Links)
+
+The `as` prop accepts any `React.ElementType`, not just `'button'` or `'a'`. This lets `Button` render as a router's `Link` component (React Router, Next.js, TanStack Router, etc.) while keeping Bulma's button styling and real anchor semantics — `href`, middle-click, right-click "copy link", and correct accessibility all keep working, unlike a `useNavigate()`-in-`onClick` wrapper.
+
+```tsx
+import { Link as RouterLink } from 'react-router-dom';
+import { Button } from '@allxsmith/bestax-bulma';
+
+<Button as={RouterLink} to="/visit" color="primary">
+  Book a visit
+</Button>;
+```
+
+When `as` is anything other than `'button'` (including `'a'` or a custom component), `Button` strips button-only HTML attributes (`type`, `disabled`, `form`, etc.) before spreading the remaining props onto the rendered element, so they don't leak onto a link-like component.
 
 ---
 

--- a/docs/docs/api/elements/link.md
+++ b/docs/docs/api/elements/link.md
@@ -25,17 +25,18 @@ import { Link } from '@allxsmith/bestax-bulma';
 
 ## Props
 
-| Prop        | Type                                                                                                                                                                                                                                                                                     | Default | Description                                       |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------- |
-| `href`      | `string`                                                                                                                                                                                                                                                                                 | —       | The URL the link points to.                       |
-| `target`    | `'_self'` \| `'_blank'` \| `'_parent'` \| `'_top'`                                                                                                                                                                                                                                       | —       | Where to open the linked document.                |
-| `rel`       | `string`                                                                                                                                                                                                                                                                                 | —       | Relationship between current and linked document. |
-| `isActive`  | `boolean`                                                                                                                                                                                                                                                                                | —       | Whether the link appears active.                  |
-| `className` | `string`                                                                                                                                                                                                                                                                                 | —       | Additional CSS classes.                           |
-| `textColor` | `'primary'` \| `'link'` \| `'info'` \| `'success'` \| `'warning'` \| `'danger'` \| `'black'` \| `'black-bis'` \| `'black-ter'` \| `'grey-darker'` \| `'grey-dark'` \| `'grey'` \| `'grey-light'` \| `'grey-lighter'` \| `'white'` \| `'light'` \| `'dark'` \| `'inherit'` \| `'current'` | —       | Text color helper.                                |
-| `bgColor`   | `'primary'` \| `'link'` \| `'info'` \| `'success'` \| `'warning'` \| `'danger'` \| `'black'` \| `'black-bis'` \| `'black-ter'` \| `'grey-darker'` \| `'grey-dark'` \| `'grey'` \| `'grey-light'` \| `'grey-lighter'` \| `'white'` \| `'light'` \| `'dark'` \| `'inherit'` \| `'current'` | —       | Background color helper.                          |
-| `children`  | `React.ReactNode`                                                                                                                                                                                                                                                                        | —       | Content to render inside the link.                |
-| ...         | All standard `<a>` and Bulma helper props                                                                                                                                                                                                                                                |         | (See [Helper Props](../helpers/usebulmaclasses))  |
+| Prop        | Type                                                                                                                                                                                                                                                                                     | Default | Description                                                           |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------- |
+| `href`      | `string`                                                                                                                                                                                                                                                                                 | —       | The URL the link points to.                                           |
+| `target`    | `'_self'` \| `'_blank'` \| `'_parent'` \| `'_top'`                                                                                                                                                                                                                                       | —       | Where to open the linked document.                                    |
+| `rel`       | `string`                                                                                                                                                                                                                                                                                 | —       | Relationship between current and linked document.                     |
+| `isActive`  | `boolean`                                                                                                                                                                                                                                                                                | —       | Whether the link appears active.                                      |
+| `as`        | `React.ElementType`                                                                                                                                                                                                                                                                      | `'a'`   | Render as a custom component (e.g. a router `Link`) instead of `<a>`. |
+| `className` | `string`                                                                                                                                                                                                                                                                                 | —       | Additional CSS classes.                                               |
+| `textColor` | `'primary'` \| `'link'` \| `'info'` \| `'success'` \| `'warning'` \| `'danger'` \| `'black'` \| `'black-bis'` \| `'black-ter'` \| `'grey-darker'` \| `'grey-dark'` \| `'grey'` \| `'grey-light'` \| `'grey-lighter'` \| `'white'` \| `'light'` \| `'dark'` \| `'inherit'` \| `'current'` | —       | Text color helper.                                                    |
+| `bgColor`   | `'primary'` \| `'link'` \| `'info'` \| `'success'` \| `'warning'` \| `'danger'` \| `'black'` \| `'black-bis'` \| `'black-ter'` \| `'grey-darker'` \| `'grey-dark'` \| `'grey'` \| `'grey-light'` \| `'grey-lighter'` \| `'white'` \| `'light'` \| `'dark'` \| `'inherit'` \| `'current'` | —       | Background color helper.                                              |
+| `children`  | `React.ReactNode`                                                                                                                                                                                                                                                                        | —       | Content to render inside the link.                                    |
+| ...         | All standard `<a>` and Bulma helper props                                                                                                                                                                                                                                                |         | (See [Helper Props](../helpers/usebulmaclasses))                      |
 
 ---
 
@@ -103,6 +104,19 @@ A `<Button as="a">` should still navigate to a URL. If the element triggers an a
 <Button as="a" href="#" color="primary">
   Button Link
 </Button>
+```
+
+### Polymorphic `as` (Router Links)
+
+`Link` renders an `<a>` by default, but the `as` prop accepts any `React.ElementType`, so it can render as a router's `Link` component (React Router, Next.js, TanStack Router, etc.) directly — no wrapper needed, and remaining props (like `to`) are forwarded to the rendered component.
+
+```tsx
+import { Link as RouterLink } from 'react-router-dom';
+import { Link } from '@allxsmith/bestax-bulma';
+
+<Link as={RouterLink} to="/about" textColor="primary">
+  About
+</Link>;
 ```
 
 ### Large Text Link

--- a/docs/docs/api/elements/linkbutton.md
+++ b/docs/docs/api/elements/linkbutton.md
@@ -32,25 +32,25 @@ import { LinkButton } from '@allxsmith/bestax-bulma';
 
 ## Props
 
-| Prop          | Type                                                                                                             | Default    | Description                                                             |
-| ------------- | ---------------------------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------- |
-| `variant`     | `'text' \| 'ghost' \| 'underline'`                                                                               | `'text'`   | Display mode. `text` has no underline; `ghost` uses default text color. |
-| `color`       | `'primary' \| 'link' \| 'info' \| 'success' \| 'warning' \| 'danger' \| 'white' \| 'light' \| 'dark' \| 'black'` | —          | Text color override for the button.                                     |
-| `size`        | `'small' \| 'normal' \| 'medium' \| 'large'`                                                                     | —          | Size of the button.                                                     |
-| `isRounded`   | `boolean`                                                                                                        | —          | Makes the button rounded.                                               |
-| `isLoading`   | `boolean`                                                                                                        | —          | Displays a loading spinner.                                             |
-| `isStatic`    | `boolean`                                                                                                        | —          | Makes the button non-interactive.                                       |
-| `isFullWidth` | `boolean`                                                                                                        | —          | Makes the button full-width.                                            |
-| `isFocused`   | `boolean`                                                                                                        | —          | Applies focused styling (visual only).                                  |
-| `isActive`    | `boolean`                                                                                                        | —          | Applies active styling (visual only).                                   |
-| `isHovered`   | `boolean`                                                                                                        | —          | Applies hovered styling (visual only).                                  |
-| `isDisabled`  | `boolean`                                                                                                        | —          | Applies disabled styling.                                               |
-| `as`          | `'button' \| 'a'`                                                                                                | `'button'` | Render as a `<button>` or `<a>`.                                        |
-| `href`        | `string`                                                                                                         | —          | Href value (if rendering as `<a>`).                                     |
-| `onClick`     | `function`                                                                                                       | —          | Click event handler.                                                    |
-| `className`   | `string`                                                                                                         | —          | Custom class name.                                                      |
-| `children`    | `React.ReactNode`                                                                                                | —          | Button content.                                                         |
-| ...           | All standard `<button>` and Bulma helper props                                                                   | —          | See [Helper Props](../helpers/usebulmaclasses.md)                       |
+| Prop          | Type                                                                                                             | Default    | Description                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------- |
+| `variant`     | `'text' \| 'ghost' \| 'underline'`                                                                               | `'text'`   | Display mode. `text` has no underline; `ghost` uses default text color.      |
+| `color`       | `'primary' \| 'link' \| 'info' \| 'success' \| 'warning' \| 'danger' \| 'white' \| 'light' \| 'dark' \| 'black'` | —          | Text color override for the button.                                          |
+| `size`        | `'small' \| 'normal' \| 'medium' \| 'large'`                                                                     | —          | Size of the button.                                                          |
+| `isRounded`   | `boolean`                                                                                                        | —          | Makes the button rounded.                                                    |
+| `isLoading`   | `boolean`                                                                                                        | —          | Displays a loading spinner.                                                  |
+| `isStatic`    | `boolean`                                                                                                        | —          | Makes the button non-interactive.                                            |
+| `isFullWidth` | `boolean`                                                                                                        | —          | Makes the button full-width.                                                 |
+| `isFocused`   | `boolean`                                                                                                        | —          | Applies focused styling (visual only).                                       |
+| `isActive`    | `boolean`                                                                                                        | —          | Applies active styling (visual only).                                        |
+| `isHovered`   | `boolean`                                                                                                        | —          | Applies hovered styling (visual only).                                       |
+| `isDisabled`  | `boolean`                                                                                                        | —          | Applies disabled styling.                                                    |
+| `as`          | `React.ElementType`                                                                                              | `'button'` | Render as a `<button>`, `<a>`, or a custom component (e.g. a router `Link`). |
+| `href`        | `string`                                                                                                         | —          | Href value (if rendering as `<a>`).                                          |
+| `onClick`     | `function`                                                                                                       | —          | Click event handler.                                                         |
+| `className`   | `string`                                                                                                         | —          | Custom class name.                                                           |
+| `children`    | `React.ReactNode`                                                                                                | —          | Button content.                                                              |
+| ...           | All standard `<button>` and Bulma helper props                                                                   | —          | See [Helper Props](../helpers/usebulmaclasses.md)                            |
 
 :::note
 The `isOutlined`, `isInverted`, and `isLight` props from Button are not available on LinkButton — they don't apply to link-like buttons.
@@ -124,6 +124,19 @@ Colors work with the ghost variant too.
     </LinkButton>
   ))}
 </Buttons>
+```
+
+### Polymorphic `as` (Router Links)
+
+Since `LinkButton` forwards its props to [`Button`](./button.md), it inherits the same polymorphic `as` prop — render it as a router's `Link` component to get a link-styled, a11y-friendly, client-side-navigating call to action.
+
+```tsx
+import { Link as RouterLink } from 'react-router-dom';
+import { LinkButton } from '@allxsmith/bestax-bulma';
+
+<LinkButton as={RouterLink} to="/dashboard" variant="underline">
+  Go to Dashboard
+</LinkButton>;
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Widen the `Button` `as` prop from a fixed `'a' | 'button'` union to `React.ElementType`, so it can render as a router `Link` component (React Router, Next.js, TanStack Router, etc.) while keeping Bulma styling and real anchor semantics.
- Add a new `as` prop (default `'a'`) to `Link` for the same polymorphic rendering.
- `LinkButton` inherits the same polymorphism for free, since it already forwards its props to `Button` — no code change needed there.
- Add an accessibility admonition to the top of the Button docs page steering readers toward `LinkButton` for link-styled or navigating click targets.
- Add Storybook stories and Jest tests for the new polymorphic `as` usage; update the `Button`, `Link`, and `LinkButton` docs pages.

Fixes #188

## Test plan
- [x] `pnpm --filter @allxsmith/bestax-bulma run typecheck`
- [x] `pnpm --filter @allxsmith/bestax-bulma run lint` (0 errors, pre-existing unrelated warnings only)
- [x] `pnpm --filter @allxsmith/bestax-bulma run test:coverage` (3325/3325 passing, `Button.tsx`/`Link.tsx`/`LinkButton.tsx` at 100% coverage)
- [x] `pnpm run format:check`
- [x] `pnpm run gen:catalog:check` (catalog unchanged — no component added/renamed)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Button`, `Link`, and `LinkButton` now support rendering with a custom `as` component, making them more flexible for router-style links and other custom elements.
  * Added examples in Storybook showing polymorphic usage for each component.

* **Bug Fixes**
  * Improved prop forwarding so component-specific attributes are passed through correctly.
  * Prevented button-only attributes from leaking onto non-button render targets.

* **Documentation**
  * Updated API docs and usage examples to cover the new polymorphic rendering behavior and related accessibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->