### PR TITLE
feat(create-bestax): bestax-icons skill — teach agents the icon system

### DIFF
--- a/bulma-ui/src/skill-examples/Icons.stories.tsx
+++ b/bulma-ui/src/skill-examples/Icons.stories.tsx
@@ -1,0 +1,98 @@
+// Skills → Examples → Icons: the bestax-icons skill's canonical example,
+// rendered live. Shows the app-root ConfigProvider, meaningful-vs-decorative
+// accessibility, sizes/variants/features, and multi-segment IconText.
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ExampleMeta } from './ExampleMeta';
+import { ConfigProvider, Icon, IconText, Box, Button, Title } from '../index';
+
+const SKILL_HREF =
+  'https://github.com/allxsmith/bestax/tree/main/skills/bestax-icons/SKILL.md';
+
+const meta: Meta = {
+  title: 'Skills/Icons',
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+};
+export default meta;
+type Story = StoryObj;
+
+function Meta_({ prompt }: { prompt: string }) {
+  return (
+    <ExampleMeta
+      skill="bestax-icons"
+      skillHref={SKILL_HREF}
+      model="Claude Fable 5"
+      date="2026-07-14"
+      prompt={prompt}
+    />
+  );
+}
+
+export const IconUsage: Story = {
+  name: 'Icon usage & accessibility',
+  render: function IconUsageExample() {
+    return (
+      <Box>
+        <Meta_ prompt="Add icons to my app: a warning indicator, a starred label, a save button, a loading spinner, and a metro-to-airport route line. Make them accessible." />
+        {/* One library for the whole app — 'fa' | 'mdi' | 'ion' |
+            'material-icons' | 'material-symbols' (Ionicons is 'ion',
+            NOT 'ionicons'). */}
+        <ConfigProvider iconLibrary="fa">
+          <Title size="5">Meaningful icons carry their own label</Title>
+          <Icon
+            name="triangle-exclamation"
+            textColor="warning"
+            ariaLabel="Warning"
+          />
+          <Icon name="circle-check" textColor="success" ariaLabel="Success" />
+
+          <Title size="5" mt="4">
+            Decorative icons hide from screen readers
+          </Title>
+          <IconText iconProps={{ name: 'star', 'aria-hidden': 'true' }}>
+            Starred
+          </IconText>
+          <Button color="primary" ml="3">
+            <Icon name="floppy-disk" aria-hidden="true" />
+            <span>Save</span>
+          </Button>
+
+          <Title size="5" mt="4">
+            Sizes, variants, features, color
+          </Title>
+          <Icon
+            name="rocket"
+            size="large"
+            features="fa-2x"
+            ariaLabel="Launch"
+          />
+          <Icon name="bell" variant="regular" ariaLabel="Notifications" />
+          <Icon name="github" variant="brands" ariaLabel="GitHub" />
+          <Icon
+            name="spinner"
+            features="fa-spin"
+            textColor="info"
+            ariaLabel="Loading"
+          />
+
+          <Title size="5" mt="4">
+            Multi-segment icon text
+          </Title>
+          <IconText
+            items={[
+              {
+                iconProps: { name: 'train', 'aria-hidden': 'true' },
+                text: 'Metro',
+              },
+              {
+                iconProps: { name: 'arrow-right', 'aria-hidden': 'true' },
+                text: 'Airport',
+              },
+            ]}
+          />
+        </ConfigProvider>
+      </Box>
+    );
+  },
+};

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -124,6 +124,7 @@ automatically when the task matches:
 - **bestax-form** — build forms with the bestax form components (no form library).
 - **bestax-theming** — colors, branding, and dark mode via the \`Theme\` component (\`colorMode\`).
 - **bestax-layout-scaffold** — scaffold full pages (app shell, landing, centered, card grid).
+- **bestax-icons** — icons via \`Icon\`/\`IconText\`: library setup, name formats, variants, a11y.
 
 Prefer the library's components and these skills over hand-written Bulma markup or custom CSS.
 

--- a/docs/docs/skills/icons.mdx
+++ b/docs/docs/skills/icons.mdx
@@ -1,0 +1,72 @@
+---
+title: Icons
+sidebar_label: Icons
+sidebar_position: 5
+---
+
+# Icons skill
+
+The [`bestax-icons`](https://github.com/allxsmith/bestax/blob/main/skills/bestax-icons/SKILL.md)
+skill teaches an agent to use icons in an app built with `@allxsmith/bestax-bulma`: the
+`Icon`/`IconText` components, the five supported icon libraries and their setup, the
+per-library name formats and variants, and decorative-vs-labeled accessibility.
+
+## Install
+
+```bash
+npx skills add https://github.com/allxsmith/bestax --skill bestax-icons
+```
+
+## What it teaches
+
+- **One library, set once** — `ConfigProvider iconLibrary` (`'fa' | 'mdi' | 'ion' |
+'material-icons' | 'material-symbols'`), so no per-`Icon` `library` prop. Including the
+  classic trap: the Ionicons value is **`'ion'`, not `'ionicons'`**.
+- **Per-library name formats** — the same glyph is `rocket` (Font Awesome),
+  `rocket-launch` (MDI), and `rocket_launch` (Material Icons/Symbols, which render the name
+  as a font-ligature text node). The wrong format is the #1 cause of blank icons.
+- **Variants and features** — Font Awesome's `solid`/`regular`/`brands`, Material Icons'
+  `round` vs Material Symbols' `rounded`, Ionicons' `outline`/`sharp` name suffixes, and
+  glyph scaling via `features` (`'fa-2x'`, `'fa-spin'`).
+- **Accessibility** — a descriptive `ariaLabel` for meaningful standalone icons;
+  `aria-hidden` for decorative icons that sit next to visible text.
+
+## Meaningful vs decorative
+
+```tsx live
+<Block>
+  <Icon name="triangle-exclamation" textColor="warning" ariaLabel="Warning" />
+  <IconText iconProps={{ name: 'star', 'aria-hidden': 'true' }}>
+    Starred
+  </IconText>
+</Block>
+```
+
+## Sizes, variants, features
+
+```tsx live
+<Block>
+  <Icon name="rocket" size="large" features="fa-2x" ariaLabel="Launch" />
+  <Icon name="bell" variant="regular" ariaLabel="Notifications" />
+  <Icon name="github" variant="brands" ariaLabel="GitHub" />
+  <Icon
+    name="spinner"
+    features="fa-spin"
+    textColor="info"
+    ariaLabel="Loading"
+  />
+</Block>
+```
+
+## Reference material the agent reads on demand
+
+- [`references/icon-libraries.md`](https://github.com/allxsmith/bestax/blob/main/skills/bestax-icons/references/icon-libraries.md)
+  — per-library setup (npm package / CDN script), full name-format and variant tables, and
+  the blank-icon troubleshooting checklist.
+- [`examples/icon-usage.tsx`](https://github.com/allxsmith/bestax/blob/main/skills/bestax-icons/examples/icon-usage.tsx)
+  — the canonical runnable example.
+
+## Related
+
+- [Icon API reference](../api/elements/icon.md) · [IconText API reference](../api/elements/icontext.md)
+- [Configuration guide](../guides/features/configuration.md) — `ConfigProvider` in depth.

--- a/docs/docs/skills/intro.md
+++ b/docs/docs/skills/intro.md
@@ -16,6 +16,7 @@ npx skills add https://github.com/allxsmith/bestax --skill bestax-custom-compone
 npx skills add https://github.com/allxsmith/bestax --skill bestax-form
 npx skills add https://github.com/allxsmith/bestax --skill bestax-theming
 npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
+npx skills add https://github.com/allxsmith/bestax --skill bestax-icons
 ```
 
 Starting a new app? `pnpm create bestax@latest` offers to **preinstall these skills** into the
