### PR TITLE
docs(bulma-ui): use real profile photo in Avatar image stories

### DIFF
--- a/bulma-ui/src/components/Avatar.stories.tsx
+++ b/bulma-ui/src/components/Avatar.stories.tsx
@@ -83,8 +83,8 @@ export const Photo: Story = {
   render: function PhotoExample() {
     return (
       <Avatar
-        src="https://bulma.io/assets/images/placeholders/128x128.png"
-        name="Ada Lovelace"
+        src="https://github.com/allxsmith.png"
+        name="Al Smith"
         size="64x64"
       />
     );
@@ -161,8 +161,8 @@ export const LazyLoadedImage: Story = {
   render: function LazyLoadedExample() {
     return (
       <Avatar
-        src="https://bulma.io/assets/images/placeholders/128x128.png"
-        name="Ada Lovelace"
+        src="https://github.com/allxsmith.png"
+        name="Al Smith"
         size="64x64"
         imageProps={{ loading: 'lazy' }}
       />


### PR DESCRIPTION
Closes #305

## What

The **Photo** and **LazyLoadedImage** stories in `Avatar.stories.tsx` rendered the generic gray Bulma placeholder (`bulma.io/assets/images/placeholders/128x128.png`), which makes an unconvincing avatar demo. Both now use the maintainer's GitHub avatar via the stable redirect:

```
https://github.com/allxsmith.png
```

with `name="Al Smith"` to match — the same photo/name pairing the docs examples already use (`docs/docs/api/components/avatar.md`, `docs/docs/guides/library/components.md`).

## Not changed

- **BrokenImageFallsBackToInitials** keeps its intentionally invalid `https://example.invalid/missing.jpg` — it exists to demo the initials fallback.
- No other story or docs page uses the gray placeholder (checked `Avatars.stories.tsx`, `Badge.stories.tsx`, and the docs tree).

## Verification

- `pnpm all` (build, typecheck, test+coverage, bundle:stats, lint, format:check, storybook build) passes locally.
- Stories-only change; no component, docs, or skills surface affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated avatar component examples with a new sample image and display name in Storybook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->