### PR TITLE
ci: enforce protected-path exclusions with --disallowedTools

### DIFF
--- a/.github/workflows/bestaxbot-reply.yml
+++ b/.github/workflows/bestaxbot-reply.yml
@@ -155,9 +155,13 @@ jobs:
           # Per-turn tool calls + denials in the log (the artifact blob host is
           # proxy-blocked) so a blocked reply/commit is diagnosable.
           show_full_output: true
+          # The prompt's protected-path exclusions are enforced here, not just
+          # stated: --disallowedTools deny rules take precedence over the
+          # Edit/MultiEdit/Write allows in --allowedTools.
           claude_args: |
             --max-turns 60
             --model claude-opus-4-8
+            --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*)"
             --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -107,9 +107,13 @@ jobs:
           # artifact's blob host is blocked by the proxy) so a blocked commit
           # or a thrash is diagnosable.
           show_full_output: true
+          # The prompt's protected-path exclusions are enforced here, not just
+          # stated: --disallowedTools deny rules take precedence over the
+          # Edit/MultiEdit/Write allows in --allowedTools.
           claude_args: |
             --max-turns 150
             --model claude-sonnet-5
+            --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*)"
             --allowedTools "Edit,MultiEdit,Write,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -364,9 +364,13 @@ jobs:
           show_full_output: true
           additional_permissions: |
             actions: read
+          # The prompt's protected-path exclusions are enforced here, not just
+          # stated: --disallowedTools deny rules take precedence over the
+          # Edit/MultiEdit/Write allows in --allowedTools.
           claude_args: |
             --max-turns 120
             --model claude-opus-4-8[1m]
+            --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*)"
             --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh api:*)"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Follow-up hardening to #258 (which allowlisted `Edit`/`MultiEdit`/`Write` for the three write-capable agents — superseding this PR's original first commit, since both made the same change).

The agent prompts forbid touching `.github/**`, `pnpm-workspace.yaml`, `.npmrc`, `.coderabbit.yaml`, `turbo.json`, and the jest/commitlint/release configs — but prompt text is advisory, and with the bare file-tool grant now on main the whole workspace is writable. CodeRabbit flagged this on the original revision of this PR (3× Major: "the prompt-only exclusions don't enforce anything").

This PR mirrors the exclusion list as `--disallowedTools` deny rules in the same three workflows (`bestaxbot-reply.yml`, `claude-pr-loop.yml` fix step, `claude-implement.yml`). Deny rules take precedence over allow rules, so the protected paths are enforced by the permission layer rather than prose:

```
Edit|MultiEdit|Write × (.github/**, pnpm-workspace.yaml, .npmrc, .coderabbit.yaml,
                        turbo.json, **/jest.config.*, commitlint.config.js, **/release.config.*)
```

Known residual gap (accepted): `Bash(sed:*)`/`Bash(node:*)` remain allowlisted and could still write protected files; removing them would break how the agents work today. The loop's changed-files gate (halting on `.github/**` etc.) stays as the backstop.

Closes #259 (core defect fixed by #258; this carries the enforcement remainder).

## Test plan

- [x] All three workflows parse as valid YAML (js-yaml)
- [x] Diff is only the `--disallowedTools` line + explanatory comment in each of the three files
- [ ] Post-merge: trigger `bestaxbot-reply` on a bestaxbot PR (e.g. #257) — file edits inside package dirs succeed; an attempted edit of a protected path is denied in the log


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated workflow reliability by updating headless Claude tool permissions and tool-access rules to correctly scope automated edits.
  * Added explicit deny rules to prevent `Edit`/`MultiEdit`/`Write` changes under protected paths (including `.github/**` and key repo config/test/release files), with deny precedence over existing allowlists.
* **Documentation**
  * Added inline workflow notes clarifying how protected-path exclusions are enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->