### PR TITLE
ci: re-applying the deep-review label re-runs the deep review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -95,6 +95,13 @@ jobs:
       # serializes the double-fire; the marker probe catches the second run.
       # (The marker, not just any claude[bot] activity: the fix agent posts
       # claude[bot] thread replies too, which must not count as "reviewed".)
+      #
+      # EXCEPTION — deep-review `labeled` events skip the probe: a triage+
+      # human re-applying the label (verified live by the perm step above)
+      # is an explicit "run a fresh review" request, e.g. after new commits
+      # or a prompt upgrade. Usage stays human-metered: one opus session per
+      # deliberate label application. The ai-loop path and label-at-creation
+      # double-fires keep the one-review invariant.
       - name: Skip if already reviewed
         id: dedupe
         if: steps.perm.outputs.allowed == 'true'
@@ -102,8 +109,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
+          ACTION: ${{ github.event.action }}
+          LABEL: ${{ github.event.label.name }}
         run: |
           set -euo pipefail
+          if [ "$ACTION" = "labeled" ] && [ "$LABEL" = "deep-review" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "deep-review label applied by a verified triage+ user — running a fresh review"
+            exit 0
+          fi
           MARKER=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" --jq \
             '[.[] | select((.user.login | test("^claude(\\[bot\\])?$"))
                            and (.body | contains("<!-- claude-deep-review -->")))] | length')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,8 @@ Issues labeled `claude-fix` (requires triage+ access, verified live) are impleme
 fix/verify rounds (cap 4) until CI is green and every AI review thread is resolved. Labels:
 `ai-loop` (in the loop), `needs-human-review` (converged or contested — owner reviews and
 squash-merges manually; the loop never merges), `ai-loop-paused` (cap/guard hit). A triage+
-user can also apply the opt-in `deep-review` label to any PR to run the one-shot Claude
-deep review on it (once ever per PR). Kill switches: remove `ai-loop` (per PR) or set repo
+user can also apply the opt-in `deep-review` label to any PR to run the Claude deep
+review on it (re-applying the label re-runs it). Kill switches: remove `ai-loop` (per PR) or set repo
 variable `AI_LOOP_ENABLED=false` (whole system). The `<!-- ai-loop-state … -->` PR comment
 is machine-managed — never reformat its first line. The loop refuses PRs that touch
 `.github/**` or the jest/commitlint/release/pnpm-workspace configs.

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -47,13 +47,13 @@ the review-time requirements (Storybook story for UI changes, docs page for API 
 
 PRs authored by the loop move through a small label lifecycle:
 
-| Label                | Where  | Meaning                                                                                               |
-| -------------------- | ------ | ----------------------------------------------------------------------------------------------------- |
-| `claude-fix`         | issues | Maintainer-approved: Claude implements this issue and opens a PR                                      |
-| `ai-loop`            | PRs    | The PR is inside the autonomous review/fix loop                                                       |
-| `needs-human-review` | PRs    | The loop converged (or hit a disagreement) — awaiting maintainer review/merge                         |
-| `ai-loop-paused`     | PRs    | The loop hit its iteration cap or a guardrail — a maintainer must intervene                           |
-| `deep-review`        | PRs    | Opt-in: a triage+ user applies it to run the one-shot Claude deep review on any PR (once ever per PR) |
+| Label                | Where  | Meaning                                                                                        |
+| -------------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `claude-fix`         | issues | Maintainer-approved: Claude implements this issue and opens a PR                               |
+| `ai-loop`            | PRs    | The PR is inside the autonomous review/fix loop                                                |
+| `needs-human-review` | PRs    | The loop converged (or hit a disagreement) — awaiting maintainer review/merge                  |
+| `ai-loop-paused`     | PRs    | The loop hit its iteration cap or a guardrail — a maintainer must intervene                    |
+| `deep-review`        | PRs    | Opt-in: a triage+ user applies it to run the Claude deep review on any PR (re-apply to re-run) |
 
 The loop itself: Claude implements the issue and opens the PR → CodeRabbit reviews it and a
 second, independent Claude review (a stronger model than the implementer) does a deep pass →


### PR DESCRIPTION
# Pull Request

## Description

The `deep-review` label was a strict one-shot: once a PR carried the `<!-- claude-deep-review -->` marker, re-applying the label was a silent no-op, so there was no way to get a fresh opus review after new commits landed or after the review prompt improved. This PR makes a `deep-review` **labeled** event skip the marker probe — re-applying the label is an explicit "run a fresh review" request from a human whose triage+ role the workflow already re-verifies live.

Cost model is unchanged in spirit: one opus session per *deliberate* label application, human-metered. The AI-loop path and the label-at-creation double-fire keep the original one-review invariant (their dedupe is untouched), so the loop can never re-trigger reviews on itself.

Also updates the two docs that stated "once ever per PR": the label table in `docs/docs/guides/getting-started/ai-development.md` and the root `CLAUDE.md` loop section — both now say "re-apply to re-run".

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): repo tooling (`.github/workflows/claude-review.yml`) + docs

## Related Issue(s)

Refs #273

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a — workflow YAML, parse-validated)
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui) (n/a)
- [x] My changes require a change to the documentation
- [x] All new and existing tests passed (no code paths touched; prettier passes on the changed markdown)
- [ ] Any relevant dependencies are updated (n/a)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

n/a

## Additional Context

- Event-shape behavior after this change: PR opened with `ai-loop` (or with `deep-review` pre-attached) → dedupe as before, one review; `ai-loop` labeled → dedupe as before; **`deep-review` labeled → always runs a fresh review** (after the live permission re-check; non-triage labelers remain a silent no-op).
- This PR edits `claude-review.yml`, so — like #270 — the deep-review workflow's own tamper guard prevents it from reviewing this PR. CodeRabbit covers it.
- Immediate use case: re-running the opus deep review across the open PR set (#267–271, #276, #277, #279) at their current heads, several of which have moved since their original reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Re-applying the `deep-review` label now triggers another deep review for a pull request.

* **Documentation**
  * Updated contributor guidance and the AI development guide to explain the revised `deep-review` label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->