### PR TITLE
ci: bestaxbot replies to a plain reviewer comment on its own PR

### DIFF
--- a/.github/workflows/bestaxbot-reply.yml
+++ b/.github/workflows/bestaxbot-reply.yml
@@ -1,8 +1,10 @@
 name: Bestaxbot Reply
 
 # bestaxbot responds to a TRUSTED human on a PR or issue:
-#   - a review SUBMITTED on a bestaxbot-authored PR (no mention needed), or
-#   - an "@bestaxbot" mention in a comment or a review.
+#   - a review SUBMITTED on a bestaxbot-authored PR (no mention needed),
+#   - a plain top-level comment on a bestaxbot-authored PR (no mention needed —
+#     a reviewer just talking on the bot's own PR is talking to the bot), or
+#   - an "@bestaxbot" mention in a comment or a review (anywhere else).
 # It can answer a question, refute a finding with reasoning, or push a small
 # in-scope code fix — all as the bestaxbot machine account.
 #
@@ -39,11 +41,13 @@ jobs:
   respond:
     # Layer 1 (cheap pre-gate): a real user that is NOT bestaxbot itself (it is
     # a User-type machine account, so `sender.type == 'User'` does not exclude
-    # it — without this it could answer its own comments in a loop), the system
-    # enabled, and either a review on a bestaxbot-authored PR, or an
-    # "@bestaxbot" mention — from someone already associated as
-    # OWNER/MEMBER/COLLABORATOR. Anyone else is a silent no-op that spends no
-    # usage.
+    # it — and now that ANY trusted comment on a bestaxbot PR fires this, the
+    # self-exclusion is what stops its own recap/reply comments from looping),
+    # the system enabled, and one of: a review on a bestaxbot-authored PR, a
+    # top-level comment on a bestaxbot-authored PR (issue.pull_request set and
+    # the PR author is bestaxbot), or an "@bestaxbot" mention — all from someone
+    # already associated as OWNER/MEMBER/COLLABORATOR. Anyone else is a silent
+    # no-op that spends no usage.
     if: |
       github.event.sender.type == 'User' &&
       github.event.sender.login != 'bestaxbot' &&
@@ -53,8 +57,12 @@ jobs:
           github.event.pull_request.user.login == 'bestaxbot' &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
         (github.event_name == 'issue_comment' &&
-          contains(github.event.comment.body, '@bestaxbot') &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          (
+            contains(github.event.comment.body, '@bestaxbot') ||
+            (github.event.issue.pull_request != null &&
+              github.event.issue.user.login == 'bestaxbot')
+          )) ||
         (github.event_name == 'pull_request_review_comment' &&
           contains(github.event.comment.body, '@bestaxbot') &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))


### PR DESCRIPTION
# Pull Request

## Description

Broadens the `bestaxbot-reply` trigger so a **trusted contributor's plain top-level comment on a bestaxbot-authored PR** fires the reply job with **no `@bestaxbot` mention required** — the natural case of a reviewer talking on the bot's own PR. Mentions still work everywhere else, and a submitted review already needed no mention.

The `issue_comment` branch now fires when the author is OWNER/MEMBER/COLLABORATOR **and** either the body mentions `@bestaxbot` **or** the comment is on a PR (`github.event.issue.pull_request` set) whose author is `bestaxbot`. The existing `github.event.sender.login != 'bestaxbot'` self-exclusion becomes load-bearing here: it stops bestaxbot's own recap/reply comments on its PRs from re-triggering the job in a loop. Bot senders are already excluded by `sender.type == 'User'`, so CodeRabbit/claude[bot]/github-actions comments never fire it.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: `.github/workflows/bestaxbot-reply.yml` (CI/automation)

## Related Issue(s)

Refs #252

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed (in-file header + `if:` comments)
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (n/a — no convention change)

## Additional Context

Follow-up to #252. YAML validated locally. Workflow-only change; no package source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bestaxbot now responds to trusted top-level comments on its pull requests, even without a direct mention.
  * Comment-based automation on bestaxbot PRs is more flexible for approved contributors.
* **Bug Fixes**
  * Improved handling of bot-triggered reply flows so valid comments are recognized more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->