### PR TITLE
fix(create-bestax): reject dot-only project names, pin icon versions, bundle bestax-icons skill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# The workflows, AI-loop guardrails, and composite actions under .github/ are
+# the repo's security boundary — changes require the owner's review.
+# (Enforced only once "Require review from Code Owners" is enabled in the
+# branch protection / ruleset for main.)
+/.github/ @allxsmith

--- a/.github/actions/verified-commit/action.yml
+++ b/.github/actions/verified-commit/action.yml
@@ -17,15 +17,21 @@ runs:
   steps:
     - name: Commit files via GitHub API
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      env:
+        # Inputs must reach the script as env vars, never via ${{ }} template
+        # interpolation into the JS source — a quote in an input would
+        # otherwise become script injection.
+        FILE_PATTERN: ${{ inputs.file-pattern }}
+        COMMIT_MESSAGE: ${{ inputs.message }}
       with:
         github-token: ${{ inputs.token }}
         script: |
           const fs = require('fs');
           const path = require('path');
-          const { execSync } = require('child_process');
+          const { execFileSync } = require('child_process');
 
           // Get all files matching the pattern using find command
-          const pattern = '${{ inputs.file-pattern }}';
+          const pattern = process.env.FILE_PATTERN;
           let files = [];
 
           // Extract base directory and file pattern
