### PR TITLE
fix(bulma-ui): Avatar/Avatars/Badge a11y batch — decorative alt, nameless links, live region, button type, surplus i18n, focus ring

### DIFF
--- a/bulma-ui/src/components/Avatar.tsx
+++ b/bulma-ui/src/components/Avatar.tsx
@@ -219,7 +219,14 @@ export const Avatar: React.FC<AvatarProps> = ({
   const initialsClass = usePrefixedClassNames('avatar-initials');
 
   const Tag: React.ElementType = as ?? (href ? 'a' : 'figure');
-  const isInteractive = Tag === 'a' || Tag === 'button';
+  // A custom `as` component given an href is being used as a link — the same
+  // condition under which isLinkLike forwards href/target/rel below — so it
+  // counts as interactive too. Otherwise alt="" would mark a real link
+  // decorative (aria-hidden) and it could render nameless.
+  const isInteractive =
+    Tag === 'a' ||
+    Tag === 'button' ||
+    (typeof Tag !== 'string' && href != null);
 
   // Only forward link attributes when rendering an anchor or a custom (non-DOM)
   // component; a plain `as="div"` must not receive a stray `href`/`target`/`rel`.

--- a/bulma-ui/src/components/Avatar.tsx
+++ b/bulma-ui/src/components/Avatar.tsx
@@ -91,7 +91,7 @@ function DefaultAvatarIcon() {
  *
  * @property {string} [className] - Additional CSS classes to apply.
  * @property {string} [src] - Image URL. On load error (or if absent), falls back to initials, then icon.
- * @property {string} [alt] - Alternate text for the image (required for meaningful images).
+ * @property {string} [alt] - Alternate text for the image (required for meaningful images). An explicit `alt=""` marks a non-interactive avatar as decorative (skipped by screen readers).
  * @property {string} [name] - Derives initials and a deterministic background color when no `src`/`initials` is shown.
  * @property {string} [initials] - Explicit initials override (else derived from `name`).
  * @property {React.ReactNode} [icon] - Final fallback rendered when there is no `src`, `name`, or `initials`.
@@ -226,17 +226,35 @@ export const Avatar: React.FC<AvatarProps> = ({
   const isLinkLike = Tag === 'a' || typeof Tag !== 'string';
   const linkProps = isLinkLike ? { href, target, rel } : {};
 
+  // alt coalesces with ?? (not ||) so an explicit alt="" survives as the
+  // standard decorative marker instead of being overridden by name.
+  const accessibleName = alt ?? name;
+  // The decorative opt-out never applies to an interactive avatar — a link or
+  // button must always expose an accessible name.
+  const isDecorative = alt === '' && !isInteractive;
+
   const a11yProps = showImage
-    ? {}
-    : {
-        ...(isInteractive ? {} : { role: 'img' as const }),
-        'aria-label': alt || name || 'Avatar',
-      };
+    ? isInteractive && !accessibleName
+      ? // The img alt normally names the control; with no alt/name (an API
+        // returning only a photo URL) the link/button would be nameless.
+        { 'aria-label': name || 'Avatar' }
+      : {}
+    : isDecorative
+      ? { 'aria-hidden': true as const }
+      : {
+          ...(isInteractive ? {} : { role: 'img' as const }),
+          'aria-label': accessibleName || name || 'Avatar',
+        };
+
+  // A clickable avatar inside a form must not submit it; default the native
+  // button type (an explicit type passed through rest still wins).
+  const buttonTypeProps = Tag === 'button' ? { type: 'button' as const } : {};
 
   return (
     <Tag
       className={combinedClasses}
       style={{ ...sizeStyle, ...style }}
+      {...buttonTypeProps}
       {...linkProps}
       {...a11yProps}
       {...rest}
@@ -247,7 +265,7 @@ export const Avatar: React.FC<AvatarProps> = ({
           {...imageProps}
           ref={imgRef}
           src={src}
-          alt={alt || name || ''}
+          alt={accessibleName ?? ''}
           onError={e => {
             imageProps?.onError?.(e);
             setErroredSrc(src);

--- a/bulma-ui/src/components/Avatars.stories.tsx
+++ b/bulma-ui/src/components/Avatars.stories.tsx
@@ -58,6 +58,11 @@ const meta: Meta<typeof Avatars> = {
       description:
         'Lay the avatars out side by side (non-overlapping) with `spacing` as the gap. Default `false`.',
     },
+    surplusLabel: {
+      control: false,
+      description:
+        "Builds the surplus avatar's accessible name from the hidden count, for localization. Default: `` `${count} more` ``.",
+    },
   },
 };
 export default meta;
@@ -79,6 +84,20 @@ export const WithSurplus: Story = {
   render: function WithSurplusExample() {
     return (
       <Avatars max={3} size="48x48">
+        {members.map(m => (
+          <Avatar key={m.id} name={m.name} />
+        ))}
+      </Avatars>
+    );
+  },
+};
+
+export const LocalizedSurplus: Story = {
+  render: function LocalizedSurplusExample() {
+    // surplusLabel localizes the surplus bubble's accessible name ("+2" stays
+    // the visible text; screen readers hear "2 weitere").
+    return (
+      <Avatars max={3} surplusLabel={count => `${count} weitere`}>
         {members.map(m => (
           <Avatar key={m.id} name={m.name} />
         ))}

--- a/bulma-ui/src/components/Avatars.tsx
+++ b/bulma-ui/src/components/Avatars.tsx
@@ -139,7 +139,10 @@ export const Avatars: React.FC<AvatarsProps> & { Avatar: typeof Avatar } = ({
         <Avatar
           initials={`+${overflowCount}`}
           alt={
-            surplusLabel ? surplusLabel(overflowCount) : `${overflowCount} more`
+            // `||` (not a plain ternary): an empty string from surplusLabel
+            // would make the bubble decorative (alt="") and hide the count
+            // from assistive tech — fall back to the default label instead.
+            surplusLabel?.(overflowCount) || `${overflowCount} more`
           }
           size={size}
           shape={shape}

--- a/bulma-ui/src/components/Avatars.tsx
+++ b/bulma-ui/src/components/Avatars.tsx
@@ -15,6 +15,7 @@ export type AvatarsSpacing = 'sm' | 'md' | 'lg';
  * @property {AvatarProps['shape']} [shape] - Uniform shape applied to every child `Avatar` (and the surplus avatar).
  * @property {AvatarsSpacing | number} [spacing] - Space between avatars: a `'sm'`/`'md'`/`'lg'` preset or a pixel `number`. Default `'md'`.
  * @property {boolean} [spaced] - Lay the avatars out side by side (non-overlapping) with `spacing` as the gap. Default `false`.
+ * @property {(count: number) => string} [surplusLabel] - Builds the surplus avatar's accessible name from the hidden count, for localization. Default: `` `${count} more` ``.
  * @property {React.ReactNode} [children] - `Avatar` elements to render inside the group.
  */
 export interface AvatarsProps
@@ -27,6 +28,7 @@ export interface AvatarsProps
   shape?: AvatarProps['shape'];
   spacing?: AvatarsSpacing | number;
   spaced?: boolean;
+  surplusLabel?: (count: number) => string;
   children?: React.ReactNode;
 }
 
@@ -78,6 +80,7 @@ export const Avatars: React.FC<AvatarsProps> & { Avatar: typeof Avatar } = ({
   shape,
   spacing = 'md',
   spaced = false,
+  surplusLabel,
   style,
   children,
   ...props
@@ -135,7 +138,9 @@ export const Avatars: React.FC<AvatarsProps> & { Avatar: typeof Avatar } = ({
       {overflowCount > 0 && (
         <Avatar
           initials={`+${overflowCount}`}
-          alt={`${overflowCount} more`}
+          alt={
+            surplusLabel ? surplusLabel(overflowCount) : `${overflowCount} more`
+          }
           size={size}
           shape={shape}
           className={surplusClass}

--- a/bulma-ui/src/components/Badge.tsx
+++ b/bulma-ui/src/components/Badge.tsx
@@ -64,8 +64,10 @@ export interface BadgeProps
  * Badge component for a small status/count indicator overlaid on the corner of another
  * element (or rendered standalone).
  *
- * Renders `{max}+` when a numeric `content` exceeds `max`, hides at `0` unless `showZero`,
- * and no-ops its `pulse` animation under `prefers-reduced-motion: reduce`.
+ * Renders `{max}+` when a numeric `content` exceeds `max` and no-ops its `pulse` animation
+ * under `prefers-reduced-motion: reduce`. At `0` without `showZero` the pill is visually
+ * hidden but stays mounted, so its `role="status"` live region announces a later `0 -> 1`
+ * change.
  *
  * @function
  * @param {BadgeProps} props - Props for the Badge component.
@@ -106,7 +108,12 @@ export const Badge: React.FC<BadgeProps> = ({
     content !== true &&
     content !== '' &&
     (!isZero || showZero);
-  const shouldRender = dot || hasContent || invisible;
+  // A hidden zero keeps the pill mounted (visually hidden via .is-zero) so the
+  // role="status" live region exists before a 0 -> 1 change — mutating text in
+  // an existing region is reliably announced, inserting an already-populated
+  // region is not.
+  const zeroPlaceholder = isZero && !showZero && !dot && !invisible;
+  const shouldRender = dot || hasContent || invisible || zeroPlaceholder;
 
   // A negative or non-integer max is nonsensical; fall back to the default
   // rather than render e.g. "-1+" (mirrors Avatars' max sanitization).
@@ -140,6 +147,7 @@ export const Badge: React.FC<BadgeProps> = ({
     'is-dot': dot,
     'is-pulse': pulse,
     'is-invisible': invisible,
+    'is-zero': zeroPlaceholder,
   });
 
   // badgeClassName is a plain (unprefixed) slot merged onto the pill, mirroring

--- a/bulma-ui/src/components/__tests__/Avatar.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatar.test.tsx
@@ -115,6 +115,31 @@ describe('Avatar', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps a custom link-like avatar interactive when alt is explicitly empty', () => {
+    const CustomLink: React.FC<{
+      href?: string;
+      children?: React.ReactNode;
+    }> = ({ href, children, ...rest }) => (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+    render(
+      <Avatar
+        as={CustomLink}
+        href="https://example.com"
+        alt=""
+        name="Ada Lovelace"
+      />
+    );
+    // A custom `as` component with href is a link (the same condition that
+    // forwards href to it) — the decorative opt-out must not aria-hide it,
+    // and it keeps an accessible name.
+    expect(
+      screen.getByRole('link', { name: 'Ada Lovelace' })
+    ).toBeInTheDocument();
+  });
+
   it('names an interactive non-image avatar from name when alt is explicitly empty', () => {
     render(<Avatar alt="" name="Ada Lovelace" as="button" />);
     expect(

--- a/bulma-ui/src/components/__tests__/Avatar.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatar.test.tsx
@@ -77,6 +77,56 @@ describe('Avatar', () => {
     expect(second).not.toBe(first);
   });
 
+  it('respects an explicit empty alt as decorative on the image', () => {
+    const { container } = render(
+      <Avatar src="/photo.jpg" alt="" name="Ada Lovelace" />
+    );
+    // alt="" must not be overridden by name — the img stays decorative.
+    expect(container.querySelector('img')).toHaveAttribute('alt', '');
+  });
+
+  it('hides a decorative non-image avatar from screen readers', () => {
+    render(<Avatar alt="" name="Ada Lovelace" data-testid="avatar" />);
+    const avatar = screen.getByTestId('avatar');
+    expect(avatar).toHaveAttribute('aria-hidden', 'true');
+    expect(avatar).not.toHaveAttribute('role');
+    expect(avatar).not.toHaveAttribute('aria-label');
+    // Still visible to sighted users.
+    expect(screen.getByText('AL')).toBeInTheDocument();
+  });
+
+  it('gives a nameless interactive image avatar an aria-label fallback', () => {
+    render(<Avatar src="/photo.jpg" href="https://example.com" />);
+    expect(screen.getByRole('link', { name: 'Avatar' })).toBeInTheDocument();
+  });
+
+  it('names an interactive image avatar from name when alt is explicitly empty', () => {
+    render(
+      <Avatar
+        src="/photo.jpg"
+        alt=""
+        name="Ada Lovelace"
+        href="https://example.com"
+      />
+    );
+    // A link must have a name, so the decorative opt-out yields to name.
+    expect(
+      screen.getByRole('link', { name: 'Ada Lovelace' })
+    ).toBeInTheDocument();
+  });
+
+  it('names an interactive non-image avatar from name when alt is explicitly empty', () => {
+    render(<Avatar alt="" name="Ada Lovelace" as="button" />);
+    expect(
+      screen.getByRole('button', { name: 'Ada Lovelace' })
+    ).toBeInTheDocument();
+  });
+
+  it('defaults an as="button" avatar to type="button"', () => {
+    render(<Avatar name="Ada Lovelace" as="button" />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
   it('derives initials from a single-word name', () => {
     render(<Avatar name="Cher" />);
     expect(screen.getByText('CH')).toBeInTheDocument();

--- a/bulma-ui/src/components/__tests__/Avatars.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatars.test.tsx
@@ -70,6 +70,20 @@ describe('Avatars', () => {
     expect(screen.getByText('+2')).toBeInTheDocument();
   });
 
+  it('falls back to the default surplus name when surplusLabel returns an empty string', () => {
+    render(
+      <Avatars max={2} surplusLabel={() => ''}>
+        <Avatar name="Ada Lovelace" />
+        <Avatar name="Grace Hopper" />
+        <Avatar name="Katherine Johnson" />
+        <Avatar name="Margaret Hamilton" />
+      </Avatars>
+    );
+    // An empty label would make the bubble decorative (alt="") and hide the
+    // count from assistive tech — the default name must win instead.
+    expect(screen.getByRole('img', { name: '2 more' })).toBeInTheDocument();
+  });
+
   it('gives the surplus avatar an accessible name of "{N} more"', () => {
     render(
       <Avatars max={2}>

--- a/bulma-ui/src/components/__tests__/Avatars.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatars.test.tsx
@@ -56,6 +56,20 @@ describe('Avatars', () => {
     expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
   });
 
+  it('builds the surplus accessible name with surplusLabel for localization', () => {
+    render(
+      <Avatars max={2} surplusLabel={count => `${count} weitere`}>
+        <Avatar name="Ada Lovelace" />
+        <Avatar name="Grace Hopper" />
+        <Avatar name="Katherine Johnson" />
+        <Avatar name="Margaret Hamilton" />
+      </Avatars>
+    );
+    expect(screen.getByRole('img', { name: '2 weitere' })).toBeInTheDocument();
+    // The visible bubble text stays numeric regardless of the label.
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
   it('gives the surplus avatar an accessible name of "{N} more"', () => {
     render(
       <Avatars max={2}>

--- a/bulma-ui/src/components/__tests__/Badge.test.tsx
+++ b/bulma-ui/src/components/__tests__/Badge.test.tsx
@@ -55,13 +55,43 @@ describe('Badge', () => {
     expect(container.querySelectorAll('.badge')).toHaveLength(0);
   });
 
-  it('hides at content=0 by default', () => {
+  it('visually hides at content=0 by default but keeps the live region mounted', () => {
     const { container } = render(
       <Badge content={0}>
         <span>child</span>
       </Badge>
     );
-    expect(container.querySelectorAll('.badge')).toHaveLength(0);
+    const pill = container.querySelector('.badge');
+    // The pill stays in the DOM as an empty role="status" node (sr-only via
+    // is-zero) so a later 0 -> 1 change is announced.
+    expect(pill).toHaveClass('is-zero');
+    expect(pill).toHaveAttribute('role', 'status');
+    expect(pill).toHaveTextContent('');
+  });
+
+  it('keeps the same live region node across a 0 -> 1 transition', () => {
+    const { container, rerender } = render(
+      <Badge content={0}>
+        <span>child</span>
+      </Badge>
+    );
+    const region = container.querySelector('.badge');
+    rerender(
+      <Badge content={1}>
+        <span>child</span>
+      </Badge>
+    );
+    const after = container.querySelector('.badge');
+    expect(after).toBe(region);
+    expect(after).not.toHaveClass('is-zero');
+    expect(after).toHaveTextContent('1');
+  });
+
+  it('renders a standalone zero badge as a hidden live region', () => {
+    const { container } = render(<Badge content={0} />);
+    const pill = container.querySelector('.badge');
+    expect(pill).toHaveClass('is-zero');
+    expect(pill).toHaveAttribute('role', 'status');
   });
 
   it('shows at content=0 when showZero is set', () => {

--- a/bulma-ui/src/scss/components/_avatars.scss
+++ b/bulma-ui/src/scss/components/_avatars.scss
@@ -50,6 +50,13 @@ $avatars-spacing-lg: 1rem !default;
       // (a physical margin-left pulls avatars apart under dir="rtl").
       margin-inline-start: calc(-1 * #{cv.getVar('avatars-spacing')});
     }
+
+    // The next avatar in the stack covers part of this one's focus outline;
+    // lift the focused avatar so its ring paints above both neighbours.
+    &:focus-visible {
+      position: relative;
+      z-index: 1;
+    }
   }
 
   // Non-overlapping: a positive gap of the same spacing var instead of a

--- a/bulma-ui/src/scss/components/_badge.scss
+++ b/bulma-ui/src/scss/components/_badge.scss
@@ -1,6 +1,7 @@
 // Badge component styles — a small status/count indicator overlaid on a corner
 @use 'bulma/sass/utilities/initial-variables' as iv;
 @use 'bulma/sass/utilities/css-variables' as cv;
+@use '../mixins' as *;
 
 // Badge-specific SCSS variables
 $badge-height: 1.25em !default;
@@ -103,6 +104,15 @@ $badge-animation-duration: 1.4s !default;
   display: inline-flex;
   transform: none;
   pointer-events: auto;
+}
+
+// Hidden-zero placeholder: the empty pill stays in the DOM (and the
+// accessibility tree) so the role="status" live region already exists when the
+// count changes from 0 — sr-only, not display/visibility, which would drop it
+// from the accessibility tree. Placed after is-standalone so the sr-only
+// positioning wins for standalone zero badges too.
+.#{iv.$class-prefix}badge.#{iv.$class-prefix}is-zero {
+  @include extras-sr-only;
 }
 
 // Overlap adjustment — nudge the badge further in on a round child so it

--- a/docs/docs/api/components/avatar.md
+++ b/docs/docs/api/components/avatar.md
@@ -24,23 +24,23 @@ import { Avatar } from '@allxsmith/bestax-bulma';
 
 ## Props
 
-| Prop         | Type                                                                                                             | Default    | Description                                                                                                                          |
-| ------------ | ---------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `src`        | `string`                                                                                                         | —          | Image URL. On load error (or if absent), falls back to initials, then `icon`.                                                        |
-| `alt`        | `string`                                                                                                         | —          | Alternate text for the image (used for the accessible name in every render mode).                                                    |
-| `name`       | `string`                                                                                                         | —          | Derives initials and a deterministic background color when no `src` is shown.                                                        |
-| `initials`   | `string`                                                                                                         | —          | Explicit initials override (else derived from `name`).                                                                               |
-| `icon`       | `React.ReactNode`                                                                                                | —          | Final fallback, rendered when there is no `src`, `name`, or `initials`.                                                              |
-| `size`       | `'16x16' \| '24x24' \| '32x32' \| '48x48' \| '64x64' \| '96x96' \| '128x128' \| number`                          | —          | Preset size, or a pixel size when a number.                                                                                          |
-| `shape`      | `'circle' \| 'rounded' \| 'square'`                                                                              | `'circle'` | Avatar shape.                                                                                                                        |
-| `color`      | `'primary' \| 'link' \| 'info' \| 'success' \| 'warning' \| 'danger' \| 'black' \| 'dark' \| 'light' \| 'white'` | —          | Background color for initials/icon avatars (else auto-derived from `name`).                                                          |
-| `as`         | `React.ElementType`                                                                                              | —          | Element/component to render as. Defaults to `'a'` when `href` is set, else `'figure'`.                                               |
-| `href`       | `string`                                                                                                         | —          | When set, renders the avatar as a link.                                                                                              |
-| `target`     | `string`                                                                                                         | —          | Anchor target — forwarded only when rendering a link (an `a` or a custom `as` component).                                            |
-| `rel`        | `string`                                                                                                         | —          | Anchor rel — forwarded only when rendering a link (an `a` or a custom `as` component).                                               |
-| `imageProps` | `React.ImgHTMLAttributes<HTMLImageElement>`                                                                      | —          | Extra props forwarded to the underlying `<img>` (e.g. `loading`, `crossOrigin`); its `onError` is chained before the fallback fires. |
-| `className`  | `string`                                                                                                         | —          | Additional CSS classes.                                                                                                              |
-| ...          | All standard HTML and Bulma helper props                                                                         |            | (See [Helper Props](../helpers/usebulmaclasses))                                                                                     |
+| Prop         | Type                                                                                                             | Default    | Description                                                                                                                                          |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src`        | `string`                                                                                                         | —          | Image URL. On load error (or if absent), falls back to initials, then `icon`.                                                                        |
+| `alt`        | `string`                                                                                                         | —          | Alternate text for the image (used for the accessible name in every render mode). An explicit `alt=""` marks a non-interactive avatar as decorative. |
+| `name`       | `string`                                                                                                         | —          | Derives initials and a deterministic background color when no `src` is shown.                                                                        |
+| `initials`   | `string`                                                                                                         | —          | Explicit initials override (else derived from `name`).                                                                                               |
+| `icon`       | `React.ReactNode`                                                                                                | —          | Final fallback, rendered when there is no `src`, `name`, or `initials`.                                                                              |
+| `size`       | `'16x16' \| '24x24' \| '32x32' \| '48x48' \| '64x64' \| '96x96' \| '128x128' \| number`                          | —          | Preset size, or a pixel size when a number.                                                                                                          |
+| `shape`      | `'circle' \| 'rounded' \| 'square'`                                                                              | `'circle'` | Avatar shape.                                                                                                                                        |
+| `color`      | `'primary' \| 'link' \| 'info' \| 'success' \| 'warning' \| 'danger' \| 'black' \| 'dark' \| 'light' \| 'white'` | —          | Background color for initials/icon avatars (else auto-derived from `name`).                                                                          |
+| `as`         | `React.ElementType`                                                                                              | —          | Element/component to render as. Defaults to `'a'` when `href` is set, else `'figure'`.                                                               |
+| `href`       | `string`                                                                                                         | —          | When set, renders the avatar as a link.                                                                                                              |
+| `target`     | `string`                                                                                                         | —          | Anchor target — forwarded only when rendering a link (an `a` or a custom `as` component).                                                            |
+| `rel`        | `string`                                                                                                         | —          | Anchor rel — forwarded only when rendering a link (an `a` or a custom `as` component).                                                               |
+| `imageProps` | `React.ImgHTMLAttributes<HTMLImageElement>`                                                                      | —          | Extra props forwarded to the underlying `<img>` (e.g. `loading`, `crossOrigin`); its `onError` is chained before the fallback fires.                 |
+| `className`  | `string`                                                                                                         | —          | Additional CSS classes.                                                                                                                              |
+| ...          | All standard HTML and Bulma helper props                                                                         |            | (See [Helper Props](../helpers/usebulmaclasses))                                                                                                     |
 
 ---
 
@@ -139,6 +139,15 @@ automatic initials/icon fallback runs.
 - Initials/icon avatars expose `role="img"` and `aria-label` (from `alt`/`name`) — unless
   rendered as a link or button, where the native link/button role and `aria-label` are used
   instead.
+- **Decorative avatars:** pass an explicit `alt=""` when the avatar repeats information
+  already visible next to it (e.g. beside the author's name in a comment row). The image
+  stays decorative and an initials/icon avatar is skipped entirely (`aria-hidden`), avoiding
+  double-speak. The opt-out never applies to a link/button avatar — an interactive element
+  always keeps an accessible name (from `name`, or a generic `"Avatar"` fallback).
+- A link/button avatar with no `alt`/`name` (e.g. an API that returns only a photo URL) still
+  gets an `aria-label` fallback rather than rendering a nameless control.
+- `as="button"` defaults to `type="button"`, so a clickable avatar inside a form doesn't
+  submit it.
 - The default fallback icon is `aria-hidden`.
 
 ---

--- a/docs/docs/api/components/avatars.md
+++ b/docs/docs/api/components/avatars.md
@@ -25,16 +25,17 @@ import { Avatars, Avatar } from '@allxsmith/bestax-bulma';
 
 ## Props
 
-| Prop        | Type                                     | Default | Description                                                                                                                                                        |
-| ----------- | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `max`       | `number`                                 | —       | Show only the first `max` children, replacing the overflow with a "+N" surplus avatar. A single overflow avatar is shown directly rather than as a pointless "+1". |
-| `size`      | `AvatarProps['size']`                    | —       | Uniform size applied to every child `Avatar` (and the surplus avatar).                                                                                             |
-| `shape`     | `'circle' \| 'rounded' \| 'square'`      | —       | Uniform shape applied to every child `Avatar` (and the surplus avatar); a child's own `shape` wins when this is unset.                                             |
-| `spacing`   | `'sm' \| 'md' \| 'lg' \| number`         | `'md'`  | Space between avatars: a preset or a pixel `number`. The overlap distance, or the gap when `spaced`.                                                               |
-| `spaced`    | `boolean`                                | `false` | Lay the avatars out side by side (non-overlapping), using `spacing` as the gap.                                                                                    |
-| `className` | `string`                                 | —       | Additional CSS classes.                                                                                                                                            |
-| `children`  | `React.ReactNode`                        | —       | `Avatar` elements to render inside the group.                                                                                                                      |
-| ...         | All standard HTML and Bulma helper props |         | (See [Helper Props](../helpers/usebulmaclasses))                                                                                                                   |
+| Prop           | Type                                     | Default | Description                                                                                                                                                        |
+| -------------- | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `max`          | `number`                                 | —       | Show only the first `max` children, replacing the overflow with a "+N" surplus avatar. A single overflow avatar is shown directly rather than as a pointless "+1". |
+| `size`         | `AvatarProps['size']`                    | —       | Uniform size applied to every child `Avatar` (and the surplus avatar).                                                                                             |
+| `shape`        | `'circle' \| 'rounded' \| 'square'`      | —       | Uniform shape applied to every child `Avatar` (and the surplus avatar); a child's own `shape` wins when this is unset.                                             |
+| `spacing`      | `'sm' \| 'md' \| 'lg' \| number`         | `'md'`  | Space between avatars: a preset or a pixel `number`. The overlap distance, or the gap when `spaced`.                                                               |
+| `spaced`       | `boolean`                                | `false` | Lay the avatars out side by side (non-overlapping), using `spacing` as the gap.                                                                                    |
+| `surplusLabel` | `(count: number) => string`              | —       | Builds the surplus avatar's accessible name from the hidden count, for localization. Default: `` `${count} more` ``.                                               |
+| `className`    | `string`                                 | —       | Additional CSS classes.                                                                                                                                            |
+| `children`     | `React.ReactNode`                        | —       | `Avatar` elements to render inside the group.                                                                                                                      |
+| ...            | All standard HTML and Bulma helper props |         | (See [Helper Props](../helpers/usebulmaclasses))                                                                                                                   |
 
 `Avatar` is also attached as a compound static (`Avatars.Avatar`), so you can import just the
 container.
@@ -61,6 +62,21 @@ Set `max` to cap the visible avatars; the remainder collapse into a single `+N` 
 
 ```tsx live
 <Avatars max={3} size="48x48">
+  <Avatar name="Ada Lovelace" />
+  <Avatar name="Grace Hopper" />
+  <Avatar name="Katherine Johnson" />
+  <Avatar name="Margaret Hamilton" />
+  <Avatar name="Radia Perlman" />
+</Avatars>
+```
+
+### Localized Surplus Label
+
+The surplus bubble always shows `+N`, but its accessible name defaults to English
+(`"{N} more"`). Pass `surplusLabel` to localize what screen readers announce.
+
+```tsx live
+<Avatars max={3} surplusLabel={count => `${count} weitere`}>
   <Avatar name="Ada Lovelace" />
   <Avatar name="Grace Hopper" />
   <Avatar name="Katherine Johnson" />
@@ -144,7 +160,10 @@ A `number` sets a pixel overlap directly:
 - `Avatars` is a plain container — each child `Avatar` carries its own accessible name (see
   [Avatar's accessibility notes](./avatar.md#accessibility)).
 - The `+N` surplus avatar gets an accessible name of `"{N} more"` (via its `alt`), so assistive
-  tech announces how many members are hidden.
+  tech announces how many members are hidden. Localize it with `surplusLabel`, e.g.
+  ``surplusLabel={count => `${count} weitere`}``.
+- A focused clickable avatar is lifted above its overlapping neighbours so its focus outline
+  is never partially covered.
 - When the group represents a labelled set (e.g. "Project members"), give the container a
   `role="group"` and an `aria-label` describing it.
 

--- a/docs/docs/api/components/badge.md
+++ b/docs/docs/api/components/badge.md
@@ -254,6 +254,9 @@ A plain-text `children` value renders at its natural height alongside the badge.
 ## Accessibility
 
 - A count/text badge exposes `role="status"` and an `aria-label` announcing its content.
+- At `content={0}` without `showZero`, the pill is visually hidden but stays mounted as an
+  empty `role="status"` node, so a later `0 -> 1` change mutates an existing live region and
+  is reliably announced (a live region inserted already populated often isn't).
 - A bare number in a `role="status"` span is not enough context on its own — put the full
   meaning on the anchor itself, e.g. `<Icon ariaLabel="Inbox, 4 unread messages" />` rather than
   relying on the badge to read out just "4".


### PR DESCRIPTION
# Pull Request

## Description

Implements the accessibility batch from #266 for Avatar/Avatars/Badge (follow-ups to #257, sequenced after the #265 fixes in #297):

1. **Decorative avatars possible** — `alt` now coalesces with `??` instead of `||`, so an explicit `alt=""` survives: the img stays unnamed, and a non-interactive initials/icon avatar is skipped entirely (`aria-hidden`) instead of double-speaking next to visible text.
2. **No more nameless links/buttons** — an interactive image-mode avatar with no `alt`/`name` gets an `aria-label` fallback; with an explicit `alt=""`, `name` still names the control (an interactive element always keeps an accessible name — the decorative opt-out never applies there).
3. **Badge live region reliability** — at `content={0}` without `showZero`, the `role="status"` pill now stays mounted, visually hidden via a new sr-only `is-zero` class, so a `0 → 1` change mutates an existing live region (reliably announced) instead of inserting an already-populated one (often not announced). A test asserts the DOM node survives the transition.
4. **`as="button"` defaults to `type="button"`** — a clickable avatar inside a form no longer submits it.
5. **`surplusLabel` prop (new API, `feat` commit)** — `surplusLabel?: (count: number) => string` localizes the surplus avatar's accessible name (default stays `` `${count} more` ``); the visible bubble text stays `+N`. Story, docs, and tests included.
6. **Focus ring never covered** — a focused avatar inside the overlapping stack is lifted (`position: relative; z-index: 1` on `:focus-visible`) so the next avatar can't obscure its outline. Verified present in the compiled `extras.css`.
7. **Theming-skill correction (item 7)** — already fixed upstream in #268: `css-variables.md` now correctly documents that the `--bulma-avatar-*`/`--bulma-badge-*` vars are registered on component selectors and shows working override patterns. No change needed; noted for completeness.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Fixes #266

Related to #257, #297

## Type of Change

- [x] Bug fix
- [x] New feature (the `surplusLabel` prop, in its own `feat(bulma-ui)` commit for a correct minor bump)
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works (9 new tests, one updated)
- [x] I have added/updated documentation as needed (Accessibility sections on avatar.md/avatars.md/badge.md; `surplusLabel` prop table row + usage example)
- [x] I have updated Storybook stories as needed (bulma-ui) — `LocalizedSurplus` story + `surplusLabel` argType
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed (3,459 tests; Avatar/Avatars/Badge at 100% all metrics, suite ≥99%)
- [x] Any relevant dependencies are updated (none needed)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (none affected)

## Screenshots / Demos

Not visual — behavior is covered by RTL role/name assertions (decorative `aria-hidden`, link names, `role="status"` node identity across `0 → 1`, `type="button"`, localized surplus name). The focus-ring rule was verified in the compiled CSS: `.avatars .avatar:focus-visible{position:relative;z-index:1}`.

## Additional Context

`pnpm gen:catalog` produced no diff (component one-liners unchanged). Full `pnpm all` gate green; the 7 eslint warnings are pre-existing in unrelated form components (Autocomplete/Slider/Taginput).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jp8AuUdsCAqCYqD3ipzcJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014Jp8AuUdsCAqCYqD3ipzcJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `surplusLabel` prop to localize the surplus (“+N”) avatar’s accessible name.

* **Accessibility Improvements**
  * Refined Avatar accessibility for `alt=""` decorative avatars and improved accessible naming for interactive link/button avatars (including `as="button"` defaulting to `type="button"`).
  * Updated badge announcements so `content={0}` keeps a live region mounted for reliable `0 -> 1` updates.
  * Improved keyboard focus visibility in overlapping avatar stacks.

* **Documentation**
  * Updated Avatar, Avatars, and Badge docs to reflect the new accessibility and labeling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->