@@ -32,3 +33,5 @@ Then explore each skill — what it does, how to install it, and live examples:
   `--bulma-*` variables with the `Theme` component.
 - **[Layout scaffold](./layout-scaffold)** — go from "build me a dashboard / landing page / catalog"
   to a complete responsive page using the layout archetypes.
+- **[Icons](./icons)** — use `Icon`/`IconText` with any of the five supported icon libraries:
+  per-library setup, name formats, variants, and decorative-vs-labeled accessibility.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -36,6 +36,7 @@ const sidebars = {
         'skills/form',
         'skills/theming',
         'skills/layout-scaffold',
+        'skills/icons',
       ],
     },
   ],

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,6 +15,7 @@ directory the agent reads on demand.
 | [`bestax-form`](./bestax-form/SKILL.md)                         | Building **forms** — Field/Control composition, the full input inventory, and the validate-it-yourself error pattern (there is no form library).                                           |
 | [`bestax-theming`](./bestax-theming/SKILL.md)                   | **Theming** — customize colors, branding, fonts/radius tokens, and dark mode by overriding Bulma's `--bulma-*` variables with the `Theme` component.                                       |
 | [`bestax-layout-scaffold`](./bestax-layout-scaffold/SKILL.md)   | **Layout scaffolding** — turn a high-level request (dashboard, landing page, auth page, catalog) into a complete responsive page from named layout archetypes.                             |
