### PR TITLE
docs: equal-height cards — Grid/Cell in the layout skill, Columns flex recipe

### DIFF
--- a/docs/docs/guides/library/columns.md
+++ b/docs/docs/guides/library/columns.md
@@ -174,7 +174,8 @@ robust pattern: make the column a flex container and let the card grow:
 
 :::tip
 For **uniform grids** of same-shaped cards, [`Grid`/`Cell`](./grid.md) gives equal-height cells
-for free (CSS Grid stretches every cell to its row) — no flex recipe needed.
+for free (CSS Grid stretches every cell to its row's height) — no flex recipe needed. Both
+approaches equalize per row: cards match their own row's tallest card.
 :::
 
 [View full documentation.](../../api/columns/column)

--- a/docs/docs/guides/library/columns.md
+++ b/docs/docs/guides/library/columns.md
@@ -147,8 +147,9 @@ Offsets are useful for centering or right-aligning columns, but can cause layout
 **Equal-Height Cards**
 
 Columns themselves are equal height (flexbox), but a `Card` inside a `Column` ends at its own
-content — and `height: 100%` on the card does nothing, because `100%` resolves against the
-column's _auto_ height. Make the column a flex container and let the card grow:
+content — and `height: 100%` on the card doesn't help here, because `100%` resolves against
+the column's _auto_ height (percentage heights only resolve against a definite size). The
+robust pattern: make the column a flex container and let the card grow:
 
 ```tsx live
 <Columns>

--- a/docs/docs/guides/library/columns.md
+++ b/docs/docs/guides/library/columns.md
@@ -144,6 +144,38 @@ Offsets are useful for centering or right-aligning columns, but can cause layout
 </Columns>
 ```
 
+**Equal-Height Cards**
+
+Columns themselves are equal height (flexbox), but a `Card` inside a `Column` ends at its own
+content — and `height: 100%` on the card does nothing, because `100%` resolves against the
+column's _auto_ height. Make the column a flex container and let the card grow:
+
+```tsx live
+<Columns>
+  <Column display="flex" flexDirection="column">
+    <Card flexGrow="1" header="Basic">
+      Short blurb.
+    </Card>
+  </Column>
+  <Column display="flex" flexDirection="column">
+    <Card flexGrow="1" header="Featured">
+      A much longer description that would normally make this card taller than
+      its neighbors — now they all match.
+    </Card>
+  </Column>
+  <Column display="flex" flexDirection="column">
+    <Card flexGrow="1" header="Pro">
+      Medium-length blurb here.
+    </Card>
+  </Column>
+</Columns>
+```
+
+:::tip
+For **uniform grids** of same-shaped cards, [`Grid`/`Cell`](./grid.md) gives equal-height cells
+for free (CSS Grid stretches every cell to its row) — no flex recipe needed.
+:::
+
 [View full documentation.](../../api/columns/column)
 
 ---

--- a/docs/docs/guides/library/grid.md
+++ b/docs/docs/guides/library/grid.md
@@ -16,8 +16,8 @@ Provides Bulma's advanced CSS Grid layout for complex, modern layouts. Supports 
 
 :::info
 Use `Grid` for advanced layouts where you need more control than Columns can provide — and for
-**uniform card grids**: CSS Grid keeps every cell in a row equal height for free, so cards line
-up without the flex recipe [`Columns` needs](./columns.md#column). It supports both auto-fit
+**uniform card grids**: CSS Grid keeps every cell in a row equal height for free (each row
+matches its tallest cell), so cards line up without the flex recipe [`Columns` needs](./columns.md#column). It supports both auto-fit
 and fixed column counts.
 :::
 

--- a/docs/docs/guides/library/grid.md
+++ b/docs/docs/guides/library/grid.md
@@ -15,7 +15,10 @@ This page summarizes the Bulma-styled grid system in Bestax, with a brief descri
 Provides Bulma's advanced CSS Grid layout for complex, modern layouts. Supports responsive and fixed grid modes, gap and min column controls, fixed column counts per breakpoint, and full color/background/utility helpers. Use with `Cell` for granular grid placement.
 
 :::info
-Use `Grid` for advanced layouts where you need more control than Columns can provide. It supports both auto-fit and fixed column counts.
+Use `Grid` for advanced layouts where you need more control than Columns can provide — and for
+**uniform card grids**: CSS Grid keeps every cell in a row equal height for free, so cards line
+up without the flex recipe [`Columns` needs](./columns.md#column). It supports both auto-fit
+and fixed column counts.
 :::
 
 ```tsx live

--- a/skills/bestax-layout-scaffold/SKILL.md
+++ b/skills/bestax-layout-scaffold/SKILL.md
@@ -41,7 +41,7 @@ Centered; a collection of items → Card grid. For mixed requests, pick the domi
   `Grid`/`Cell`: CSS Grid gives equal-height cells for free. Use `Columns`/`Column` for
   proportional or per-breakpoint column layouts — and when cards there must be equal height,
   apply the flex recipe (`Column display="flex" flexDirection="column"` + `Card flexGrow="1"`;
-  `height: 100%` on the card does nothing).
+  `height: 100%` on the card doesn't help — the column's height is auto).
 - Rely on Bulma's responsive defaults: `Columns` sit side by side on tablet and up and stack on
   mobile. Add responsive `size*` props only to tune the breakpoints.
 - For a `fixed="top"` `Navbar`, add the `has-navbar-fixed-top` class to `<html>` so content is not

--- a/skills/bestax-layout-scaffold/SKILL.md
+++ b/skills/bestax-layout-scaffold/SKILL.md
@@ -36,8 +36,12 @@ Centered; a collection of items → Card grid. For mixed requests, pick the domi
 ## Approach
 
 - Compose pages from the shipped layout components — `Container`, `Section`, `Hero`, `Footer`,
-  `Level`, `Columns`/`Column`, `Navbar`, `Menu`, `Card`. There is **no `Tile` component** — build
-  grids with `Columns`/`Column`.
+  `Level`, `Columns`/`Column`, `Grid`/`Cell`, `Navbar`, `Menu`, `Card`. There is **no `Tile`
+  component**. For **uniform grids** (card grids, galleries — same-shaped items) prefer
+  `Grid`/`Cell`: CSS Grid gives equal-height cells for free. Use `Columns`/`Column` for
+  proportional or per-breakpoint column layouts — and when cards there must be equal height,
+  apply the flex recipe (`Column display="flex" flexDirection="column"` + `Card flexGrow="1"`;
+  `height: 100%` on the card does nothing).
 - Rely on Bulma's responsive defaults: `Columns` sit side by side on tablet and up and stack on
   mobile. Add responsive `size*` props only to tune the breakpoints.
 - For a `fixed="top"` `Navbar`, add the `has-navbar-fixed-top` class to `<html>` so content is not
@@ -74,7 +78,8 @@ color }}`. Set the app-wide icon library once with `<ConfigProvider iconLibrary=
 
 - [ ] Map the request to one archetype; do not ask layout questions.
 - [ ] Wrap page content in `Container` (+ `Section` for vertical rhythm).
-- [ ] Use `Columns`/`Column` for side-by-side layout; rely on the mobile stack default.
+- [ ] Use `Grid`/`Cell` for uniform grids (equal heights free); `Columns`/`Column` for
+      proportional side-by-side layout — with the flex recipe when its cards must match height.
 - [ ] For a fixed navbar, add `has-navbar-fixed-top` to `<html>`.
 - [ ] Do not use `Tile` — it is not shipped.
 - [ ] Style with helper props (`mt`/`p`, `textAlign`, `textColor`), not inline `style`.

--- a/skills/bestax-layout-scaffold/SKILL.md
+++ b/skills/bestax-layout-scaffold/SKILL.md
@@ -38,7 +38,8 @@ Centered; a collection of items → Card grid. For mixed requests, pick the domi
 - Compose pages from the shipped layout components — `Container`, `Section`, `Hero`, `Footer`,
   `Level`, `Columns`/`Column`, `Grid`/`Cell`, `Navbar`, `Menu`, `Card`. There is **no `Tile`
   component**. For **uniform grids** (card grids, galleries — same-shaped items) prefer
-  `Grid`/`Cell`: CSS Grid gives equal-height cells for free. Use `Columns`/`Column` for
+  `Grid`/`Cell`: CSS Grid gives equal-height cells for free (per row — each row's cells match
+  its tallest, same row-level behavior as the flex recipe). Use `Columns`/`Column` for
   proportional or per-breakpoint column layouts — and when cards there must be equal height,
   apply the flex recipe (`Column display="flex" flexDirection="column"` + `Card flexGrow="1"`;
   `height: 100%` on the card doesn't help — the column's height is auto).
@@ -78,8 +79,9 @@ color }}`. Set the app-wide icon library once with `<ConfigProvider iconLibrary=
 
 - [ ] Map the request to one archetype; do not ask layout questions.
 - [ ] Wrap page content in `Container` (+ `Section` for vertical rhythm).
-- [ ] Use `Grid`/`Cell` for uniform grids (equal heights free); `Columns`/`Column` for
-      proportional side-by-side layout — with the flex recipe when its cards must match height.
+- [ ] Use `Grid`/`Cell` for uniform grids (equal heights per row, free); `Columns`/`Column`
+      for proportional or per-breakpoint side-by-side layout — with the flex recipe when its
+      cards must match height.
 - [ ] For a fixed navbar, add `has-navbar-fixed-top` to `<html>`.
 - [ ] Do not use `Tile` — it is not shipped.
 - [ ] Style with helper props (`mt`/`p`, `textAlign`, `textColor`), not inline `style`.

--- a/skills/bestax-layout-scaffold/examples/card-grid.tsx
+++ b/skills/bestax-layout-scaffold/examples/card-grid.tsx
@@ -1,6 +1,10 @@
 // Card grid / catalog page — a collection of similar items.
 // `<Columns isMultiline>` wraps cards onto new rows; the responsive column sizes
 // give 1 card per row on mobile, 2 on tablet, 3 on desktop.
+// Equal heights: each Column is a flex container and its Card grows to fill
+// it (flexGrow="1"), so short blurbs don't leave ragged card bottoms.
+// (`height: 100%` on the card would NOT work — it resolves against auto
+// height. For uniform grids, Grid/Cell gives equal heights for free.)
 import React from 'react';
 import {
   Section,
@@ -78,8 +82,11 @@ export default function CatalogPage() {
               sizeMobile="full"
               sizeTablet="half"
               sizeDesktop="one-third"
+              display="flex"
+              flexDirection="column"
             >
               <Card
+                flexGrow="1"
                 image={product.image}
                 imageAlt={product.name}
                 header={product.name}

--- a/skills/bestax-layout-scaffold/references/archetypes.md
+++ b/skills/bestax-layout-scaffold/references/archetypes.md
@@ -165,8 +165,11 @@ search results, "a grid of cards".
           sizeMobile="full"
           sizeTablet="half"
           sizeDesktop="one-third"
+          display="flex"
+          flexDirection="column"
         >
           <Card
+            flexGrow="1"
             image={item.image}
             header={item.name}
             footer={<span className="card-footer-item">{item.price}</span>}
@@ -182,6 +185,13 @@ search results, "a grid of cards".
 
 **Responsive:** `isMultiline` wraps cards onto new rows; the `size*` props set the per-row count —
 1 on mobile, 2 on tablet, 3 on desktop here. Change the fractions to change the column count.
+
+**Equal heights:** the `display="flex" flexDirection="column"` on each `Column` plus
+`flexGrow="1"` on the `Card` stretches every card to its row's height — without it, cards end
+at their content and rows look ragged (`height: 100%` on the card does nothing). Alternatively
+build the whole grid with `Grid`/`Cell` (`<Grid isFixed fixedColsMobile={1} fixedColsTablet={2}
+fixedColsDesktop={3} gap={4}>`) — CSS Grid keeps cells equal-height for free; see the
+`Grid / Cell` section in `layout-components.md`.
 
 ---
 

--- a/skills/bestax-layout-scaffold/references/archetypes.md
+++ b/skills/bestax-layout-scaffold/references/archetypes.md
@@ -188,7 +188,8 @@ search results, "a grid of cards".
 
 **Equal heights:** the `display="flex" flexDirection="column"` on each `Column` plus
 `flexGrow="1"` on the `Card` stretches every card to its row's height — without it, cards end
-at their content and rows look ragged (`height: 100%` on the card does nothing). Alternatively
+at their content and rows look ragged (`height: 100%` on the card doesn't help — it resolves
+against the column's auto height). Alternatively
 build the whole grid with `Grid`/`Cell` (`<Grid isFixed fixedColsMobile={1} fixedColsTablet={2}
 fixedColsDesktop={3} gap={4}>`) — CSS Grid keeps cells equal-height for free; see the
 `Grid / Cell` section in `layout-components.md`.

--- a/skills/bestax-layout-scaffold/references/layout-components.md
+++ b/skills/bestax-layout-scaffold/references/layout-components.md
@@ -157,8 +157,8 @@ the column's auto height). Make the `Column` a flex container and let the card g
 ## Grid / Cell
 
 Bulma's CSS Grid. **Preferred for uniform grids** — same-shaped items in a repeating pattern
-(card grids, galleries, dashboards): CSS Grid gives **equal-height cells for free**, with no
-flex recipe needed. Reach for `Columns`/`Column` instead when you need proportional or
+(card grids, galleries, dashboards): CSS Grid gives **equal-height cells for free** (per row —
+each row's cells match its tallest), with no flex recipe needed. Reach for `Columns`/`Column` instead when you need proportional or
 per-breakpoint column _sizes_ (a 2/3 + 1/3 split, different counts per breakpoint).
 
 **Grid**

--- a/skills/bestax-layout-scaffold/references/layout-components.md
+++ b/skills/bestax-layout-scaffold/references/layout-components.md
@@ -12,6 +12,8 @@ import {
   Level,
   Columns,
   Column,
+  Grid,
+  Cell,
   Navbar,
   Menu,
   Card,
@@ -26,7 +28,9 @@ Every component also accepts the shared Bulma helper props (`m`/`p` spacing, `te
 > `textColor="grey"` / `bgColor="light"` not `style={{ color }}`. Spacing scale is `0`–`6` | `auto`
 > (`4` = 1rem). Reserve `style`/CSS vars only for values the design system doesn't tokenize.
 
-> **There is no `Tile` component.** Build grids and nested layouts with `Columns` / `Column`.
+> **There is no `Tile` component.** For uniform grids (cards, galleries) use `Grid` / `Cell` —
+> equal-height cells for free; for proportional or per-breakpoint layouts use
+> `Columns` / `Column`.
 
 ## Container
 
@@ -126,6 +130,76 @@ type BulmaColumnSize =
 
 > Columns **stack on mobile** by default and go side-by-side at the tablet breakpoint and up.
 > Use the per-breakpoint `size*` props to control how many cells share a row at each width.
+
+**Equal-height cards inside Columns** — columns are equal height, but a card inside one does
+**not** stretch to fill it (and `height: 100%` on the card resolves against auto height, so it
+does nothing). Make the `Column` a flex container and let the card grow:
+
+```tsx
+<Columns isMultiline>
+  {items.map(item => (
+    <Column
+      key={item.id}
+      sizeTablet="half"
+      sizeDesktop="one-third"
+      display="flex"
+      flexDirection="column"
+    >
+      <Card flexGrow="1">{item.blurb}</Card>
+    </Column>
+  ))}
+</Columns>
+```
+
+`display`, `flexDirection`, and `flexGrow` are helper props every component accepts;
+`flexGrow` takes a string (`"1"`).
+
+## Grid / Cell
+
+Bulma's CSS Grid. **Preferred for uniform grids** — same-shaped items in a repeating pattern
+(card grids, galleries, dashboards): CSS Grid gives **equal-height cells for free**, with no
+flex recipe needed. Reach for `Columns`/`Column` instead when you need proportional or
+per-breakpoint column _sizes_ (a 2/3 + 1/3 split, different counts per breakpoint).
+
+**Grid**
+
+| Prop                                                                                                                   | Type                                                         |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `gap` / `columnGap` / `rowGap`                                                                                         | `0`–`8` (number or string, same scale as Columns' `gap`)     |
+| `minCol`                                                                                                               | `1`–`32` (smart grid: min column width step, `is-col-min-X`) |
+| `isFixed`                                                                                                              | `boolean` (fixed column count instead of auto-fill)          |
+| `fixedCols` (+ `fixedColsMobile` / `fixedColsTablet` / `fixedColsDesktop` / `fixedColsWidescreen` / `fixedColsFullhd`) | `0`–`12` or `'auto'` (fixed grid only)                       |
+
+**Cell**
+
+| Prop                                  | Type                                    |
+| ------------------------------------- | --------------------------------------- |
+| `colStart` / `colFromEnd` / `colSpan` | `number` (manual column placement/span) |
+| `rowStart` / `rowFromEnd` / `rowSpan` | `number` (manual row placement/span)    |
+
+By default the smart grid **auto-fills**: cells flow into as many columns as fit (tune the
+minimum width with `minCol`). `isFixed` + `fixedCols*` pins an exact column count per
+breakpoint instead.
+
+```tsx
+// Uniform card grid — equal heights for free, responsive column count for free.
+<Grid
+  isFixed
+  fixedColsMobile={1}
+  fixedColsTablet={2}
+  fixedColsDesktop={3}
+  gap={4}
+>
+  {items.map(item => (
+    <Cell key={item.id}>
+      <Card header={item.name}>{item.blurb}</Card>
+    </Cell>
+  ))}
+</Grid>
+```
+
+> To stretch each card to its cell's full (equal) height, the same `display="flex"
+flexDirection="column"` + `flexGrow="1"` pattern applies to `Cell` + `Card`.
 
 ## Navbar
 

--- a/skills/bestax-layout-scaffold/references/layout-components.md
+++ b/skills/bestax-layout-scaffold/references/layout-components.md
@@ -132,8 +132,8 @@ type BulmaColumnSize =
 > Use the per-breakpoint `size*` props to control how many cells share a row at each width.
 
 **Equal-height cards inside Columns** — columns are equal height, but a card inside one does
-**not** stretch to fill it (and `height: 100%` on the card resolves against auto height, so it
-does nothing). Make the `Column` a flex container and let the card grow:
+**not** stretch to fill it (and `height: 100%` on the card doesn't help — it resolves against
+the column's auto height). Make the `Column` a flex container and let the card grow:
 
 ```tsx
 <Columns isMultiline>


### PR DESCRIPTION
# Pull Request

## Description

Fixes both documentation gaps from #196 ("a row of equal-height cards" — one of the most common layout needs):

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`) — ships the updated layout skill
- [x] docs (`@allxsmith/bestax-docs`) — columns + grid library guides
- [x] Other: `skills/bestax-layout-scaffold`

**1. `Grid`/`Cell` now exist in the layout skill — and are the preferred tool for uniform grids.**
`layout-components.md` gains a full `Grid / Cell` section (props tables for `gap`/`minCol`/`isFixed`/`fixedCols*` and `colStart`/`colSpan`/`rowSpan` — source-verified post-#300 — plus auto-fill vs fixed-count explanation and a responsive card-grid snippet). The skill's steering flips from "build grids with `Columns`/`Column`" to: **uniform grids → `Grid`/`Cell` (equal heights free); proportional/per-breakpoint layouts → `Columns`/`Column`** — in the SKILL.md approach bullet, the checklist item, and the no-`Tile` note at the top of the reference. The import block gains `Grid, Cell`.

**2. The equal-height recipe for `Columns` is documented everywhere it's needed.**
The exact footgun from the issue (`height: 100%` on the card resolves against auto height → ragged bottoms) and its fix — `<Column display="flex" flexDirection="column">` + `<Card flexGrow="1">` — now appear in: the skill reference, the card-grid archetype skeleton, the docs **columns guide** (new "Equal-Height Cards" live example), and a pointer in the **grid guide**. Helper-prop facts verified against `useFlexboxClasses`: `flexGrow` is an ungated item property (string `"1"`), `display="flex"` gates only the container helpers.

**3. `examples/card-grid.tsx` now models the correct result** — the skill's canonical card-grid example renders actually-equal-height cards via the flex recipe, with a comment explaining why and pointing at Grid/Cell for the free alternative.

## Related Issue(s)

Closes #196

## Type of Change

- [x] Documentation (docs + shipped-skill guidance)

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] All new and existing tests passed (no package code changed; prettier + format:check green; full docs build green)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (none affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Equal-Height Cards” section to the `Column` guide, including a live example using flexbox (`Column` as a vertical flex container, `Card` growing to match row height).
  * Expanded `Grid` guidance with clearer “when to use” instructions for uniform equal-height card grids, including auto-fit vs fixed column counts.
  * Updated the card-grid archetype and the layout/scaffold references and examples to consistently reflect the new `Grid`/`Cell` vs `Columns`/`Column` selection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->