### PR TITLE
ci: log full fix/verify output + give agents the gh-api thread-reply recipe

### DIFF
--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -358,6 +358,10 @@ jobs:
           # github-actions[bot] (the loop's self-dispatch continuation).
           allowed_bots: 'coderabbitai,claude,github-actions'
           use_commit_signing: true
+          # Stream the full turn-by-turn (tool calls + permission denials) into
+          # the job log. The proxy blocks the execution-output artifact's blob
+          # host, so this is the only way to see WHICH tool a denial hit.
+          show_full_output: true
           additional_permissions: |
             actions: read
           claude_args: |
@@ -424,6 +428,13 @@ jobs:
                re-engage such a thread once the REVIEWER has replied to your
                refutation (then answer that rebuttal: fix if it convinced you,
                or hold your ground once and let the loop escalate to a human).
+               HOW TO REPLY — reply INSIDE the review thread with `gh api`, not
+               an MCP tool. The ONLY MCP tool available here is
+               mcp__github_inline_comment__create_inline_comment (a NEW inline
+               comment); there is NO MCP "reply" tool, so reaching for one just
+               burns denials. Use the thread id from the query above:
+                 gh api graphql -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' -f t=<thread-id> -f b="<your reply>"
+               (A brand-new top-level note is `gh pr comment`.)
             2. Handle threads ONE AT A TIME and FINISH each — including its
                reply — before starting the next. Do NOT defer replies to the
                end of the pass.
@@ -582,6 +593,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'coderabbitai,claude,github-actions'
+          # Stream tool calls + denials to the log (blob-hosted artifact is
+          # blocked by the proxy) so a rebuttal pass is diagnosable.
+          show_full_output: true
           claude_args: |
             --max-turns 25
             --model claude-opus-4-8
@@ -601,6 +615,9 @@ jobs:
             1. List unresolved review threads whose FIRST comment author is
                claude (your earlier review) using the reviewThreads GraphQL
                query (fetch id, path, and every comment's author + body).
+               Reply INSIDE a thread with `gh api` (you have no MCP tools here):
+                 gh api graphql -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' -f t=<thread-id> -f b="<your reply>"
+               Resolve with the resolveReviewThread mutation.
 
             2. VERIFY — for a thread whose LAST reply STARTS WITH "Fixed in"
                (the fix agent claims a fix): re-examine the current code there


### PR DESCRIPTION
## What

Two changes to `claude-pr-loop.yml` so the fix agent stops silently no-op'ing on denials:

1. **`show_full_output: true`** on the **fix** and **verify** jobs → every tool call + permission denial lands in the readable job log.
2. **Explicit `gh api` thread-reply recipe** in both prompts (`addPullRequestReviewThreadReply`), plus a plain statement that there is **no MCP "reply" tool** here — only `mcp__github_inline_comment__create_inline_comment` (for a *new* comment).

## Why

On **#247** the fix agent ran clean (Opus 4.8, 24 turns, `success`) but hit **15 permission denials** and produced **zero output** — no commits, no replies, no recap — so the loop escalated with the 2 Minor findings unaddressed. Same class as the original #238 thrash: **the agent reached for a tool that isn't allowlisted and gave up.**

We couldn't name the tool because:
- the execution-output artifact (#241) is defeated by the **proxy blocking its blob-storage host** (`productionresultssa4.blob.core.windows.net` → 403), and
- the job log **hides per-turn detail** by default.

`show_full_output` fixes the observability gap directly (log, not artifact). The reply recipe fixes the most likely *cause*: the agent almost certainly reached for a nonexistent MCP "reply" tool instead of the `gh api` graphql mutation that worked on #243 — making the reply path deterministic should stop the thrash.

## Note

Prompt + one input per job. No allowlist, permission, or logic changes. YAML validated. After merge I'll re-run the fix on #247 — if it *still* denies, `show_full_output` will now name the exact tool and we allowlist it precisely.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow logging so automation runs now show more complete execution details, including tool calls and permission denials.
  * Updated automated review handling to reply directly within existing review threads and resolve them properly when issues are addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->