### PR TITLE
ci: allowlist Edit/MultiEdit/Write for the write-capable agents

### DIFF
--- a/.github/workflows/bestaxbot-reply.yml
+++ b/.github/workflows/bestaxbot-reply.yml
@@ -158,7 +158,7 @@ jobs:
           claude_args: |
             --max-turns 60
             --model claude-opus-4-8
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"
+            --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"
           prompt: |
             REPO: ${{ github.repository }}
             NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -110,7 +110,7 @@ jobs:
           claude_args: |
             --max-turns 150
             --model claude-sonnet-5
-            --allowedTools "Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
+            --allowedTools "Edit,MultiEdit,Write,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -367,7 +367,7 @@ jobs:
           claude_args: |
             --max-turns 120
             --model claude-opus-4-8[1m]
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh api:*)"
+            --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh api:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.gate.outputs.pr }}


### PR DESCRIPTION
# Pull Request

## Description

Grants the `Edit` / `MultiEdit` / `Write` file tools to the three **write-capable** AI agents — `bestaxbot-reply`, the loop's `fix` job, and `claude-implement`. They were never allowlisted, so every file-tool call was permission-denied and runs only succeeded when the agent happened to fall back to `sed -i` (the one permitted mutation path).

Evidence from the #257 logs (`show_full_output`):
- The loop's fix run says verbatim: *"the Edit/Write tools and the file-ops MCP were permission-gated in this session, so I applied the source edits via `sed -i` (the only file-mutation path that was allowed)"* — its denial list shows Edit ×3, Write, python/perl heredocs all blocked before it found `sed`.
- The `bestaxbot-reply` run for the human review probed `Edit`, `Write`, shell redirects, and `git apply`, found all denied, and had to report "no commit landed."

**No new capability is granted**: the same allowlists already permit arbitrary file writes via `Bash(sed:*)` and `Bash(node:*)` (`node -e 'fs.writeFileSync(...)'`). This just makes the intended primary path deterministic instead of luck-based, and stops agents burning turns probing for a writable path.

The read-only agents are unchanged: deep review (`claude-review.yml`) and the loop's `verify` job still have no file tools.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: `.github/workflows/` (CI/automation)

## Related Issue(s)

Refs #252, #254 (prior bestaxbot-reply hardening); observed on #257.

## Type of Change

- [x] Build tooling
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed (commit message + this PR document the rationale)
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed (YAML validated; no package source touched)
- [ ] Any relevant dependencies are updated
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (n/a — no convention change)

## Additional Context

Three one-line changes (one per workflow). Follow-up test: re-trigger bestaxbot on PR #257's review comment after merge and confirm it can now implement the requested changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVR5yWevceZEFbTJmpviiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated AI workflow permissions to allow a broader set of editing actions during code-generation and review tasks.
  * Adjusted the response workflow’s permitted tool list for cleaner, more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->