@@ -33,8 +39,8 @@ runs:
           const basePath = pattern.replace(/\/\*\*\/.*$/, '');  // "create-bestax/e2e/tests"
 
           try {
-            const output = execSync(
-              `find ${basePath} -type f -name "*.png"`,
+            const output = execFileSync(
+              'find', [basePath, '-type', 'f', '-name', '*.png'],
               { cwd: process.env.GITHUB_WORKSPACE, encoding: 'utf-8' }
             );
             files = output.trim().split('\n').filter(Boolean).map(f =>
@@ -53,7 +59,7 @@ runs:
           console.log(`Found ${files.length} files to commit`);
 
           const branch = context.ref.replace('refs/heads/', '');
-          const commitMessage = '${{ inputs.message }}';
+          const commitMessage = process.env.COMMIT_MESSAGE;
 
           // Get the current commit SHA
           const { data: refData } = await github.rest.git.getRef({

--- a/.github/actions/verified-commit/action.yml
+++ b/.github/actions/verified-commit/action.yml
@@ -34,13 +34,14 @@ runs:
           const pattern = process.env.FILE_PATTERN;
           let files = [];
 
-          // Extract base directory and file pattern
-          // Pattern like "create-bestax/e2e/tests/**/*.png"
+          // Extract base directory and filename glob from a pattern like
+          // "create-bestax/e2e/tests/**/*.png"
           const basePath = pattern.replace(/\/\*\*\/.*$/, '');  // "create-bestax/e2e/tests"
+          const nameGlob = pattern.slice(pattern.lastIndexOf('/') + 1) || '*';  // "*.png"
 
           try {
             const output = execFileSync(
-              'find', [basePath, '-type', 'f', '-name', '*.png'],
+              'find', [basePath, '-type', 'f', '-name', nameGlob],
               { cwd: process.env.GITHUB_WORKSPACE, encoding: 'utf-8' }
             );
             files = output.trim().split('\n').filter(Boolean).map(f =>

--- a/.github/actions/verified-commit/action.yml
+++ b/.github/actions/verified-commit/action.yml
@@ -38,10 +38,15 @@ runs:
           // "create-bestax/e2e/tests/**/*.png"
           const basePath = pattern.replace(/\/\*\*\/.*$/, '');  // "create-bestax/e2e/tests"
           const nameGlob = pattern.slice(pattern.lastIndexOf('/') + 1) || '*';  // "*.png"
+          // find's first positional arg must never start with '-': GNU find
+          // would parse it as an expression (path defaulting to '.') — a
+          // pattern like "-delete" would otherwise delete workspace files.
+          // -name is safe (it always consumes the following argv slot).
+          const safeBase = basePath.startsWith('-') ? './' + basePath : basePath;
 
           try {
             const output = execFileSync(
-              'find', [basePath, '-type', 'f', '-name', nameGlob],
+              'find', [safeBase, '-type', 'f', '-name', nameGlob],
               { cwd: process.env.GITHUB_WORKSPACE, encoding: 'utf-8' }
             );
             files = output.trim().split('\n').filter(Boolean).map(f =>

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -14,11 +14,7 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: claude-implement-${{ github.event.issue.number }}
@@ -26,6 +22,11 @@ concurrency:
 
 jobs:
   implement:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     # Label + human-labeler gate. GitHub only lets triage+ users apply
     # labels, and the permission step below re-verifies the labeler's role
     # live (belt and braces — e.g. against a template auto-applying the

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,11 +24,7 @@ on:
   pull_request:
     types: [opened, labeled]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -36,6 +32,11 @@ concurrency:
 
 jobs:
   review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
     # Two ways in, both same-repo PRs only: (a) AI-loop PRs from claude/*
     # branches, or (b) any PR a triage+ user opts in via the `deep-review`
     # label (role re-verified live in the perm step below). For `labeled`

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,14 +20,15 @@ on:
   issues:
     types: [opened, assigned]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
+permissions: {}
 
 jobs:
   claude:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     # Only OWNER / MEMBER / COLLABORATOR may trigger Claude, and only when the
     # relevant body actually contains the "@claude" trigger phrase. Anyone else
     # mentioning @claude is a no-op — the job never starts, so no usage is spent.
@@ -43,23 +44,49 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # Layer 2 (authoritative): author_association can be COLLABORATOR with
+      # only read access. Re-check the LIVE role and require write/triage+.
+      - name: Check trigger permission
+        id: perm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          set -euo pipefail
+          ROLE=$(gh api "repos/$REPO/collaborators/$SENDER/permission" \
+            --jq '.role_name' || echo none)
+          case "$ROLE" in
+            admin|maintain|write|triage)
+              echo "allowed=true" >> "$GITHUB_OUTPUT"
+              echo "$SENDER has $ROLE access — responding" ;;
+            *)
+              echo "allowed=false" >> "$GITHUB_OUTPUT"
+              echo "$SENDER lacks write/triage access ($ROLE) — ignoring" ;;
+          esac
+
       - name: Checkout code
+        if: steps.perm.outputs.allowed == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Pre-provision the toolchain so @claude can run tests/lint/build without
       # burning turns bootstrapping the environment.
       - name: Setup pnpm
+        if: steps.perm.outputs.allowed == 'true'
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
+        if: steps.perm.outputs.allowed == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Run Claude
+        if: steps.perm.outputs.allowed == 'true'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           # OAuth token from a Claude Pro/Max subscription (flat cost, no

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -37,13 +37,25 @@ jobs:
           mkdir -p docs/build/storybook
           cp -r bulma-ui/storybook-static/* docs/build/storybook/
 
+      # github.head_ref is attacker-chosen text (the PR branch name) — never
+      # interpolate it into a command. Reduce it to [A-Za-z0-9-] first; the
+      # sanitized output is safe to interpolate by construction and matches
+      # Cloudflare's branch-alias charset.
+      - name: Sanitize preview branch name
+        id: branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          SAFE=$(printf '%s' "$HEAD_REF" | tr -cs 'a-zA-Z0-9-' '-' | cut -c1-63)
+          echo "safe=$SAFE" >> "$GITHUB_OUTPUT"
+
       - name: Deploy Preview to Cloudflare Pages
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         id: deploy
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy docs/build --project-name=bestax --branch=${{ github.head_ref }} --commit-dirty=true
+          command: pages deploy docs/build --project-name=bestax --branch=${{ steps.branch.outputs.safe }} --commit-dirty=true
 
       - name: Comment Preview URL
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/create-bestax/scripts/sync-skills.mjs
+++ b/create-bestax/scripts/sync-skills.mjs
@@ -18,6 +18,7 @@ const SKILLS = [
   'bestax-form',
   'bestax-theming',
   'bestax-layout-scaffold',
+  'bestax-icons',
 ];
 
 if (!fs.existsSync(skillsSrc)) {

--- a/create-bestax/src/__tests__/constants.test.ts
+++ b/create-bestax/src/__tests__/constants.test.ts
@@ -120,6 +120,15 @@ describe('constants', () => {
         }
       });
     });
+
+    it('should pin an explicit caret version for every npm-installed library', () => {
+      ICON_LIBRARIES.forEach(library => {
+        if (library.packageName) {
+          expect(library.packageVersion).toMatch(/^\^\d+\.\d+\.\d+$/);
+          expect(library.packageVersion).not.toBe('latest');
+        }
+      });
+    });
   });
 
   describe('BULMA_FLAVORS', () => {

--- a/create-bestax/src/__tests__/project-creator.test.ts
+++ b/create-bestax/src/__tests__/project-creator.test.ts
@@ -112,6 +112,16 @@ describe('ProjectCreator', () => {
       );
     });
 
+    it('should return null for dot names that would target the current or parent directory', async () => {
+      for (const name of ['.', '..', '.hidden']) {
+        const result = await projectCreator.getProjectName(name);
+        expect(result).toBeNull();
+        expect(console.log).toHaveBeenCalledWith(
+          expect.stringContaining('Project name cannot start with a dot')
+        );
+      }
+    });
+
     it('should prompt for project name when not provided', async () => {
       (prompts as jest.MockedFunction<typeof prompts>).mockResolvedValue({
         projectName: 'prompted-project',

--- a/create-bestax/src/__tests__/project-creator.test.ts
+++ b/create-bestax/src/__tests__/project-creator.test.ts
@@ -592,7 +592,7 @@ describe('ProjectCreator', () => {
         packageJsonPath,
         expect.objectContaining({
           dependencies: expect.objectContaining({
-            '@fortawesome/fontawesome-free': 'latest',
+            '@fortawesome/fontawesome-free': '^7.2.0',
           }),
         }),
         { spaces: 2 }
@@ -629,7 +629,7 @@ describe('ProjectCreator', () => {
         packageJsonPath,
         expect.objectContaining({
           dependencies: expect.objectContaining({
-            '@mdi/font': 'latest',
+            '@mdi/font': '^7.4.47',
           }),
         }),
         { spaces: 2 }
@@ -1517,7 +1517,7 @@ describe('ProjectCreator', () => {
         packageJsonPath,
         expect.objectContaining({
           dependencies: expect.objectContaining({
-            '@fortawesome/fontawesome-free': 'latest',
+            '@fortawesome/fontawesome-free': '^7.2.0',
           }),
         }),
         { spaces: 2 }

--- a/create-bestax/src/__tests__/validators.test.ts
+++ b/create-bestax/src/__tests__/validators.test.ts
@@ -68,6 +68,16 @@ describe('validators', () => {
       expect(validateProjectName('v1.0.0')).toBe(true);
     });
 
+    it('should reject project names that start with a dot', () => {
+      const dotMessage =
+        'Project name cannot start with a dot (names like "." or ".." would scaffold outside a new directory) — pass a directory name';
+      expect(validateProjectName('.')).toBe(dotMessage);
+      expect(validateProjectName('..')).toBe(dotMessage);
+      expect(validateProjectName('...')).toBe(dotMessage);
+      expect(validateProjectName('.hidden')).toBe(dotMessage);
+      expect(validateProjectName('.dotfile')).toBe(dotMessage);
+    });
+
     it('should accept project names with underscores', () => {
       expect(validateProjectName('my_project')).toBe(true);
       expect(validateProjectName('my_awesome_project')).toBe(true);
@@ -115,6 +125,13 @@ describe('validators', () => {
       expect(isValidProjectName('my$project')).toBe(false);
       expect(isValidProjectName('my%project')).toBe(false);
       expect(isValidProjectName('my&project')).toBe(false);
+    });
+
+    it('should return false for dot and leading-dot project names', () => {
+      expect(isValidProjectName('.')).toBe(false);
+      expect(isValidProjectName('..')).toBe(false);
+      expect(isValidProjectName('...')).toBe(false);
+      expect(isValidProjectName('.hidden')).toBe(false);
     });
 
     it('should be consistent with validateProjectName', () => {

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -20,6 +20,8 @@ export const MESSAGES = {
   PROJECT_NAME_TOO_LONG: 'Project name too long',
   PROJECT_NAME_INVALID_CHARS:
     'Project name can only contain letters, numbers, dots, dashes and underscores',
+  PROJECT_NAME_DOT:
+    'Project name cannot start with a dot (names like "." or ".." would scaffold outside a new directory) — pass a directory name',
   OPERATION_CANCELLED: '✖ Operation cancelled',
   NO_TTY:
     'No interactive terminal detected — cannot prompt for input.\n' +

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -143,6 +143,10 @@ export interface IconLibrary {
   display: string;
   color: typeof chalk.yellow;
   packageName?: string;
+  // Version range written into the generated app's package.json. Keep in sync
+  // with the ranges bulma-ui/docs are tested against — never 'latest', which
+  // would make scaffolded installs non-reproducible.
+  packageVersion?: string;
   importStatement?: string;
   setupInstructions?: string;
 }
@@ -158,6 +162,7 @@ export const ICON_LIBRARIES: IconLibrary[] = [
     display: 'Font Awesome',
     color: chalk.blue,
     packageName: '@fortawesome/fontawesome-free',
+    packageVersion: '^7.2.0',
     importStatement: "import '@fortawesome/fontawesome-free/css/all.min.css';",
   },
   {
@@ -165,6 +170,7 @@ export const ICON_LIBRARIES: IconLibrary[] = [
     display: 'Material Design Icons',
     color: chalk.cyan,
     packageName: '@mdi/font',
+    packageVersion: '^7.4.47',
     importStatement: "import '@mdi/font/css/materialdesignicons.min.css';",
   },
   {
@@ -179,6 +185,7 @@ export const ICON_LIBRARIES: IconLibrary[] = [
     display: 'Google Material Icons',
     color: chalk.yellow,
     packageName: 'material-icons',
+    packageVersion: '^1.13.14',
     importStatement: "import 'material-icons';",
   },
   {
@@ -186,6 +193,7 @@ export const ICON_LIBRARIES: IconLibrary[] = [
     display: 'Material Symbols',
     color: chalk.magenta,
     packageName: 'material-symbols',
+    packageVersion: '^0.45.2',
     importStatement: "import 'material-symbols';",
   },
 ];

--- a/create-bestax/src/project-creator.ts
+++ b/create-bestax/src/project-creator.ts
@@ -237,6 +237,10 @@ export class ProjectCreator {
         const headEndMatch = htmlContent.match(/<\/head>/);
         if (headEndMatch) {
           const insertPosition = headEndMatch.index!;
+          // The ionicons version is pinned to an immutable unpkg URL. SRI
+          // integrity attributes are deliberately not added: the ionicons ESM
+          // loader dynamically imports per-icon chunks that cannot carry
+          // integrity hashes, so entry-file SRI would give false assurance.
           const ioniconScripts = `    <!-- Ionicons -->
     <script type="module" src="https://unpkg.com/ionicons@8.0.13/dist/ionicons/ionicons.esm.js"></script>
     <script nomodule src="https://unpkg.com/ionicons@8.0.13/dist/ionicons/ionicons.js"></script>
@@ -261,7 +265,8 @@ export class ProjectCreator {
           packageJson.dependencies = {};
         }
         if (library.packageName) {
-          packageJson.dependencies[library.packageName] = 'latest';
+          packageJson.dependencies[library.packageName] =
+            library.packageVersion ?? 'latest';
         }
         await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
 

--- a/create-bestax/src/validators.ts
+++ b/create-bestax/src/validators.ts
@@ -13,6 +13,13 @@ export function validateProjectName(value: string): boolean | string {
     return MESSAGES.PROJECT_NAME_TOO_LONG;
   }
 
+  // The regex below allows dots, so "." and ".." would pass and resolve to
+  // the current/parent directory — which --yes would then empty. Rejecting
+  // every leading-dot name closes that hole ("/" and "\" are already blocked).
+  if (value.startsWith('.')) {
+    return MESSAGES.PROJECT_NAME_DOT;
+  }
+
   if (!PROJECT_NAME_REGEX.test(value)) {
     return MESSAGES.PROJECT_NAME_INVALID_CHARS;
   }


### PR DESCRIPTION
# Pull Request

## Description

Fixes from a full security review of the repo (scaffolder, workflows, composite actions, repo docs). The written deep-dive report is delivered separately (not committed — it discloses details best kept out of the public repo until this merges).

- [x] create-bestax (`create-bestax`)
- [x] Other (please specify): GitHub Actions workflows, `.github/actions/verified-commit`, CODEOWNERS, SECURITY.md

**create-bestax (release-affecting — the squash commit title above cuts one patch release):**
- **Destructive path bug (high severity):** `.` and `..` passed project-name validation, resolved to the current/parent directory, and `--yes` then emptied that directory — `npm create bestax .. -- -y` wiped the parent dir on an end-user machine. All leading-dot names are now rejected (slashes were already blocked). Trade-off: `npm create bestax .` (scaffold into the current dir) is now rejected too, with a message saying to pass a directory name.
- **Floating `latest` deps:** generated apps pinned icon libraries to `latest`; they now get the caret ranges bulma-ui/docs are tested against (`@fortawesome/fontawesome-free ^7.2.0`, `@mdi/font ^7.4.47`, `material-icons ^1.13.14`, `material-symbols ^0.45.2`), with a drift-guard test. The pinned ionicons CDN tags now carry a comment documenting why SRI is deliberately omitted (the ESM loader dynamically imports per-icon chunks that can't carry integrity hashes).
- **Skill drift:** the generated `CLAUDE.md` advertises `bestax-icons`, but `sync-skills.mjs` never bundled it (omission from #302). It now ships.

**Workflow hardening (release-neutral `ci:`/`chore:`/`docs:` commits riding along):**
- `test-deploy.yml`: `github.head_ref` (attacker-chosen PR-branch text) was interpolated into the wrangler command; it's now sanitized to `[A-Za-z0-9-]` via a step output first.
- `verified-commit` action: inputs were interpolated directly into the github-script body and an `` execSync(`find …`) `` string — a latent injection sink for any future caller. Inputs now arrive via `env:` and `find` runs through `execFileSync` with an argument array. Behavior unchanged for the current caller (`visual-regression.yml`).
- `claude.yml`: added the same authoritative live collaborator role re-check its siblings use, plus `persist-credentials: false`. **Behavior change:** read-only COLLABORATOR/MEMBER accounts can no longer trigger `@claude` — intentional, matches `bestaxbot-reply.yml`/`claude-implement.yml`.
- `claude.yml`, `claude-implement.yml`, `claude-review.yml`, `ci.yml`: moved to the repo's own `permissions: {}` + per-job pattern; CI's PR-path jobs drop the unused `contents: write`/`pull-requests: write` and add `persist-credentials: false`. The `publish` job is untouched.
- New `.github/CODEOWNERS` (`/.github/ @allxsmith`) — inert until "Require review from Code Owners" is enabled in the `main` branch protection.

## Related Issue(s)

Related to #302 (bestax-icons skill was added there but never bundled into create-bestax).

## Type of Change

- [x] Bug fix
- [x] Other (please describe): security hardening of CI/workflows; SECURITY.md doc update

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui) — n/a, no bulma-ui changes
- [ ] My changes require a change to the documentation — n/a beyond SECURITY.md
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated — n/a, no command/convention changes

## Screenshots / Demos

Live smoke test after the fix (scratchpad, built CLI):

```
$ node create-bestax/dist/index.js .. -y
✖ Project name cannot start with a dot (names like "." or ".." would scaffold outside a new directory) — pass a directory name
✖ Operation cancelled   (exit 1, parent directory untouched)
```

Generated `package.json` now contains `"@mdi/font": "^7.4.47"` (no `latest`), and `.claude/skills/` includes `bestax-icons`.

## Additional Context

Verified locally: create-bestax jest suite 191/191 passing with coverage 97.9% stmts / 87.9% branches (thresholds 95/78); lint, typecheck, `format:check`, `gen:catalog:check`, `check:conformance` all green; every edited workflow YAML parses. This PR touches `.github/**`, so the AI loop won't drive it — it needs a human review and squash-merge. The squash-commit title should stay `fix(create-bestax): …` so exactly one create-bestax patch releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk9z4hXDifYFQg9VLjxEo3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk9z4hXDifYFQg9VLjxEo3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Bestax Icons skill to generated projects.
  * Added pinned versions for supported icon libraries in generated `package.json` files.
  * Added clearer guidance when project names begin with a dot.

* **Bug Fixes**
  * Prevented scaffolding projects with dot-prefixed names.
  * Improved preview deployment branch-name handling.
  * Added permission checks before automated workflows run.

* **Security**
  * Restricted workflow permissions to the jobs that require them.
  * Improved secure file discovery and disabled credential persistence during checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->