### PR TITLE
ci: auto-label AI-assisted PRs with claude-assisted (#272)

### DIFF
--- a/.github/workflows/auto-label-claude-prs.yml
+++ b/.github/workflows/auto-label-claude-prs.yml
@@ -1,0 +1,51 @@
+name: Auto-label Claude PRs
+
+# Applies the `claude-assisted` provenance label to PRs that are AI-assisted:
+# authored by the bot account, or carrying the Claude Code attribution footer
+# in the PR body. Mirrors oven-sh/bun's auto-label-claude-prs.yml. This never
+# checks out or executes PR code — it is a single labeling API call — so
+# `pull_request_target` is safe here (same rationale as on-slop.yml).
+#
+# The addLabels API auto-creates the label on first application; suggested
+# cosmetics once it exists: color #7057ff, description "PR authored or
+# assisted by Claude (auto-applied)".
+#
+# Deliberately NOT gated on vars.AI_LOOP_ENABLED: this workflow uses zero
+# Claude/AI itself, and provenance labeling must survive the AI-loop kill
+# switch.
+
+on:
+  pull_request_target:
+    types: [opened]
+
+# No workflow-level grants; the single job takes exactly what it needs.
+permissions: {}
+
+concurrency:
+  group: auto-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  label:
+    if: |
+      github.event.pull_request.user.login == 'bestaxbot' ||
+      contains(github.event.pull_request.body, '🤖 Generated with')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write # apply the label to the PR
+      # Labels on PRs go through the issues API, and auto-creating a missing
+      # repo label requires it.
+      issues: write
+    steps:
+      - name: Add claude-assisted label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # addLabels endpoint: creates the label if it does not exist yet
+          # (unlike `gh pr edit --add-label`, which rejects unknown labels).
+          gh api "repos/$REPO/issues/$PR/labels" -f "labels[]=claude-assisted"
+          echo "Labeled PR #$PR as claude-assisted"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,9 @@ fix/verify rounds (cap 4) until CI is green and every AI review thread is resolv
 `ai-loop` (in the loop), `needs-human-review` (converged or contested — owner reviews and
 squash-merges manually; the loop never merges), `ai-loop-paused` (cap/guard hit). A triage+
 user can also apply the opt-in `deep-review` label to any PR to run the one-shot Claude
-deep review on it (once ever per PR). Kill switches: remove `ai-loop` (per PR) or set repo
-variable `AI_LOOP_ENABLED=false` (whole system). The `<!-- ai-loop-state … -->` PR comment
-is machine-managed — never reformat its first line. The loop refuses PRs that touch
-`.github/**` or the jest/commitlint/release/pnpm-workspace configs.
+deep review on it (once ever per PR). AI-assisted PRs (bestaxbot author or the Claude Code
+attribution footer) also get an auto-applied `claude-assisted` provenance label. Kill
+switches: remove `ai-loop` (per PR) or set repo variable `AI_LOOP_ENABLED=false` (whole
+system). The `<!-- ai-loop-state … -->` PR comment is machine-managed — never reformat its
+first line. The loop refuses PRs that touch `.github/**` or the
+jest/commitlint/release/pnpm-workspace configs.

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -54,6 +54,7 @@ PRs authored by the loop move through a small label lifecycle:
 | `needs-human-review` | PRs    | The loop converged (or hit a disagreement) — awaiting maintainer review/merge                         |
 | `ai-loop-paused`     | PRs    | The loop hit its iteration cap or a guardrail — a maintainer must intervene                           |
 | `deep-review`        | PRs    | Opt-in: a triage+ user applies it to run the one-shot Claude deep review on any PR (once ever per PR) |
+| `claude-assisted`    | PRs    | Auto-applied provenance for AI-assisted PRs (bestaxbot or the Claude footer)                          |
 
 The loop itself: Claude implements the issue and opens the PR → CodeRabbit reviews it and a
 second, independent Claude review (a stronger model than the implementer) does a deep pass →


### PR DESCRIPTION
# Pull Request

## Description

Adds `.github/workflows/auto-label-claude-prs.yml` (mirroring oven-sh/bun's workflow of the same name): on `pull_request_target: opened`, if the PR author is `bestaxbot` or the PR body contains the Claude Code attribution footer (`🤖 Generated with`), a plain `gh` step applies the `claude-assisted` provenance label. `pull_request_target` is safe here because the workflow never checks out or executes PR code — it is a single labeling API call (same rationale as `on-slop.yml`). Workflow-level `permissions: {}`; the job takes `pull-requests: write` plus `issues: write` (labels on PRs go through the issues API, and auto-creating the missing label requires it). Deliberately not gated on `vars.AI_LOOP_ENABLED` — this workflow uses zero Claude, so provenance survives the kill switch. Also documents the label in the ai-development guide's label table and the root `CLAUDE.md`.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): repo tooling + docs label table

## Related Issue(s)

Closes #272

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works (no tests apply to workflow YAML)
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui) (not applicable)
- [x] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated (no dependency changes)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

Not applicable — CI workflow + docs only.

## Additional Context

- Part 1 of 4: siblings #273/#274/#275 touch the same label table in `docs/docs/guides/getting-started/ai-development.md`, so trivial merge conflicts on that table are expected; this PR adds exactly one row to keep them minimal.
- The `claude-assisted` label auto-creates on first application (the addLabels API creates missing labels); suggested cosmetics afterward: color `#7057ff`, description "PR authored or assisted by Claude (auto-applied)".
- Verified locally: workflow YAML parses, and `prettier --check` passes on both changed markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically applies a `claude-assisted` label to newly opened pull requests when AI-assisted provenance is detected, improving visibility and tracking.
* **Documentation**
  * Updated the AI development guide to include the new `claude-assisted` label in the autonomous loop label lifecycle.
  * Reflowed the `deep-review` label description and adjacent kill-switch instructions for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->