### PR TITLE
fix(create-bestax): fail fast with guidance instead of hanging when stdin is not a TTY (#192)

### DIFF
--- a/create-bestax/src/__tests__/project-creator.test.ts
+++ b/create-bestax/src/__tests__/project-creator.test.ts
@@ -55,16 +55,29 @@ const { ICON_LIBRARIES: _ICON_LIBRARIES, BULMA_FLAVORS: _BULMA_FLAVORS } =
 
 // Mock console methods
 const originalConsole = { ...console };
+const originalIsTTY = process.stdin.isTTY;
+
+function setStdinTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
 
 beforeEach(() => {
   console.log = jest.fn();
   console.error = jest.fn();
+  // ProjectCreator falls through to interactive prompts, which are guarded
+  // against non-TTY stdin (#192); jest's stdin is not a TTY, so simulate one.
+  setStdinTTY(true);
   jest.clearAllMocks();
 });
 
 afterEach(() => {
   console.log = originalConsole.log;
   console.error = originalConsole.error;
+  setStdinTTY(originalIsTTY);
 });
 
 describe('ProjectCreator', () => {

--- a/create-bestax/src/__tests__/project-creator.test.ts
+++ b/create-bestax/src/__tests__/project-creator.test.ts
@@ -55,7 +55,10 @@ const { ICON_LIBRARIES: _ICON_LIBRARIES, BULMA_FLAVORS: _BULMA_FLAVORS } =
 
 // Mock console methods
 const originalConsole = { ...console };
-const originalIsTTY = process.stdin.isTTY;
+const originalIsTTYDescriptor = Object.getOwnPropertyDescriptor(
+  process.stdin,
+  'isTTY'
+);
 
 function setStdinTTY(value: boolean | undefined): void {
   Object.defineProperty(process.stdin, 'isTTY', {
@@ -63,6 +66,14 @@ function setStdinTTY(value: boolean | undefined): void {
     configurable: true,
     writable: true,
   });
+}
+
+function restoreStdinTTY(): void {
+  if (originalIsTTYDescriptor) {
+    Object.defineProperty(process.stdin, 'isTTY', originalIsTTYDescriptor);
+  } else {
+    delete (process.stdin as { isTTY?: boolean }).isTTY;
+  }
 }
 
 beforeEach(() => {
@@ -77,7 +88,7 @@ beforeEach(() => {
 afterEach(() => {
   console.log = originalConsole.log;
   console.error = originalConsole.error;
-  setStdinTTY(originalIsTTY);
+  restoreStdinTTY();
 });
 
 describe('ProjectCreator', () => {

--- a/create-bestax/src/__tests__/prompts.test.ts
+++ b/create-bestax/src/__tests__/prompts.test.ts
@@ -65,7 +65,10 @@ const {
 
 // Mock console methods
 const originalConsole = { ...console };
-const originalIsTTY = process.stdin.isTTY;
+const originalIsTTYDescriptor = Object.getOwnPropertyDescriptor(
+  process.stdin,
+  'isTTY'
+);
 
 function setStdinTTY(value: boolean | undefined): void {
   Object.defineProperty(process.stdin, 'isTTY', {
@@ -73,6 +76,14 @@ function setStdinTTY(value: boolean | undefined): void {
     configurable: true,
     writable: true,
   });
+}
+
+function restoreStdinTTY(): void {
+  if (originalIsTTYDescriptor) {
+    Object.defineProperty(process.stdin, 'isTTY', originalIsTTYDescriptor);
+  } else {
+    delete (process.stdin as { isTTY?: boolean }).isTTY;
+  }
 }
 
 beforeEach(() => {
@@ -87,7 +98,7 @@ beforeEach(() => {
 afterEach(() => {
   console.log = originalConsole.log;
   console.error = originalConsole.error;
-  setStdinTTY(originalIsTTY);
+  restoreStdinTTY();
 });
 
 describe('prompts', () => {

--- a/create-bestax/src/__tests__/prompts.test.ts
+++ b/create-bestax/src/__tests__/prompts.test.ts
@@ -65,19 +65,70 @@ const {
 
 // Mock console methods
 const originalConsole = { ...console };
+const originalIsTTY = process.stdin.isTTY;
+
+function setStdinTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
 
 beforeEach(() => {
   console.log = jest.fn();
   console.error = jest.fn();
+  // Prompts are only reachable on an interactive terminal (#192); jest's
+  // stdin is not a TTY, so simulate one for the interactive tests.
+  setStdinTTY(true);
   jest.clearAllMocks();
 });
 
 afterEach(() => {
   console.log = originalConsole.log;
   console.error = originalConsole.error;
+  setStdinTTY(originalIsTTY);
 });
 
 describe('prompts', () => {
+  describe('non-interactive guard (#192)', () => {
+    const promptFns: Array<[string, () => Promise<unknown>]> = [
+      ['promptProjectName', () => promptProjectName()],
+      ['promptOverwriteDirectory', () => promptOverwriteDirectory('project')],
+      ['promptInstallSkills', () => promptInstallSkills()],
+      ['promptTemplate', () => promptTemplate()],
+      ['promptIconLibrary', () => promptIconLibrary()],
+      ['promptBulmaFlavor', () => promptBulmaFlavor()],
+    ];
+
+    it.each(promptFns)(
+      '%s exits with code 1 and guidance when stdin is not a TTY',
+      async (_name, fn) => {
+        setStdinTTY(undefined);
+        const originalExit = process.exit;
+        const exitMock = jest.fn((code?: number | string | null) => {
+          throw new Error(`process.exit(${code})`);
+        });
+        process.exit = exitMock as unknown as typeof process.exit;
+
+        try {
+          await expect(fn()).rejects.toThrow('process.exit(1)');
+          expect(exitMock).toHaveBeenCalledWith(1);
+          expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('No interactive terminal detected')
+          );
+          expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('-t vite-ts -b complete -i none -y')
+          );
+          // The underlying prompt must never start (it would hang forever).
+          expect(prompts).not.toHaveBeenCalled();
+        } finally {
+          process.exit = originalExit;
+        }
+      }
+    );
+  });
+
   describe('promptProjectName', () => {
     it('should prompt for project name', async () => {
       (prompts as jest.MockedFunction<typeof prompts>).mockResolvedValue({

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -21,6 +21,11 @@ export const MESSAGES = {
   PROJECT_NAME_INVALID_CHARS:
     'Project name can only contain letters, numbers, dots, dashes and underscores',
   OPERATION_CANCELLED: '✖ Operation cancelled',
+  NO_TTY:
+    'No interactive terminal detected — cannot prompt for input.\n' +
+    'Re-run non-interactively with a project name and flags, e.g.:\n' +
+    '  npm create bestax@latest my-app -- -t vite-ts -b complete -i none -y\n' +
+    'Run with --help to see all options.',
   DIRECTORY_NOT_EMPTY: (dir: string) =>
     `Directory ${chalk.yellow(dir)} is not empty. Remove existing files and continue?`,
   EMPTYING_DIRECTORY: (dir: string) => `\n  Emptying ${dir}...`,

--- a/create-bestax/src/prompts.ts
+++ b/create-bestax/src/prompts.ts
@@ -8,8 +8,22 @@ import {
   BULMA_FLAVORS,
 } from './constants.js';
 import { validateProjectName } from './validators.js';
+import { displayError } from './display.js';
+
+/**
+ * Guard against hanging forever in non-interactive environments (CI, agents,
+ * piped stdin): every interactive question must fail fast with actionable
+ * guidance when stdin is not a TTY (#192).
+ */
+function ensureInteractive(): void {
+  if (!process.stdin.isTTY) {
+    displayError(MESSAGES.NO_TTY);
+    process.exit(1);
+  }
+}
 
 export async function promptProjectName(): Promise<string | null> {
+  ensureInteractive();
   const response = await prompts({
     type: 'text',
     name: 'projectName',
@@ -24,6 +38,7 @@ export async function promptProjectName(): Promise<string | null> {
 export async function promptOverwriteDirectory(
   targetDir: string
 ): Promise<boolean> {
+  ensureInteractive();
   const response = await prompts({
     type: 'confirm',
     name: 'overwrite',
@@ -35,6 +50,7 @@ export async function promptOverwriteDirectory(
 }
 
 export async function promptInstallSkills(): Promise<boolean> {
+  ensureInteractive();
   const response = await prompts({
     type: 'confirm',
     name: 'skills',
@@ -46,6 +62,7 @@ export async function promptInstallSkills(): Promise<boolean> {
 }
 
 export async function promptTemplate(): Promise<string | null> {
+  ensureInteractive();
   const response = await prompts({
     type: 'select',
     name: 'template',
@@ -60,6 +77,7 @@ export async function promptTemplate(): Promise<string | null> {
 }
 
 export async function promptIconLibrary(): Promise<string | null> {
+  ensureInteractive();
   const response = await prompts({
     type: 'select',
     name: 'iconLibrary',
@@ -75,6 +93,7 @@ export async function promptIconLibrary(): Promise<string | null> {
 }
 
 export async function promptBulmaFlavor(): Promise<string | null> {
+  ensureInteractive();
   const response = await prompts({
     type: 'select',
     name: 'bulmaFlavor',


### PR DESCRIPTION
# Pull Request

## Description

Fixes the non-interactive (no-TTY) behavior of the scaffolder reported in #192.

**Before (verified against `main` @ b02eccc, built `dist/index.js` run outside the workspace):**

- `node dist/index.js app2 < /dev/null` (EOF stdin, missing options) → rendered the framework select prompt, then **exited 0 in ~0.12s without creating anything** — the dangling `prompts` promise let the event loop drain, so CI would see a false success.
- `tail -f /dev/null | node dist/index.js app4` (open non-TTY stdin — the realistic CI/agent case) → **hung until killed** (`timeout 15` → exit 124), exactly the symptom in the issue.

**After:** every interactive prompt (`src/prompts.ts`) is preceded by an `ensureInteractive()` guard: when `process.stdin.isTTY` is falsy, it prints actionable guidance and exits 1:

```
✖ No interactive terminal detected — cannot prompt for input.
Re-run non-interactively with a project name and flags, e.g.:
  npm create bestax@latest my-app -- -t vite-ts -b complete -i none -y
Run with --help to see all options.
```

Placing the guard inside each prompt function (rather than predicting prompt-need up front) structurally guarantees the CLAUDE.md promise — no current or future prompt call site (including the directory-overwrite confirm) can ever hang without a TTY.

**Verified after the fix** (all wrapped in `timeout`, run outside the workspace):

| Scenario | stdin | Exit | Time |
|---|---|---|---|
| `app1 -t vite-ts --bulma complete --icon none -y` | `< /dev/null` | 0, project created | 0.13s |
| `app2` (no flags) | `< /dev/null` | 1 + guidance | 0.11s |
| `app3 -t vite-ts` (partial flags) | `< /dev/null` | 1 + guidance | 0.11s |
| `app4` (no flags) | open pipe (`tail -f /dev/null \|`) | 1 + guidance | 1.0s |
| no project name at all | open pipe | 1 + guidance | 1.0s |

**About the issue's other symptom (the red `npm error config prefix cannot be changed from project config` line):** create-bestax spawns no npm/npx processes at all (verified: no `child_process` usage in `src/`, ever, per `git log -S`). The line is printed by the user's **outer** `npx create-bestax@latest` wrapper — npm emits it for *any* command run where a project-level `.npmrc` sets `prefix=` (reproduced with plain `npm config get registry`), before create-bestax's code executes. Running the built `dist/index.js` directly in that same environment produces zero npm error lines. There is nothing this package can suppress; it is upstream npm behavior in the user's environment.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Closes #192

## Type of Change

- [x] Bug fix

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works (6 new guard tests in `prompts.test.ts` — all 6 fail on `main`, pass with the fix; existing suites updated to simulate a TTY since jest's stdin is not one)
- [ ] I have added/updated documentation as needed (no public API change; `create-bestax/CLAUDE.md` already documents the no-TTY invariant for #192)
- [ ] I have updated Storybook stories as needed (bulma-ui) — n/a
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed (187/187; coverage 97.96% stmts / 88.17% branches / 100% funcs / 97.89% lines — above the 95/78 thresholds)
- [ ] Any relevant dependencies are updated — none
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated — no changes needed

## Screenshots / Demos

```
$ tail -f /dev/null | node create-bestax/dist/index.js app4   # previously hung forever
✖ No interactive terminal detected — cannot prompt for input.
Re-run non-interactively with a project name and flags, e.g.:
  npm create bestax@latest my-app -- -t vite-ts -b complete -i none -y
Run with --help to see all options.
$ echo $?
1
```

## Additional Context

`pnpm --filter create-bestax run typecheck`, `lint`, `test:coverage`, `pnpm check:conformance`, and `prettier --check` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fast-fail guard for non-interactive environments with a clear error message and exit code `1`.
  * Ensured all interactive setup prompts behave consistently (no hanging when terminal input isn’t available).
  * Added guidance on how to rerun with non-interactive options.
* **Tests**
  * Added test coverage to verify prompts exit early in non-interactive mode.
  * Improved test isolation by saving and restoring terminal (TTY) behavior between test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->