### PR TITLE
ci: steer the implement agent to commit via git CLI, not the file-ops MCP

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -103,6 +103,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           use_commit_signing: true
+          # Stream tool calls + denials into the job log (the execution-output
+          # artifact's blob host is blocked by the proxy) so a blocked commit
+          # or a thrash is diagnosable.
+          show_full_output: true
           claude_args: |
             --max-turns 150
             --model claude-sonnet-5
@@ -151,11 +155,20 @@ jobs:
                `... test:coverage`, `pnpm run format:check`,
                `pnpm run gen:catalog:check`. Fix failures; full CI is the
                backstop.
-            4. Commit messages AND the PR title must be conventional
-               commits; the types feat|fix|perf|refactor|style REQUIRE a
-               scope of bulma-ui, docs, or create-bestax. The PR title
-               becomes the squash commit and drives semantic-release — this
-               is release-critical.
+            4. COMMIT + PUSH with the git CLI — create the branch and push it
+               yourself with plain git:
+                 git checkout -b claude/issue-${{ github.event.issue.number }}-<short-timestamp>
+                 git add -A
+                 git commit -m "<conventional commit message>"
+                 git push -u origin HEAD
+               Do NOT use any MCP commit tool (e.g.
+               mcp__github_file_ops__commit_files) — it is NOT allowlisted here
+               and will be denied. Git is already configured to SSH-sign your
+               commits as bestaxbot, so git-CLI commits come out Verified.
+               Commit messages AND the PR title must be Conventional Commits;
+               the types feat|fix|perf|refactor|style REQUIRE a scope of
+               bulma-ui, docs, or create-bestax. The PR title becomes the
+               squash commit and drives semantic-release — release-critical.
             5. Open the PR yourself. This is REQUIRED and is the definition
                of "done" — the task is NOT complete until a real PR exists.
                Do NOT merely post a "Create a PR" / compare link; a link does


### PR DESCRIPTION
## What

Give the **implement** agent an explicit git-CLI commit+push recipe and tell it there's no MCP commit tool, plus `show_full_output`.

## Why

Implement run #18 fully built Reveal (gates green, `Reveal.tsx` 100% coverage) but opened **no PR** — its own finish comment said it was blocked:

> *"the `mcp__github_file_ops__commit_files` tool is being rejected… I have no way to grant this permission myself."*

It reached for the **file-ops MCP commit tool** (not allowlisted) instead of the **git CLI** (`git add/commit/push`, which *is* allowlisted and is exactly what runs #16/#17 used to open #243 and #247). Same non-deterministic tool-grab as the fixer reaching for a nonexistent MCP reply tool — and the same fix: steer it to the proven path explicitly.

## Changes

- **Step 4 rewritten** with a literal `git checkout -b / add / commit / push -u origin HEAD` recipe, and a plain statement that `mcp__github_file_ops__commit_files` is **not allowlisted / will be denied**. Git is already SSH-signing as bestaxbot, so git-CLI commits come out **Verified**.
- **`show_full_output: true`** on the implement job — a blocked commit shows in the log (the artifact's blob host is proxy-blocked).

## Note

Prompt + one input. No allowlist/permission/model change (git verbs were already allowlisted; this just steers to them). YAML validated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow logging so more execution details appear in job output, making blocked or looping runs easier to diagnose.
  * Updated automated commit-and-push guidance to be more explicit and reliable, helping changes be recorded and published consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->