+| [`bestax-icons`](./bestax-icons/SKILL.md)                       | **Icons** — the `Icon`/`IconText` components and the five supported libraries (Font Awesome, MDI, Ionicons, Material Icons/Symbols): setup, name formats, variants, and accessibility.     |
 
 ## Install
 
@@ -25,6 +26,7 @@ npx skills add https://github.com/allxsmith/bestax --skill bestax-custom-compone
 npx skills add https://github.com/allxsmith/bestax --skill bestax-form
 npx skills add https://github.com/allxsmith/bestax --skill bestax-theming
 npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
+npx skills add https://github.com/allxsmith/bestax --skill bestax-icons
 ```
 
 ## Layout
@@ -64,6 +66,12 @@ skills/
       centered.tsx             # centered single column
       card-grid.tsx            # multiline columns of cards
       content-page.tsx         # hero + cards + CTA, helper props (no inline style)
+  bestax-icons/
+    SKILL.md
+    references/
+      icon-libraries.md        # per-library setup, name formats, variants, troubleshooting
+    examples/
+      icon-usage.tsx           # ConfigProvider + sizes/variants/colors + a11y patterns
 ```
 
 > `component-catalog.md` is generated from the API docs by `scripts/gen-component-catalog.mjs`

--- a/skills/bestax-icons/SKILL.md
+++ b/skills/bestax-icons/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: bestax-icons
+description: Use icons in an app built with @allxsmith/bestax-bulma — the Icon/IconText components and the five supported libraries (Font Awesome, Material Design Icons, Ionicons, Google Material Icons, Material Symbols). Use when adding an icon, choosing or configuring the app-wide icon library, fixing an icon that renders blank, pairing icons with text, or making icons accessible (decorative vs labeled).
+license: MIT
+---
+
+# Icons with @allxsmith/bestax-bulma
+
+`Icon` renders a Bulma icon container (`span.icon`) around a glyph from any of five icon
+libraries behind one normalized API. `IconText` pairs icons with text. The library ships **no
+icon fonts** — the chosen library's package (or CDN script) must be installed in the app.
+
+## Quick start
+
+```tsx
+import { ConfigProvider, Icon, IconText } from '@allxsmith/bestax-bulma';
+
+// Set the library ONCE at the app root; <Icon> then never needs `library`.
+<ConfigProvider iconLibrary="fa">
+  <App />
+</ConfigProvider>;
+
+// Inside the app:
+<Icon name="rocket" ariaLabel="Launch" />;
+<IconText iconProps={{ name: 'star', ariaLabel: 'Favorite' }}>
+  Starred
+</IconText>;
+```
+
+## The five libraries
+
+| Library                | `iconLibrary` / `library` value | Name format                  | Example `name`  |
+| ---------------------- | ------------------------------- | ---------------------------- | --------------- |
+| Font Awesome (default) | `'fa'`                          | kebab-case, no `fa-` prefix  | `rocket`        |
+| Material Design Icons  | `'mdi'`                         | kebab-case, no `mdi-` prefix | `rocket-launch` |
+| Ionicons               | `'ion'`                         | kebab-case                   | `rocket`        |
+| Google Material Icons  | `'material-icons'`              | snake_case (a text ligature) | `rocket_launch` |
+| Material Symbols       | `'material-symbols'`            | snake_case (a text ligature) | `rocket_launch` |
+
+⚠️ **The Ionicons value is `'ion'`, not `'ionicons'`.** The `npm create bestax` scaffold's
+`--icon ionicons` flag maps to `iconLibrary="ion"` — passing `'ionicons'` to `ConfigProvider`
+or `library` silently renders nothing.
+
+**The same glyph has a different name per library** (`rocket` vs `rocket-launch` vs
+`rocket_launch`). When an icon renders blank, the name format for the active library is the
+first thing to check. A redundant `fa-`/`mdi-` prefix in `name` is tolerated (stripped), but
+don't rely on it.
+
+## Styling
+
+- `size` — `'small' | 'medium' | 'large'` sizes the Bulma **container** (`is-small` ≈ 1rem,
+  `is-medium` ≈ 2rem, `is-large` ≈ 3rem box). To scale the **glyph**, use `features`
+  (Font Awesome `'fa-lg'`/`'fa-2x'`) or a Bulma text-size class (`'is-size-3'`).
+- `variant` — per-library style: Font Awesome `solid` (default) / `regular` / `brands` /
+  `light` / `duotone` / `thin`; Material Icons `filled` (default) / `outlined` / `round` /
+  `sharp`; Material Symbols `outlined` (default) / `rounded` / `sharp`; Ionicons `outline` /
+  `sharp`. MDI has no variants. Note Material **Icons** uses `round`, Material **Symbols**
+  uses `rounded`.
+- `features` — extra library classes, string or array: `'fa-spin'`, `['fa-lg', 'fa-border']`.
+- Color via the helper props: `textColor="primary"`, `textColor="danger"`, etc.
+
+## Accessibility
+
+Every `Icon` renders `aria-label` (default `"icon"`).
+
+- **Meaningful icon** (stands alone, conveys information): pass a descriptive
+  `ariaLabel="Delete item"`.
+- **Decorative icon** (next to visible text that says the same thing, e.g. inside `IconText`
+  or a labeled `Button`): hide it from screen readers with `aria-hidden`:
+  `<Icon name="check" aria-hidden="true" />` — otherwise "icon" (or a duplicate label) is
+  announced alongside the text.
+
+## References
+
+- `references/icon-libraries.md` — per-library setup (install/import/CDN), the full
+  name-format and variant tables, `features` values, and the blank-icon troubleshooting list.
+- `examples/icon-usage.tsx` — runnable example: ConfigProvider setup, sizes, variants,
+  colors, IconText, and decorative-vs-labeled patterns.

