### PR TITLE
ci: exempt triage+ collaborators from the ai-triage daily budget

### DIFF
--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -15,8 +15,10 @@ name: AI Triage
 #   label | opt-in only — the label is the sole trigger (today's behavior)
 #   off   | everything dead, label included
 #
-# BUDGET (auto runs only; label runs are exempt — already human-metered by
-# the click): a repo-wide daily counter kept as ONE marker comment on
+# BUDGET (auto runs by outside authors only; label runs are exempt — already
+# human-metered by the click — and so are items opened by collaborators with
+# triage+ access, verified live: trusted authors always get triage, the cap
+# only meters strangers): a repo-wide daily counter kept as ONE marker comment on
 # tracking issue #290 (`<!-- ai-triage-budget date=YYYY-MM-DD count=N -->`),
 # edited in place. Same fail-closed pattern as claude-pr-loop.yml's
 # iteration cap: the probe is author-filtered to github-actions[bot] so
@@ -114,8 +116,10 @@ jobs:
       #             template-applied label can never trigger a session.
       #             Budget is BYPASSED — each run is human-metered.
       #   opened  → skip bot authors, AI-loop PRs (claude/* heads or bodies
-      #             that already link an issue), then charge the daily
-      #             budget BEFORE any Claude spend.
+      #             that already link an issue); then triage+ collaborators
+      #             bypass the budget (same live role check as labeled runs),
+      #             and everyone else charges the daily budget BEFORE any
+      #             Claude spend.
       # All later steps gate on `run`.
       - name: Gate (permissions / budget)
         id: gate
@@ -173,6 +177,20 @@ jobs:
             fi
           fi
 
+          # ---- Collaborator bypass: items OPENED by triage+ collaborators
+          #      always get triage — the budget only meters outside authors.
+          #      Same live role check as the labeled path (the opened
+          #      event's sender IS the author), so a stale association or
+          #      revoked collaborator can never bypass the cap. ----
+          ROLE=$(gh api "repos/$REPO/collaborators/$SENDER/permission" \
+            --jq '.role_name' || echo none)
+          case "$ROLE" in
+            admin|maintain|write|triage)
+              out run true
+              echo "$SENDER has $ROLE access — running triage (budget exempt)"
+              exit 0 ;;
+          esac
+
           # ---- Daily budget (single marker comment on the tracking issue,
           #      edited in place). Author-filtered probe over ALL comment
           #      pages (--paginate applies --jq per page, so a second
@@ -210,7 +228,7 @@ jobs:
           # ---- Charge the budget BEFORE Claude runs (crashes still count) ----
           NEXT=$((COUNT + 1))
           BODY="<!-- ai-triage-budget date=$TODAY count=$NEXT -->
-          **AI triage budget**: $NEXT/$LIMIT auto-triggered session(s) on $TODAY (UTC). Label-triggered runs are exempt.
+          **AI triage budget**: $NEXT/$LIMIT auto-triggered session(s) on $TODAY (UTC). Label-triggered runs and triage+ collaborators' items are exempt.
           _Managed by ai-triage.yml — never reformat the first line; a new UTC day resets the count._"
           if [ -n "$COMMENT_ID" ]; then
             gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$BODY" >/dev/null

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,9 @@ variable `AI_LOOP_ENABLED=false` (whole system). The `<!-- ai-loop-state … -->
 is machine-managed — never reformat its first line. The loop refuses PRs that touch
 `.github/**` or the jest/commitlint/release/pnpm-workspace configs.
 Separately, `ai-triage` runs a one-shot sonnet triage session that comments with related
-issues/duplicates: automatic on new issues/PRs when `AI_TRIAGE_MODE=auto` (capped at
-`AI_TRIAGE_DAILY_LIMIT`/day via a counter comment on issue #290), or on demand via the label
+issues/duplicates: automatic on new issues/PRs when `AI_TRIAGE_MODE=auto` (outside authors
+capped at `AI_TRIAGE_DAILY_LIMIT`/day via a counter comment on issue #290; items opened by
+triage+ collaborators are uncapped), or on demand via the label
 (triage+ only, budget-exempt; auto-removed after the run). Flagged duplicates may be
 auto-closed after 14 days per `AI_TRIAGE_AUTOCLOSE` (see the ai-development docs guide).
 Stale automation: PRs go `stale` at 30 days and close 14 days later — except Claude-assisted

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -68,7 +68,9 @@ issues a PR probably resolves, and overlapping PRs. Three repository variables c
   works), `label` (opt-in only; the default when unset), or `off` (disables both automatic
   triage **and** the label).
 - **`AI_TRIAGE_DAILY_LIMIT`** — maximum auto-triggered triage sessions per UTC day (default
-  10). Label-triggered runs are exempt — each one is already human-metered by the click.
+  10). The cap only meters outside authors: label-triggered runs are exempt (each one is
+  already human-metered by the click), and so are issues/PRs opened by collaborators with
+  triage access or higher (their role is verified live against the repository).
 - **`AI_TRIAGE_AUTOCLOSE`** — `on`, `dry-run`, or `off` (the default). When active, an issue
   whose triage comment names a `Duplicate of #N` is auto-closed after **14 days** — unless
   anyone objects: a human comment after the triage comment, a 👎 reaction on it, or reopening


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #292: issues and PRs **opened by collaborators with triage access or higher always get auto-triage** — the `AI_TRIAGE_DAILY_LIMIT` budget now only meters outside authors.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`) — ai-development guide
- [x] Other: repo tooling (`.github/workflows/ai-triage.yml`, root `CLAUDE.md`)

**How:** in the gate step's `opened` path, after the existing skips (bot authors, `claude/*` heads, PRs already carrying `Fixes #`/`Closes #` — these still apply to everyone, since triage would be redundant regardless of author), the sender's live role is checked via `repos/{repo}/collaborators/{sender}/permission` — the exact same check the `labeled` path already performs. `admin|maintain|write|triage` ⇒ run triage without touching the budget counter; anyone else charges the daily budget as before.

**Security notes:**

- The check is live against the repository, not `author_association` from the event payload — a revoked collaborator or a gameable "has one merged commit" association can never bypass the cap.
- For `opened` events the sender **is** the author, so this can't be confused with a third party's action.
- API failure on the permission lookup falls through to `none` ⇒ the budget path — fail-closed, same idiom as the labeled gate.

## Related Issue(s)

Follow-up to #289 / #292.

## Type of Change

- [x] Build tooling
- [x] Documentation

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (ai-development guide + root CLAUDE.md)
- [x] All new and existing tests passed (no package code changed; YAML parsed, gate script `bash -n` clean, prettier clean)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Additional Context

The budget marker comment's human-readable line now reads "Label-triggered runs and triage+ collaborators' items are exempt." No repo-variable changes needed — this works with the values already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Triage requests created by collaborators with sufficient permissions are now exempt from the daily auto-triage limit.
  * Label-triggered triage runs remain exempt from the daily cap.

* **Documentation**
  * Updated AI triage guidance to clarify daily limits and exemption rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->