### PR TITLE
ci: add loop observability + mirror inspection tools to implement agent

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -106,7 +106,7 @@ jobs:
           claude_args: |
             --max-turns 150
             --model claude-sonnet-5
-            --allowedTools "Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
+            --allowedTools "Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}
@@ -173,6 +173,20 @@ jobs:
             6. Never merge or close PRs, never enable auto-merge, never push
                to main, and never write "@claude" or "@coderabbitai" in any
                comment, commit message, or PR text.
+
+      # Observability: the action writes a full turn-by-turn stream (every
+      # tool call, and every permission denial) to this file. Upload it so a
+      # failed/thrashing run is diagnosable after the fact — the Actions log
+      # itself only carries the init + final result. `always()` so it is kept
+      # even when the Claude step fails (exactly when it is needed).
+      - name: Upload Claude execution log
+        if: always() && steps.perm.outputs.allowed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: claude-implement-log-${{ github.event.issue.number }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          if-no-files-found: ignore
+          retention-days: 14
 
       # Optional second reviewer (repo variable AI_LOOP_COPILOT=true).
       # Copilot's automatic-review ruleset skips bot-authored PRs on personal

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -421,6 +421,20 @@ jobs:
             (every remaining thread is refuted), say so in the summary
             comment and stop — do not make cosmetic commits.
 
+      # Observability: the action writes a full turn-by-turn stream (every
+      # tool call, and every permission denial) to this file. Upload it so a
+      # failed/thrashing fix pass is diagnosable after the fact — the Actions
+      # log itself only carries the init + final result. `always()` so it is
+      # kept even when the fix step fails (exactly when it is needed).
+      - name: Upload Claude execution log
+        if: always() && steps.claude.conclusion != 'skipped'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: claude-fix-log-pr${{ needs.gate.outputs.pr }}-iter${{ needs.gate.outputs.iteration }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          if-no-files-found: ignore
+          retention-days: 14
+
       # No push + threads still open would stall the loop forever (no event
       # fires). End in a named state instead.
       - name: Terminal state check


### PR DESCRIPTION
## What

Two hardening changes to the AI loop, ahead of stress-testing it on a real bug (#189):

1. **Mirror inspection utils into the implement agent.** `claude-implement.yml`'s allowlist gains `rg`/`grep`/`cat`/`sed`/`ls`/`head`/`tail`/`wc`/`find` — the same read-only set #239 added to the fix agent.
2. **Upload the execution-output JSON as an artifact** (`if: always()`) from **both** the implement and fix jobs.

## Why

**(1)** The sonnet fixer thrashed on #238 with **42 permission denials** because it lacked read-only inspection utilities. The implement agent has the *same* allowlist gap — it's coped so far on sonnet-5 + 150 turns + the native Read/Grep tools, but a heavy issue could hit the same wall. Cheap insurance; all read-only.

**(2)** When the fixer thrashed, the Actions log told us *"42 denials"* but **not which tools** — the action streams only `init` + final `result`, and uploads no artifact. The `claude-execution-output.json` it writes to `${RUNNER_TEMP}` carries the **full turn-by-turn stream, including every tool call and every denial**. Uploading it (with `always()`, so a failed run is captured) turns the next failure from guesswork into a downloadable trace. Reuses the repo's existing pinned `actions/upload-artifact@043fb46d…`, and never fails the job (`if-no-files-found: ignore`).

## Deliberately unchanged: the models

Left as **sonnet-5 implement / opus deep review / opus fix**. The heterogeneity is intentional — the opus reviewer decorrelates from the sonnet implementer's blind spots, so unifying on one model (either direction) would weaken review. See `claude-review.yml`'s header.

## Scope

Two allowlist entries + two `upload-artifact` steps. No prompt or logic changes. YAML validated.

## Testing

- [ ] Next implement/fix run produces a downloadable `claude-*-log-*` artifact.
- [ ] If a run thrashes, the artifact enumerates the denied tools.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the set of available command-line tools for automated workflow runs.
  * Added artifact uploads for execution logs so failed or looping runs can be reviewed later.
  * Improved log retention for these artifacts to support troubleshooting over a longer period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->