--- a/skills/bestax-icons/SKILL.md
+++ b/skills/bestax-icons/SKILL.md
@@ -22,7 +22,7 @@ import { ConfigProvider, Icon, IconText } from '@allxsmith/bestax-bulma';
 
 // Inside the app:
 <Icon name="rocket" ariaLabel="Launch" />;
-<IconText iconProps={{ name: 'star', ariaLabel: 'Favorite' }}>
+<IconText iconProps={{ name: 'star', 'aria-hidden': 'true' }}>
   Starred
 </IconText>;
 ```

--- a/skills/bestax-icons/examples/icon-usage.tsx
+++ b/skills/bestax-icons/examples/icon-usage.tsx
@@ -1,0 +1,80 @@
+// Icons with @allxsmith/bestax-bulma — the canonical patterns.
+//
+// The app must load the icon library itself (bestax ships no icon fonts):
+// here Font Awesome, via `npm install @fortawesome/fontawesome-free` and
+// `import '@fortawesome/fontawesome-free/css/all.min.css';` in main.tsx.
+// Set the library ONCE on ConfigProvider ('fa' | 'mdi' | 'ion' |
+// 'material-icons' | 'material-symbols' — Ionicons is 'ion', NOT 'ionicons');
+// every <Icon> below then omits `library`.
+import React from 'react';
+import {
+  ConfigProvider,
+  Icon,
+  IconText,
+  Button,
+  Box,
+  Title,
+} from '@allxsmith/bestax-bulma';
+
+export function IconShowcase() {
+  return (
+    <ConfigProvider iconLibrary="fa">
+      <Box>
+        <Title size="5">Meaningful icons carry their own label</Title>
+        {/* Standalone icons convey information — give them a descriptive
+            ariaLabel (the default is just "icon"). */}
+        <Icon
+          name="triangle-exclamation"
+          textColor="warning"
+          ariaLabel="Warning"
+        />
+        <Icon name="circle-check" textColor="success" ariaLabel="Success" />
+
+        <Title size="5" mt="4">
+          Decorative icons hide from screen readers
+        </Title>
+        {/* Next to visible text the icon repeats the message — aria-hidden
+            stops "icon" (or a duplicate) being announced. */}
+        <IconText iconProps={{ name: 'star', 'aria-hidden': 'true' }}>
+          Starred
+        </IconText>
+        <Button color="primary">
+          <Icon name="floppy-disk" aria-hidden="true" />
+          <span>Save</span>
+        </Button>
+
+        <Title size="5" mt="4">
+          Sizes, variants, features, color
+        </Title>
+        {/* `size` sizes the Bulma container; `features` scales the glyph. */}
+        <Icon name="rocket" size="large" features="fa-2x" ariaLabel="Launch" />
+        {/* Font Awesome styles come from `variant`; brands require it. */}
+        <Icon name="bell" variant="regular" ariaLabel="Notifications" />
+        <Icon name="github" variant="brands" ariaLabel="GitHub" />
+        {/* Spin + color via features and the textColor helper. */}
+        <Icon
+          name="spinner"
+          features="fa-spin"
+          textColor="info"
+          ariaLabel="Loading"
+        />
+
+        <Title size="5" mt="4">
+          Multi-segment icon text
+        </Title>
+        <IconText
+          items={[
+            {
+              iconProps: { name: 'train', 'aria-hidden': 'true' },
+              text: 'Metro',
+            },
+            {
+              iconProps: { name: 'arrow-right', 'aria-hidden': 'true' },
+              text: 'Airport',
+            },
+          ]}
+        />
+      </Box>
+    </ConfigProvider>
+  );
+}

--- a/skills/bestax-icons/references/icon-libraries.md
+++ b/skills/bestax-icons/references/icon-libraries.md
@@ -1,0 +1,131 @@
+# Icon libraries — setup, names, variants, troubleshooting
+
+Facts an agent can act on for each of the five libraries `Icon` supports. The library ships no
+icon fonts: the app must install the chosen library (the `npm create bestax` scaffold's
+`--icon` flag does this; in an existing app, follow Setup below).
+
+## How `Icon` renders
+
+- `fa` / `mdi` — an `<i>` with CSS classes (`fas fa-rocket`, `mdi mdi-rocket-launch`).
+- `material-icons` / `material-symbols` — an `<i>` whose **text content** is the name
+  (a font ligature): `<i class="material-icons">rocket_launch</i>`. That's why these names are
+  snake_case — they are literal text, not class names.
+- `ion` — the `<ion-icon>` web component: `<ion-icon name="rocket-outline" />`.
+
+The resolution order for the library is `library` prop → `ConfigProvider iconLibrary` → `'fa'`.
+Set it once on `ConfigProvider` and omit `library` everywhere else.
+
+## Font Awesome — `'fa'` (the default)
+
+- **Setup:** `npm install @fortawesome/fontawesome-free` and
+  `import '@fortawesome/fontawesome-free/css/all.min.css';` once (e.g. `main.tsx`).
+- **Scaffold flag:** `--icon fontawesome`.
+- **Names:** kebab-case without the `fa-` prefix: `rocket`, `circle-check`, `magnifying-glass`.
+  A leading `fa-` in `name` is stripped automatically (so `fa-rocket` also works), but write
+  the bare name.
+- **Variants** (`variant` → class): `solid` → `fas` (default), `regular` → `far`, `brands` →
+  `fab`, `light` → `fal`, `duotone` → `fad`, `thin` → `fat`. The free package includes only
+  solid, regular (partial), and brands — light/duotone/thin need a Font Awesome Pro kit.
+- **Features:** Font Awesome utility classes — `'fa-lg'`, `'fa-2x'`…`'fa-10x'`, `'fa-spin'`,
+  `'fa-pulse'`, `'fa-border'`, `'fa-fw'`, `'fa-flip-horizontal'`, `'fa-rotate-90'`.
+- Brand icons **require** `variant="brands"`: `<Icon name="github" variant="brands" />`.
+
+## Material Design Icons — `'mdi'`
+
+- **Setup:** `npm install @mdi/font` and
+  `import '@mdi/font/css/materialdesignicons.min.css';`.
+- **Scaffold flag:** `--icon mdi`.
+- **Names:** kebab-case without the `mdi-` prefix: `account`, `rocket-launch`,
+  `home-outline`. A leading `mdi-` is stripped automatically. Outline/off styles are part of
+  the **name** (`home-outline`, `bell-off`), not a variant.
+- **Variants:** none — `variant` is ignored for MDI.
+- **Features:** MDI helpers (`'mdi-24px'`, `'mdi-48px'`, `'mdi-spin'`, `'mdi-rotate-90'`) or
+  Bulma text-size classes (`'is-size-3'`).
+
+## Ionicons — `'ion'` ⚠️ value is `ion`, not `ionicons`
+
+- **Setup:** a CDN script pair in `index.html` (no npm package — it registers the
+  `<ion-icon>` web component):
+
+  ```html
+  <script
+    type="module"
+    src="https://unpkg.com/ionicons@8.0.13/dist/ionicons/ionicons.esm.js"
+  ></script>
+  <script
+    nomodule
+    src="https://unpkg.com/ionicons@8.0.13/dist/ionicons/ionicons.js"
+  ></script>
+  ```
+
+- **Scaffold flag:** `--icon ionicons` — which maps to `iconLibrary="ion"`. Passing
+  `'ionicons'` as the `library`/`iconLibrary` value renders nothing.
+- **Names:** kebab-case: `rocket`, `heart`, `settings`.
+- **Variants:** `outline` and `sharp` — appended to the name (`variant="outline"` +
+  `name="heart"` renders `<ion-icon name="heart-outline">`). Omit for the filled default.
+- **Features:** not applicable (web component, not classes); size the container with `size`
+  or style via CSS.
+
+## Google Material Icons — `'material-icons'`
+
+- **Setup:** `npm install material-icons` and `import 'material-icons';`.
+- **Scaffold flag:** `--icon material-icons`.
+- **Names:** snake_case ligature text: `home`, `rocket_launch`, `shopping_cart`. A kebab-case
+  name will not match a ligature and renders as raw text.
+- **Variants:** `filled` (default) / `outlined` / `round` / `sharp` — note **`round`**, not
+  `rounded`.
+- **Features:** Bulma classes like `'is-size-1'` (the font scales with text size).
+
+## Material Symbols — `'material-symbols'`
+
+- **Setup:** `npm install material-symbols` and `import 'material-symbols';`.
+- **Scaffold flag:** `--icon material-symbols`.
+- **Names:** snake_case ligature text, same as Material Icons: `rocket_launch`.
+- **Variants:** `outlined` (default) / `rounded` / `sharp` — note **`rounded`** here vs
+  Material Icons' `round`.
+- **Features:** Bulma classes like `'is-size-1'`.
+
+## One glyph, five names
+
+| Glyph    | fa                 | mdi             | ion        | material-icons / material-symbols |
+| -------- | ------------------ | --------------- | ---------- | --------------------------------- |
+| Rocket   | `rocket`           | `rocket-launch` | `rocket`   | `rocket_launch`                   |
+| Home     | `house` / `home`   | `home`          | `home`     | `home`                            |
+| Settings | `gear`             | `cog`           | `settings` | `settings`                        |
+| Search   | `magnifying-glass` | `magnify`       | `search`   | `search`                          |
+
+## Blank icon? Check in this order
+
+1. **Library value** — `'ion'` not `'ionicons'`; the five valid values are `fa`, `mdi`,
+   `ion`, `material-icons`, `material-symbols`.
+2. **Name format for that library** — kebab vs snake_case (see the table above); for
+   material-* a wrong name renders as literal text instead of a glyph.
+3. **The library's CSS/script is actually loaded** — the import in `main.tsx` (or the
+   Ionicons scripts in `index.html`) must exist; bestax ships none of them.
+4. **Variant availability** — Font Awesome free has no `light`/`duotone`/`thin`; brand
+   glyphs need `variant="brands"`.
+
+## IconText
+
+Pairs icon(s) with text inside a Bulma `icon-text` container. Single icon:
+
+```tsx
+<IconText iconProps={{ name: 'check', 'aria-hidden': 'true' }}>Saved</IconText>
+```
+
+Multiple segments via `items`:
+
+```tsx
+<IconText
+  items={[
+    { iconProps: { name: 'train', 'aria-hidden': 'true' }, text: 'Metro' },
+    {
+      iconProps: { name: 'arrow-right', 'aria-hidden': 'true' },
+      text: 'Airport',
+    },
+  ]}
+/>
+```
+
+Icons inside `IconText` sit next to their visible text — mark them decorative with
+`aria-hidden` (see SKILL.md's accessibility rules).


### PR DESCRIPTION
# Pull Request

## Description

New `bestax-icons` Agent Skill (#287): teaches agents the icon system end to end — `Icon`/`IconText`, the five supported libraries, and accessibility.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`) — Storybook showcase story only (no component code)
- [x] create-bestax (`create-bestax`) — ships the skill (bundled at build via sync-skills) + `CLAUDE_MD` template listing
- [x] docs (`@allxsmith/bestax-docs`) — new `docs/skills/icons.mdx` page + intro listing + sidebar
- [x] Other: `skills/bestax-icons/` (the skill itself), `skills/README.md`

