### PR TITLE
test(bulma-ui): add central classPrefix sweep across every component export

### DIFF
--- a/bulma-ui/src/__tests__/prefix-sweep.test.tsx
+++ b/bulma-ui/src/__tests__/prefix-sweep.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Central classPrefix sweep: renders every public component export under
+ * `<ConfigProvider classPrefix="bestax-">` and asserts no emitted class escapes
+ * unprefixed. Each component also carries its own hand-written prefix test, but
+ * that pattern relies on remembering to write it — this sweep is a backstop that
+ * catches a forgotten `usePrefixedClassNames` call anywhere, current or future,
+ * without relying on a per-component test author to think of it.
+ *
+ * PROPS supplies the minimal props/children a component needs either to satisfy
+ * a required prop or to reach a code path that renders its own literal class
+ * (e.g. a conditional child). Components not listed render with no props at all —
+ * still a valid (if shallow) check of whatever they emit by default.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import * as Library from '../index';
+import { ConfigProvider } from '../helpers/Config';
+
+const PREFIX = 'bestax-';
+
+// Vendor icon-library classes are deliberately never routed through the
+// runtime class prefix: they come from an external CSS framework (Font
+// Awesome, Material Design Icons, Google Material Icons/Symbols) selected via
+// the `library`/`iconLibrary` prop, not from Bulma, and have no
+// bestax-prefixed equivalent to switch to.
+const ICON_LIBRARY_CLASS =
+  /^(fas|far|fab|fal|fad|fat|fa-[a-z0-9-]+|mdi|mdi-[a-z0-9-]+|material-icons(-(outlined|round|sharp))?|material-symbols-(outlined|rounded|sharp))$/;
+
+type AnyComponent = React.ComponentType<Record<string, unknown>>;
+
+function isComponentExport(value: unknown): value is AnyComponent {
+  if (typeof value === 'function') return true;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '$$typeof' in (value as Record<string, unknown>)
+  );
+}
+
+const PROPS: Record<string, Record<string, unknown>> = {
+  Icon: { name: 'star' },
+  IconText: { children: 'Text', iconProps: { name: 'star' } },
+  Avatar: { name: 'Ada Lovelace' },
+  Badge: { children: '9' },
+  Steps: { items: [{ label: 'Step 1' }], hasNavigation: true },
+  Carousel: {
+    children: [
+      <Library.CarouselItem key="a">Slide A</Library.CarouselItem>,
+      <Library.CarouselItem key="b">Slide B</Library.CarouselItem>,
+    ],
+  },
+  Rate: { value: 2.5, showScore: true, text: 'Good' },
+  Checkbox: { children: 'Accept' },
+  Radio: { children: 'Choose' },
+  Switch: { children: 'Enable' },
+  Loading: { active: true, canCancel: true, children: 'Loading…' },
+  Toast: {
+    message: 'Saved',
+    inline: true,
+    indefinite: true,
+    closable: true,
+    actionText: 'Undo',
+  },
+  Taginput: { value: ['tag-one'] },
+  Modal: { active: true, children: 'Modal content' },
+  Dialog: { isOpen: true, message: 'Are you sure?' },
+  Tabs: {
+    children: [
+      <Library.Tabs.Tab key="a" label="A">
+        A
+      </Library.Tabs.Tab>,
+      <Library.Tabs.Tab key="b" label="B">
+        B
+      </Library.Tabs.Tab>,
+    ],
+  },
+  Dropdown: { label: 'Menu', children: 'Item', active: true },
+  Sidebar: { isOpen: true, children: 'Sidebar content' },
+  Pagination: { current: 1, total: 5 },
+  Breadcrumb: { items: [{ label: 'Home', href: '#' }] },
+  Message: { children: 'Hello' },
+  Notification: { children: 'Hello' },
+  Slider: {
+    marks: [{ value: 50, label: '50' }],
+    tooltip: 'always',
+  },
+};
+
+describe('classPrefix sweep', () => {
+  const entries = Object.entries(Library as Record<string, unknown>)
+    .filter(([name]) => /^[A-Z]/.test(name))
+    .filter((entry): entry is [string, AnyComponent] =>
+      isComponentExport(entry[1])
+    )
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  // Sanity check the enumeration itself isn't accidentally empty (e.g. a
+  // broken barrel import), which would make every test below vacuously pass.
+  it('found a substantial number of component exports to sweep', () => {
+    expect(entries.length).toBeGreaterThan(50);
+  });
+
+  it.each(entries)('%s renders no unprefixed classes', (name, Component) => {
+    const props = PROPS[name] ?? {};
+
+    const { baseElement } = render(
+      <ConfigProvider classPrefix={PREFIX}>
+        <Component {...props} />
+      </ConfigProvider>
+    );
+
+    const offenders: string[] = [];
+    baseElement.querySelectorAll('[class]').forEach(el => {
+      (el.getAttribute('class') ?? '')
+        .split(/\s+/)
+        .filter(Boolean)
+        .forEach(cls => {
+          if (!cls.startsWith(PREFIX) && !ICON_LIBRARY_CLASS.test(cls)) {
+            offenders.push(`<${el.tagName.toLowerCase()}> "${cls}"`);
+          }
+        });
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/bulma-ui/src/components/Carousel.tsx
+++ b/bulma-ui/src/components/Carousel.tsx
@@ -8,8 +8,13 @@ import React, {
   isValidElement,
   cloneElement,
 } from 'react';
-import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import {
+  classNames,
+  prefixedClassNames,
+  usePrefixedClassNames,
+} from '../helpers/classNames';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
+import { useClassPrefix } from '../helpers/Config';
 import { Icon } from '../elements/Icon';
 import { Button } from '../elements/Button';
 
@@ -33,9 +38,10 @@ export interface CarouselItemProps extends React.HTMLAttributes<HTMLDivElement> 
  */
 export const CarouselItem = forwardRef<HTMLDivElement, CarouselItemProps>(
   ({ active, className, children, ...props }, ref) => {
-    const itemClasses = classNames('carousel-item', className, {
-      'is-active': active,
-    });
+    const itemClasses = classNames(
+      usePrefixedClassNames('carousel-item', { 'is-active': active }),
+      className
+    );
 
     return (
       <div ref={ref} className={itemClasses} {...props}>
@@ -455,6 +461,23 @@ export const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
       [`is-indicator-${indicatorStyle}`]: indicatorStyle !== 'dots',
       [`is-arrow-${arrowColor}`]: !!arrowColor,
     });
+    const classPrefix = useClassPrefix();
+    const carouselContainerClass = usePrefixedClassNames('carousel-container');
+    const carouselSlidesClass = usePrefixedClassNames('carousel-slides');
+    const carouselArrowPrevClass = usePrefixedClassNames(
+      'carousel-arrow',
+      'is-prev',
+      { 'is-transparent': !arrowBackground }
+    );
+    const carouselArrowNextClass = usePrefixedClassNames(
+      'carousel-arrow',
+      'is-next',
+      { 'is-transparent': !arrowBackground }
+    );
+    const carouselIndicatorClass = usePrefixedClassNames('carousel-indicator', {
+      'is-inside': indicatorInside,
+      'is-top': indicatorPosition === 'top',
+    });
 
     const combinedClasses = classNames(
       carouselClasses,
@@ -512,7 +535,7 @@ export const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
       >
         <div
           ref={containerRef}
-          className="carousel-container"
+          className={carouselContainerClass}
           onMouseDown={hasDrag ? handleMouseDown : undefined}
           onMouseMove={hasDrag && isDragging ? handleMouseMove : undefined}
           onMouseUp={hasDrag ? handleMouseUp : undefined}
@@ -526,7 +549,7 @@ export const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
           }}
         >
           <div
-            className="carousel-slides"
+            className={carouselSlidesClass}
             style={{
               // When repeat is enabled, account for the prepended clone (+1 offset)
               transform: `translateX(-${(repeat && itemCount > 1 ? displayIndex + 1 : displayIndex) * 100}%)`,
@@ -543,9 +566,7 @@ export const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
           {arrow && itemCount > 1 && (
             <>
               <Button
-                className={classNames('carousel-arrow is-prev', {
-                  'is-transparent': !arrowBackground,
-                })}
+                className={carouselArrowPrevClass}
                 onClick={goToPrev}
                 isDisabled={!canGoPrev}
                 aria-label="Previous slide"
@@ -563,9 +584,7 @@ export const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
                 )}
               </Button>
               <Button
-                className={classNames('carousel-arrow is-next', {
-                  'is-transparent': !arrowBackground,
-                })}
+                className={carouselArrowNextClass}
                 onClick={goToNext}
                 isDisabled={!canGoNext}
                 aria-label="Next slide"
@@ -587,17 +606,11 @@ export const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
         </div>
 
         {indicator && itemCount > 1 && (
-          <div
-            className={classNames('carousel-indicator', {
-              'is-inside': indicatorInside,
-              'is-top': indicatorPosition === 'top',
-            })}
-            role="tablist"
-          >
+          <div className={carouselIndicatorClass} role="tablist">
             {items.map((_, index) => (
               <Button
                 key={index}
-                className={classNames('indicator-item', {
+                className={prefixedClassNames(classPrefix, 'indicator-item', {
                   'is-active': index === activeIndex,
                 })}
                 onClick={() => goToSlide(index)}

--- a/bulma-ui/src/components/Collapse.tsx
+++ b/bulma-ui/src/components/Collapse.tsx
@@ -179,15 +179,14 @@ export const Collapse: React.FC<CollapseProps> = ({
     className
   );
   const combinedTriggerClasses = classNames(
-    'collapse-trigger',
+    usePrefixedClassNames('collapse-trigger'),
     triggerClassName
   );
   const combinedContentClasses = classNames(
-    'collapse-content',
-    contentClassName,
-    {
+    usePrefixedClassNames('collapse-content', {
       'is-active': isOpen,
-    }
+    }),
+    contentClassName
   );
 
   // Content wrapper styles based on animation type

--- a/bulma-ui/src/components/Loading.tsx
+++ b/bulma-ui/src/components/Loading.tsx
@@ -115,10 +115,14 @@ export const Loading: React.FC<LoadingProps> = ({
     className
   );
   const combinedOverlayClasses = classNames(
-    'loading-overlay',
+    usePrefixedClassNames('loading-overlay'),
     overlayClassName
   );
   const combinedIconClasses = classNames(iconClasses, iconClassName);
+  const loadingContentClass = usePrefixedClassNames('loading-content');
+  const loadingIconCustomClass = usePrefixedClassNames('loading-icon-custom');
+  const loadingTextClass = usePrefixedClassNames('loading-text');
+  const loadingCancelClass = usePrefixedClassNames('loading-cancel');
 
   // Handle cancel click
   const handleOverlayClick = () => {
@@ -169,17 +173,17 @@ export const Loading: React.FC<LoadingProps> = ({
         onClick={handleOverlayClick}
         aria-hidden="true"
       />
-      <div className="loading-content">
+      <div className={loadingContentClass}>
         {indicator ? (
-          <span className="loading-icon-custom">{indicator}</span>
+          <span className={loadingIconCustomClass}>{indicator}</span>
         ) : (
           <span className={combinedIconClasses} />
         )}
-        {children && <div className="loading-text">{children}</div>}
+        {children && <div className={loadingTextClass}>{children}</div>}
         {canCancel && (
           <button
             type="button"
-            className="loading-cancel"
+            className={loadingCancelClass}
             onClick={onCancel}
             aria-label="Cancel loading"
           >

--- a/bulma-ui/src/components/Sidebar.tsx
+++ b/bulma-ui/src/components/Sidebar.tsx
@@ -168,7 +168,9 @@ const SidebarComponent = forwardRef<HTMLElement, SidebarProps>(
       [`is-${position}`]: position,
       'is-fullwidth': fullWidth,
     });
-    const backgroundClass = usePrefixedClassNames('sidebar-background');
+    const backgroundClass = usePrefixedClassNames('sidebar-background', {
+      'is-active': isOpen,
+    });
     const contentClass = usePrefixedClassNames('sidebar-content');
 
     const combinedClasses = classNames(
@@ -187,9 +189,7 @@ const SidebarComponent = forwardRef<HTMLElement, SidebarProps>(
       <>
         {overlay && (
           <div
-            className={classNames(backgroundClass, {
-              'is-active': isOpen,
-            })}
+            className={backgroundClass}
             onClick={handleOverlayClick}
             aria-hidden="true"
           />

--- a/bulma-ui/src/components/Steps.tsx
+++ b/bulma-ui/src/components/Steps.tsx
@@ -132,14 +132,17 @@ export const Step: React.FC<StepProps> = ({
   const { bulmaHelperClasses, rest } = useBulmaClasses(props);
 
   const stepClasses = classNames(
-    'steps-segment',
-    {
+    usePrefixedClassNames('steps-segment', {
       'is-active': isActive,
       'is-completed': isCompleted,
-    },
+    }),
     bulmaHelperClasses,
     className
   );
+  const stepsLinkClass = usePrefixedClassNames('steps-link');
+  const stepsMarkerClass = usePrefixedClassNames('steps-marker');
+  const stepsContentClass = usePrefixedClassNames('steps-content');
+  const stepsTitleClass = usePrefixedClassNames('steps-title');
 
   const handleClick = () => {
     if (clickable && onClick) {
@@ -172,11 +175,11 @@ export const Step: React.FC<StepProps> = ({
       aria-current={isActive ? 'step' : undefined}
       {...rest}
     >
-      <div className="steps-link">
-        <span className="steps-marker">{markerContent}</span>
+      <div className={stepsLinkClass}>
+        <span className={stepsMarkerClass}>{markerContent}</span>
         {(label || children) && (
-          <div className="steps-content">
-            <p className="steps-title">{label || children}</p>
+          <div className={stepsContentClass}>
+            <p className={stepsTitleClass}>{label || children}</p>
           </div>
         )}
       </div>
@@ -262,8 +265,13 @@ export const Steps: React.FC<StepsProps> & { Step: typeof Step } = ({
   );
 
   // Generate classes for the ul (list)
-  const listClasses = classNames('steps-list', {
+  const listClasses = usePrefixedClassNames('steps-list', {
     'is-vertical': vertical,
+  });
+  const stepsNavigationClass = usePrefixedClassNames('steps-navigation');
+  const prevButtonClass = usePrefixedClassNames('button');
+  const nextButtonClass = usePrefixedClassNames('button', {
+    'is-primary': true,
   });
 
   // Count total steps for navigation
@@ -315,16 +323,16 @@ export const Steps: React.FC<StepsProps> & { Step: typeof Step } = ({
     <div className={combinedClasses} {...rest}>
       <ul className={listClasses}>{renderSteps()}</ul>
       {hasNavigation && (
-        <div className="steps-navigation">
+        <div className={stepsNavigationClass}>
           <button
-            className="button"
+            className={prevButtonClass}
             disabled={value === 0}
             onClick={onPrev ?? (() => onStepClick?.(value - 1))}
           >
             {prevLabel ?? 'Previous'}
           </button>
           <button
-            className="button is-primary"
+            className={nextButtonClass}
             disabled={value === totalSteps - 1}
             onClick={onNext ?? (() => onStepClick?.(value + 1))}
           >

--- a/bulma-ui/src/components/Toast.tsx
+++ b/bulma-ui/src/components/Toast.tsx
@@ -196,6 +196,12 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
       bulmaHelperClasses,
       className
     );
+    const toastMessageClass = usePrefixedClassNames('toast-message');
+    const toastActionsClass = usePrefixedClassNames('toast-actions');
+    const toastCancelClass = usePrefixedClassNames('toast-cancel');
+    const toastActionClass = usePrefixedClassNames('toast-action');
+    const toastButtonClass = usePrefixedClassNames('button');
+    const toastCloseClass = usePrefixedClassNames('delete', 'is-small');
 
     if (!isVisible) {
       return null;
@@ -235,14 +241,14 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
         onClick={dismissible ? handleClose : undefined}
         {...rest}
       >
-        <span className="toast-message">{message}</span>
+        <span className={toastMessageClass}>{message}</span>
         {(cancelText || actionText) && (
-          <div className="toast-actions">
+          <div className={toastActionsClass}>
             {cancelText && (
-              <span className="toast-cancel">
+              <span className={toastCancelClass}>
                 <button
                   type="button"
-                  className="button"
+                  className={toastButtonClass}
                   onClick={e => {
                     e.stopPropagation();
                     handleClose();
@@ -253,10 +259,10 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
               </span>
             )}
             {actionText && (
-              <span className="toast-action">
+              <span className={toastActionClass}>
                 <button
                   type="button"
-                  className="button"
+                  className={toastButtonClass}
                   onClick={e => {
                     e.stopPropagation();
                     handleAction();
@@ -271,7 +277,7 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>(
         {closable && (
           <button
             type="button"
-            className="delete is-small"
+            className={toastCloseClass}
             onClick={e => {
               e.stopPropagation();
               handleClose();

--- a/bulma-ui/src/form/Checkbox.tsx
+++ b/bulma-ui/src/form/Checkbox.tsx
@@ -141,6 +141,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       [`is-${size}`]: size && checkboxSizes.includes(size),
     });
     const checkboxClass = classNames(mainClass, bulmaHelperClasses, className);
+    const checkClass = usePrefixedClassNames('check');
+    const controlLabelClass = usePrefixedClassNames('control-label');
 
     return (
       <label className={checkboxClass}>
@@ -155,8 +157,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           onChange={handleChange}
           {...rest}
         />
-        <span className="check" />
-        {children && <span className="control-label">{children}</span>}
+        <span className={checkClass} />
+        {children && <span className={controlLabelClass}>{children}</span>}
       </label>
     );
   }

--- a/bulma-ui/src/form/Radio.tsx
+++ b/bulma-ui/src/form/Radio.tsx
@@ -136,6 +136,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
       [`is-${size}`]: size && radioSizes.includes(size),
     });
     const radioClass = classNames(mainClass, bulmaHelperClasses, className);
+    const checkClass = usePrefixedClassNames('check');
+    const controlLabelClass = usePrefixedClassNames('control-label');
 
     return (
       <label className={radioClass}>
@@ -150,8 +152,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
           onChange={handleChange}
           {...rest}
         />
-        <span className="check" />
-        {children && <span className="control-label">{children}</span>}
+        <span className={checkClass} />
+        {children && <span className={controlLabelClass}>{children}</span>}
       </label>
     );
   }

--- a/bulma-ui/src/form/Rate.tsx
+++ b/bulma-ui/src/form/Rate.tsx
@@ -1,8 +1,12 @@
 import React, { forwardRef, useState, useCallback } from 'react';
-import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import {
+  classNames,
+  prefixedClassNames,
+  usePrefixedClassNames,
+} from '../helpers/classNames';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 import { Icon } from '../elements/Icon';
-import { useIconLibrary } from '../helpers/Config';
+import { useClassPrefix, useIconLibrary } from '../helpers/Config';
 import { useInsideField, useInsideControl } from './FormContext';
 import { Field } from './Field';
 import { Control } from './Control';
@@ -324,6 +328,7 @@ export const Rate = forwardRef<HTMLDivElement, RateProps>(
     };
 
     // Generate classes
+    const classPrefix = useClassPrefix();
     const rateClasses = usePrefixedClassNames('rate', {
       [`is-${size}`]: size,
       'is-disabled': disabled,
@@ -387,14 +392,14 @@ export const Rate = forwardRef<HTMLDivElement, RateProps>(
       if (iconName) {
         return (
           <span
-            className="rate-icon-partial"
+            className={prefixedClassNames(classPrefix, 'rate-icon-partial')}
             style={
               {
                 '--rate-fill-percent': `${fillPercent}%`,
               } as React.CSSProperties
             }
           >
-            <span className="rate-icon-bg">
+            <span className={prefixedClassNames(classPrefix, 'rate-icon-bg')}>
               <Icon
                 name={iconName}
                 library={resolvedLibrary}
@@ -402,7 +407,7 @@ export const Rate = forwardRef<HTMLDivElement, RateProps>(
                 features={iconFeatures}
               />
             </span>
-            <span className="rate-icon-fg">
+            <span className={prefixedClassNames(classPrefix, 'rate-icon-fg')}>
               <Icon
                 name={iconName}
                 library={resolvedLibrary}
@@ -469,7 +474,7 @@ export const Rate = forwardRef<HTMLDivElement, RateProps>(
         icons.push(
           <span
             key={iconIndex}
-            className={classNames('rate-item', {
+            className={prefixedClassNames(classPrefix, 'rate-item', {
               'is-active': isActive,
               'is-hovered': isHovered,
             })}
@@ -506,6 +511,11 @@ export const Rate = forwardRef<HTMLDivElement, RateProps>(
     });
     const messageEl = message ? <p className={helpClass}>{message}</p> : null;
 
+    const rateItemsClass = usePrefixedClassNames('rate-items');
+    const rateScoreClass = usePrefixedClassNames('rate-score');
+    const rateTextClass = usePrefixedClassNames('rate-text');
+    const rateCustomTextClass = usePrefixedClassNames('rate-custom-text');
+
     const rateElement = (
       <div
         ref={ref}
@@ -520,10 +530,14 @@ export const Rate = forwardRef<HTMLDivElement, RateProps>(
         onKeyDown={handleKeyDown}
         {...rest}
       >
-        <div className="rate-items">{renderIcons()}</div>
-        {showScore && <span className="rate-score">{getScoreDisplay()}</span>}
-        {text && <span className="rate-text">{text}</span>}
-        {customText && <span className="rate-custom-text">{customText}</span>}
+        <div className={rateItemsClass}>{renderIcons()}</div>
+        {showScore && (
+          <span className={rateScoreClass}>{getScoreDisplay()}</span>
+        )}
+        {text && <span className={rateTextClass}>{text}</span>}
+        {customText && (
+          <span className={rateCustomTextClass}>{customText}</span>
+        )}
         {name && (
           <input type="hidden" name={name} value={currentValue} form={form} />
         )}

--- a/bulma-ui/src/form/Slider.tsx
+++ b/bulma-ui/src/form/Slider.tsx
@@ -6,8 +6,13 @@ import React, {
   useMemo,
   useLayoutEffect,
 } from 'react';
-import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import {
+  classNames,
+  prefixedClassNames,
+  usePrefixedClassNames,
+} from '../helpers/classNames';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
+import { useClassPrefix } from '../helpers/Config';
 import { useInsideField, useInsideControl } from './FormContext';
 import { Field } from './Field';
 import { Control } from './Control';
@@ -438,6 +443,7 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
     };
 
     // Generate wrapper classes
+    const classPrefix = useClassPrefix();
     const sliderClasses = usePrefixedClassNames('slider', {
       [`is-${size}`]: size,
       [`is-${color}`]: color,
@@ -574,7 +580,7 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
     const renderTicks = () => {
       if (tickPositions.length === 0) return null;
       return (
-        <div className="slider-ticks">
+        <div className={prefixedClassNames(classPrefix, 'slider-ticks')}>
           {tickPositions.map((tick, i) => {
             const pct = ((tick.value - min) / (max - min)) * 100;
             const posStyle = isVertical
@@ -584,13 +590,20 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
             return (
               <span
                 key={i}
-                className={classNames('slider-tick', {
+                className={prefixedClassNames(classPrefix, 'slider-tick', {
                   'is-endpoint': isEndpoint,
                 })}
                 style={posStyle}
               >
                 {tick.label !== undefined && (
-                  <span className="slider-tick-label">{tick.label}</span>
+                  <span
+                    className={prefixedClassNames(
+                      classPrefix,
+                      'slider-tick-label'
+                    )}
+                  >
+                    {tick.label}
+                  </span>
                 )}
               </span>
             );
@@ -621,7 +634,7 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
           onMouseLeave={() => setShowTooltip(false)}
           onFocus={() => setShowTooltip(true)}
           onBlur={() => setShowTooltip(false)}
-          className="slider-input"
+          className={prefixedClassNames(classPrefix, 'slider-input')}
           style={
             {
               '--slider-progress': `${progressSingle}%`,
@@ -638,7 +651,7 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
         {tooltipMode !== 'hidden' && (
           <output
             ref={outputRef}
-            className={classNames('slider-output', {
+            className={prefixedClassNames(classPrefix, 'slider-output', {
               'is-visible': showTipLow,
               'is-flipped': flipped,
               'is-flipped-left': isVertical && verticalFlippedLeft,
@@ -673,7 +686,7 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
       <div ref={wrapperRef} className={combinedClasses} style={wrapperStyle}>
         {/* Visible track background */}
         <div
-          className="slider-track"
+          className={prefixedClassNames(classPrefix, 'slider-track')}
           style={
             isVertical
               ? ({
@@ -701,7 +714,11 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
           onMouseLeave={() => setShowTooltip(false)}
           onFocus={() => setShowTooltip(true)}
           onBlur={() => setShowTooltip(false)}
-          className="slider-input slider-input-low"
+          className={prefixedClassNames(
+            classPrefix,
+            'slider-input',
+            'slider-input-low'
+          )}
           aria-valuenow={currentRange[0]}
           aria-valuemin={min}
           aria-valuemax={max}
@@ -727,7 +744,11 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
           onMouseLeave={() => setShowTooltipHigh(false)}
           onFocus={() => setShowTooltipHigh(true)}
           onBlur={() => setShowTooltipHigh(false)}
-          className="slider-input slider-input-high"
+          className={prefixedClassNames(
+            classPrefix,
+            'slider-input',
+            'slider-input-high'
+          )}
           aria-valuenow={currentRange[1]}
           aria-valuemin={min}
           aria-valuemax={max}
@@ -742,11 +763,16 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
         {tooltipMode !== 'hidden' && (
           <output
             ref={outputRef}
-            className={classNames('slider-output slider-output-low', {
-              'is-visible': showTipLow,
-              'is-flipped': flipped,
-              'is-flipped-left': isVertical && verticalFlippedLeft,
-            })}
+            className={prefixedClassNames(
+              classPrefix,
+              'slider-output',
+              'slider-output-low',
+              {
+                'is-visible': showTipLow,
+                'is-flipped': flipped,
+                'is-flipped-left': isVertical && verticalFlippedLeft,
+              }
+            )}
             style={
               isVertical
                 ? ((verticalFlippedLeft
@@ -774,11 +800,16 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
         {tooltipMode !== 'hidden' && (
           <output
             ref={outputHighRef}
-            className={classNames('slider-output slider-output-high', {
-              'is-visible': showTipHigh,
-              'is-flipped': flippedHigh,
-              'is-flipped-left': isVertical && verticalFlippedLeft,
-            })}
+            className={prefixedClassNames(
+              classPrefix,
+              'slider-output',
+              'slider-output-high',
+              {
+                'is-visible': showTipHigh,
+                'is-flipped': flippedHigh,
+                'is-flipped-left': isVertical && verticalFlippedLeft,
+              }
+            )}
             style={
               isVertical
                 ? ((verticalFlippedLeft

--- a/bulma-ui/src/form/Switch.tsx
+++ b/bulma-ui/src/form/Switch.tsx
@@ -129,12 +129,14 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       bulmaHelperClasses,
       className
     );
+    const checkClass = usePrefixedClassNames('check');
+    const controlLabelClass = usePrefixedClassNames('control-label');
 
     return (
       <label className={labelClasses}>
         <input ref={ref} type="checkbox" disabled={disabled} {...rest} />
-        <span className="check" />
-        {children && <span className="control-label">{children}</span>}
+        <span className={checkClass} />
+        {children && <span className={controlLabelClass}>{children}</span>}
       </label>
     );
   }

--- a/bulma-ui/src/form/Taginput.tsx
+++ b/bulma-ui/src/form/Taginput.tsx
@@ -608,7 +608,7 @@ export const Taginput = forwardRef<HTMLInputElement, TaginputProps>(
                   {closable && !disabled && !readonly && (
                     <button
                       type="button"
-                      className="delete is-small"
+                      className={pcn('delete', 'is-small')}
                       onClick={e => {
                         e.stopPropagation();
                         removeTag(index);


### PR DESCRIPTION
## Summary

- Adds `bulma-ui/src/__tests__/prefix-sweep.test.tsx`, a single parameterized test that renders every public component export from `bulma-ui/src/index.ts` (enumerated at runtime from the barrel — nothing to keep manually in sync) inside `<ConfigProvider classPrefix="bestax-">` and asserts that no rendered `class` attribute escapes unprefixed. Vendor icon-library classes (Font Awesome / MDI / Material Icons / Material Symbols) are explicitly allowlisted since they intentionally bypass the runtime prefix.
- This backstops the existing per-component prefix tests, which rely on the component author remembering to write one — a gap #263 called out explicitly (a 99%-coverage trap the skill template had to grow one for in #268).
- Running the sweep for the first time immediately found 12 components with a forgotten `usePrefixedClassNames` call (a literal `className="foo"` string that never went through the prefix helper): `Carousel`, `Collapse`, `Loading`, `Sidebar`, `Steps`, `Toast`, `Checkbox`, `Radio`, `Rate`, `Slider`, `Switch`, `Taginput`. Fixed each by routing the class through `usePrefixedClassNames` (or the non-hook `prefixedClassNames(classPrefix, ...)` where the class is built inside a `.map()`/helper function, since a hook can't be called conditionally per loop iteration).
- The fix is a no-op in the default (unprefixed) mode — `prefixedClassNames(undefined, 'x')` still returns `'x'` — so every existing per-component test suite passes unchanged.

## Test plan

- [x] New `prefix-sweep.test.tsx` — 144 sub-tests (one per component export), all green
- [x] `pnpm --filter @allxsmith/bestax-bulma run lint` — 0 errors (7 pre-existing unrelated warnings)
- [x] `pnpm --filter @allxsmith/bestax-bulma run typecheck` — clean
- [x] `pnpm --filter @allxsmith/bestax-bulma run test:coverage` — 3610/3610 passing, coverage thresholds met
- [x] `pnpm run format:check`
- [x] `pnpm run gen:catalog:check`
- [x] `pnpm run check:conformance`
- [x] `pnpm --filter @allxsmith/bestax-bulma run build`
- [x] `pnpm --filter @allxsmith/bestax-bulma run build-storybook`

Refs #263 (Tier 2, item 4).
Fixes #286

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed class prefix handling across carousel, collapse, loading, sidebar, steps, toast, form controls, sliders, rate inputs, switches, and tag inputs.
  - Custom configured prefixes now apply consistently to component-generated CSS classes.

- **Tests**
  - Added coverage that checks exported components honor configured class prefixes while allowing supported third-party icon classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->