### PR TITLE
fix(bulma-ui): retry failed Avatar src, flatten Fragment children in Avatars, RTL-safe overlap

### DIFF
--- a/bulma-ui/src/components/Avatar.tsx
+++ b/bulma-ui/src/components/Avatar.tsx
@@ -160,9 +160,10 @@ export const Avatar: React.FC<AvatarProps> = ({
 }) => {
   // Tracks the src that failed to load. A src change clears the latch during
   // render (React's "reset state when props change" pattern) so a previously
-  // failed src is retried when switched back to; keeping the failed *string*
-  // (not a boolean) additionally guards against a stale onError from an
-  // already-replaced image re-latching the new src.
+  // failed src is retried when switched back to. The img is additionally
+  // keyed by src so a swap discards the old DOM node — a late error event
+  // from the previous request can't fire on a retained node and latch the
+  // replacement src as failed.
   const [erroredSrc, setErroredSrc] = useState<string | undefined>(undefined);
   const [prevSrc, setPrevSrc] = useState(src);
   if (src !== prevSrc) {
@@ -242,6 +243,7 @@ export const Avatar: React.FC<AvatarProps> = ({
     >
       {showImage && (
         <img
+          key={src}
           {...imageProps}
           ref={imgRef}
           src={src}

--- a/bulma-ui/src/components/Avatar.tsx
+++ b/bulma-ui/src/components/Avatar.tsx
@@ -158,9 +158,17 @@ export const Avatar: React.FC<AvatarProps> = ({
   style,
   ...props
 }) => {
-  // Tracks the src that failed to load (rather than a plain boolean) so a
-  // new src is shown again without needing an effect to reset the flag.
+  // Tracks the src that failed to load. A src change clears the latch during
+  // render (React's "reset state when props change" pattern) so a previously
+  // failed src is retried when switched back to; keeping the failed *string*
+  // (not a boolean) additionally guards against a stale onError from an
+  // already-replaced image re-latching the new src.
   const [erroredSrc, setErroredSrc] = useState<string | undefined>(undefined);
+  const [prevSrc, setPrevSrc] = useState(src);
+  if (src !== prevSrc) {
+    setPrevSrc(src);
+    setErroredSrc(undefined);
+  }
   const imgRef = useRef<HTMLImageElement>(null);
 
   const { bulmaHelperClasses, rest } = useBulmaClasses(props);

--- a/bulma-ui/src/components/Avatars.stories.tsx
+++ b/bulma-ui/src/components/Avatars.stories.tsx
@@ -149,6 +149,22 @@ export const NumericSpacing: Story = {
   },
 };
 
+export const Rtl: Story = {
+  render: function RtlExample() {
+    // The overlap uses margin-inline-start, so under dir="rtl" the stack
+    // overlaps toward the reading direction instead of spreading apart.
+    return (
+      <div dir="rtl">
+        <Avatars max={3} size="48x48">
+          {members.map(m => (
+            <Avatar key={m.id} name={m.name} />
+          ))}
+        </Avatars>
+      </div>
+    );
+  },
+};
+
 export const Spaced: Story = {
   render: function SpacedExample() {
     return (

--- a/bulma-ui/src/components/Avatars.tsx
+++ b/bulma-ui/src/components/Avatars.tsx
@@ -31,6 +31,32 @@ export interface AvatarsProps
 }
 
 /**
+ * Flattens Fragment children (recursively) into a flat element array so they
+ * participate in max clamping and size/shape injection. Children.toArray keys
+ * restart at ".0" inside each fragment, so fragment children are re-keyed by
+ * prefixing the fragment's own key — otherwise a fragment sibling of a direct
+ * child would collide (both ".0") and trigger duplicate-key warnings.
+ */
+function flattenChildren(
+  children: React.ReactNode,
+  keyPrefix = ''
+): React.ReactElement<AvatarProps>[] {
+  return React.Children.toArray(children).flatMap(child => {
+    if (!React.isValidElement(child)) return [];
+    if (child.type === React.Fragment) {
+      return flattenChildren(
+        (child.props as { children?: React.ReactNode }).children,
+        keyPrefix + child.key
+      );
+    }
+    const el = child as React.ReactElement<AvatarProps>;
+    return [
+      keyPrefix ? React.cloneElement(el, { key: keyPrefix + el.key }) : el,
+    ];
+  });
+}
+
+/**
  * Avatars component for rendering an overlapping/stacked group of `Avatar`s.
  *
  * Clamps to `max`, rendering the overflow as a single "+N" surplus avatar. Mirrors the
@@ -78,9 +104,7 @@ export const Avatars: React.FC<AvatarsProps> & { Avatar: typeof Avatar } = ({
     className
   );
 
-  const childArray = React.Children.toArray(children).filter(
-    React.isValidElement
-  ) as React.ReactElement<AvatarProps>[];
+  const childArray = flattenChildren(children);
 
   const maxCount =
     typeof max === 'number' && Number.isInteger(max) && max >= 0

--- a/bulma-ui/src/components/__tests__/Avatar.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatar.test.tsx
@@ -43,6 +43,29 @@ describe('Avatar', () => {
     );
   });
 
+  it('retries a previously failed src after switching away and back', () => {
+    const { rerender } = render(
+      <Avatar src="/broken.jpg" name="Ada Lovelace" />
+    );
+    const img = screen.getByRole('img', { hidden: true }) as HTMLImageElement;
+    fireEvent.error(img);
+    expect(screen.getByText('AL')).toBeInTheDocument();
+
+    rerender(<Avatar src="/fixed.jpg" name="Ada Lovelace" />);
+    expect(screen.getByRole('img', { name: 'Ada Lovelace' })).toHaveAttribute(
+      'src',
+      '/fixed.jpg'
+    );
+
+    // Switching back to the once-failed src must remount the img and retry it,
+    // not permanently latch onto the old failure.
+    rerender(<Avatar src="/broken.jpg" name="Ada Lovelace" />);
+    expect(screen.getByRole('img', { name: 'Ada Lovelace' })).toHaveAttribute(
+      'src',
+      '/broken.jpg'
+    );
+  });
+
   it('derives initials from a single-word name', () => {
     render(<Avatar name="Cher" />);
     expect(screen.getByText('CH')).toBeInTheDocument();

--- a/bulma-ui/src/components/__tests__/Avatar.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatar.test.tsx
@@ -66,6 +66,17 @@ describe('Avatar', () => {
     );
   });
 
+  it('remounts the img node when src changes', () => {
+    const { rerender } = render(<Avatar src="/a.jpg" name="Ada Lovelace" />);
+    const first = screen.getByRole('img', { name: 'Ada Lovelace' });
+    rerender(<Avatar src="/b.jpg" name="Ada Lovelace" />);
+    const second = screen.getByRole('img', { name: 'Ada Lovelace' });
+    expect(second).toHaveAttribute('src', '/b.jpg');
+    // A fresh DOM node (via key={src}) means a late error event from the old
+    // request cannot fire on a retained node and latch the new src as failed.
+    expect(second).not.toBe(first);
+  });
+
   it('derives initials from a single-word name', () => {
     render(<Avatar name="Cher" />);
     expect(screen.getByText('CH')).toBeInTheDocument();

--- a/bulma-ui/src/components/__tests__/Avatars.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatars.test.tsx
@@ -289,20 +289,23 @@ describe('Avatars', () => {
     const consoleError = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-    render(
-      <Avatars>
-        <Avatar name="Ada Lovelace" />
-        <>
-          <Avatar name="Grace Hopper" />
-          <Avatar name="Katherine Johnson" />
-        </>
-      </Avatars>
-    );
-    expect(screen.getByText('AL')).toBeInTheDocument();
-    expect(screen.getByText('GH')).toBeInTheDocument();
-    expect(screen.getByText('KJ')).toBeInTheDocument();
-    expect(consoleError).not.toHaveBeenCalled();
-    consoleError.mockRestore();
+    try {
+      render(
+        <Avatars>
+          <Avatar name="Ada Lovelace" />
+          <>
+            <Avatar name="Grace Hopper" />
+            <Avatar name="Katherine Johnson" />
+          </>
+        </Avatars>
+      );
+      expect(screen.getByText('AL')).toBeInTheDocument();
+      expect(screen.getByText('GH')).toBeInTheDocument();
+      expect(screen.getByText('KJ')).toBeInTheDocument();
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('applies the classPrefix from ConfigProvider', () => {

--- a/bulma-ui/src/components/__tests__/Avatars.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatars.test.tsx
@@ -232,6 +232,77 @@ describe('Avatars', () => {
       </Avatars>
     );
     expect(screen.getByText('AL')).toBeInTheDocument();
+    expect(screen.queryByText('text node')).not.toBeInTheDocument();
+  });
+
+  it('counts fragment-wrapped children toward max clamping', () => {
+    render(
+      <Avatars max={2}>
+        <Avatar name="Ada Lovelace" />
+        <>
+          <Avatar name="Grace Hopper" />
+          <Avatar name="Katherine Johnson" />
+          <Avatar name="Margaret Hamilton" />
+        </>
+      </Avatars>
+    );
+    expect(screen.getByText('AL')).toBeInTheDocument();
+    expect(screen.getByText('GH')).toBeInTheDocument();
+    expect(screen.queryByText('KJ')).not.toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('injects the group size and shape into fragment-wrapped children', () => {
+    render(
+      <Avatars size="64x64" shape="square">
+        <>
+          <Avatar name="Ada Lovelace" data-testid="wrapped" />
+        </>
+      </Avatars>
+    );
+    const wrapped = screen.getByTestId('wrapped');
+    expect(wrapped).toHaveClass('is-64x64');
+    expect(wrapped).toHaveClass('is-square');
+  });
+
+  it('flattens nested fragments and ignores non-elements inside them', () => {
+    render(
+      <Avatars max={2}>
+        <>
+          <Avatar name="Ada Lovelace" />
+          {'stray text'}
+          <>
+            <Avatar name="Grace Hopper" />
+            <Avatar name="Katherine Johnson" />
+            <Avatar name="Margaret Hamilton" />
+          </>
+        </>
+      </Avatars>
+    );
+    expect(screen.getByText('AL')).toBeInTheDocument();
+    expect(screen.getByText('GH')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.queryByText('stray text')).not.toBeInTheDocument();
+  });
+
+  it('renders mixed direct and fragment children without duplicate-key warnings', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    render(
+      <Avatars>
+        <Avatar name="Ada Lovelace" />
+        <>
+          <Avatar name="Grace Hopper" />
+          <Avatar name="Katherine Johnson" />
+        </>
+      </Avatars>
+    );
+    expect(screen.getByText('AL')).toBeInTheDocument();
+    expect(screen.getByText('GH')).toBeInTheDocument();
+    expect(screen.getByText('KJ')).toBeInTheDocument();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it('applies the classPrefix from ConfigProvider', () => {

--- a/bulma-ui/src/scss/components/_avatars.scss
+++ b/bulma-ui/src/scss/components/_avatars.scss
@@ -46,7 +46,9 @@ $avatars-spacing-lg: 1rem !default;
       cv.getVar('avatars-ring-color');
 
     &:not(:first-child) {
-      margin-left: calc(-1 * #{cv.getVar('avatars-spacing')});
+      // Logical property so the stack overlaps toward the reading direction
+      // (a physical margin-left pulls avatars apart under dir="rtl").
+      margin-inline-start: calc(-1 * #{cv.getVar('avatars-spacing')});
     }
   }
 
@@ -59,7 +61,7 @@ $avatars-spacing-lg: 1rem !default;
       box-shadow: none;
 
       &:not(:first-child) {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
     }
   }


### PR DESCRIPTION
# Pull Request

## Description

Fixes the three Avatar/Avatars behavior defects reported in #265 (regressions from #257), each with a test that failed before the fix and passes after:

1. **Avatar: failed `src` never retried** — the `erroredSrc` latch was only ever set, so cycling `src` a→b→a left the once-failed URL permanently skipped. The latch is now cleared during render when `src` changes (React's "reset state when props change" pattern); the failed-string comparison is kept as a guard against a stale `onError` from an already-replaced image.
2. **Avatars: Fragment children broke `max` and prop injection** — `React.Children.toArray` doesn't descend into Fragments, so a fragment-wrapped list counted as one child (no clamp, no "+N" surplus, `size`/`shape` injected onto the Fragment and dropped). A recursive `flattenChildren` helper now flattens fragments before filtering, re-keying fragment children with the fragment's own key to avoid duplicate-key collisions with direct siblings.
3. **Avatars: RTL overlap broken** — the overlap used physical `margin-left`, which pulled avatars apart under `dir="rtl"`. Both the negative overlap margin and its `.is-spaced` reset now use logical `margin-inline-start`; a permanent `Rtl` story demonstrates the right-to-left stack. Verified geometrically in Storybook with Playwright: each subsequent avatar overlaps 12px toward the left under RTL, LTR unchanged.

Drive-by from the issue: the "ignores non-element children" test now asserts the text node is actually dropped.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Fixes #265

Related to #257

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed (no API/prop change — docs prop tables untouched; `pnpm gen:catalog` produced no diff)
- [x] I have updated Storybook stories as needed (bulma-ui) — added `Rtl` story
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed (3,449 tests; coverage ≥99% all metrics)
- [x] Any relevant dependencies are updated (none needed)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (none affected)

## Screenshots / Demos

The new `Rtl` story after the fix — avatars overlap toward the reading direction under `dir="rtl"` instead of spreading apart:

Bounding boxes measured via Playwright (DOM order, RTL): each avatar sits 36px further left with a 12px overlap (`md` spacing): `[{left:536},{left:500},{left:464},{left:428}]`.

## Additional Context

Each fix landed as its own scoped commit; new tests were run against the unfixed code first to confirm they fail for the right reasons. Full `pnpm all` gate is green (build, typecheck, test+coverage, bundle stats, lint, format check, Storybook build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jp8AuUdsCAqCYqD3ipzcJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014Jp8AuUdsCAqCYqD3ipzcJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar images now properly retry after a previously failed source when you switch away and back.
  * Avatar groups now correctly clamp `max` and apply sizing/shape when avatars are wrapped in nested fragments.
* **Enhancements**
  * Added right-to-left Storybook coverage for overlapping avatar groups.
* **Bug Fixes (RTL styling)**
  * Avatar overlap spacing now renders correctly in right-to-left layouts using logical margin properties.
* **Tests**
  * Expanded unit coverage for fragment handling and avatar image remount/error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->