**The skill** (follows the `skills/CLAUDE.md` layout contract):

- `SKILL.md` — kept short: quick start, the five-library table with `ConfigProvider` values (⚠️ **`ionicons` → `'ion'`** — the trap #271 documented), per-library name formats (`rocket` / `rocket-launch` / `rocket_launch`), variant + `features` guidance, container-vs-glyph sizing, and the decorative-vs-labeled rules (`ariaLabel` for meaningful icons, `aria-hidden` next to visible text).
- `references/icon-libraries.md` — depth on demand: per-library setup (npm import statements or the Ionicons CDN script pair, matching what create-bestax scaffolds), full variant tables (Material Icons **`round`** vs Material Symbols **`rounded`**), how each library actually renders (classes vs text ligatures vs web component), a one-glyph-five-names table, and a blank-icon troubleshooting checklist.
- `examples/icon-usage.tsx` — the runnable canonical example.

**Listing surfaces synced in the same PR:** `skills/README.md` (table row, install line, layout tree), `docs/docs/skills/intro.md` + new `icons.mdx` + `sidebars.js`, the create-bestax `CLAUDE_MD` template's skills list, and a `Skills/Icons` Storybook showcase per the skill-examples sync rule.

Every fact was verified against `Icon.tsx`/`IconText.tsx`/`Config.tsx` source and the create-bestax scaffold constants — not written from memory.

## Related Issue(s)

Closes #287
Relates to #67 (future libraries would extend this skill), #271 (the `ion` trap's origin)

## Type of Change

- [x] New feature
- [x] Documentation

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] I have updated Storybook stories as needed (new `Skills/Icons` showcase)
- [x] All new and existing tests passed (stories meta-test + full repo suite; `gen:catalog` no diff; typecheck, lint, prettier, conformance, and full docs build green locally)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (create-bestax `CLAUDE_MD` template line)

## Additional Context

Commit is scoped `feat(create-bestax)` since skills ship inside the create-bestax package — this cuts the minor release that delivers the new skill to `npm create bestax` users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive icon usage guidance and examples.
  * Added support documentation for configuring and using five icon libraries.
  * Added examples covering icon sizing, variants, features, buttons, and accessible decorative icons.
  * Added the new Icons skill to the available skills and starter project guidance.

* **Documentation**
  * Added the Icons skill to the documentation navigation, overview, and installation instructions.
  * Added troubleshooting and icon library reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->