### PR TITLE
docs: security policy rewrite + supply-chain security guide

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,10 @@ Measures active in this repository and its release pipeline:
 - **Install scripts blocked by default** — pnpm refuses dependency
   install/postinstall scripts unless explicitly allow-listed
   (`allowBuilds` in `pnpm-workspace.yaml`).
-- **Dependency cooldown** — versions published less than 3 days ago won't
-  install (`minimumReleaseAge`), defending against just-published malicious
-  releases.
+- **Dependency cooldown** — by default, versions published less than 3 days
+  ago won't install (`minimumReleaseAge`), defending against just-published
+  malicious releases. One dev-only exception: `prettier` is excluded (and
+  pinned) so formatting stays deterministic; it is never shipped to users.
 - **Isolated `node_modules`** — pnpm's isolated linker prevents phantom
   (undeclared) dependencies from being imported.
 - **Frozen lockfile in CI** — builds and releases install with
@@ -45,8 +46,9 @@ Measures active in this repository and its release pipeline:
 - **Dependabot** — weekly, grouped dependency update PRs.
 
 Consumers can verify provenance themselves: the npm package pages show the
-attestation ("Provenance" section), and `npm audit signatures` checks
-registry signatures and provenance attestations for everything in your tree.
+attestation ("Provenance" section), and — in projects installed with the npm
+CLI — `npm audit signatures` checks registry signatures and provenance
+attestations for everything in your tree.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,51 @@
 
 ## Supported Versions
 
-We provide security updates for the following versions of the library. Older versions may still work but are not actively maintained for security issues. Please upgrade to a supported version if possible.
+Security fixes land on the **latest release line only** — currently
+`@allxsmith/bestax-bulma` 5.x and `create-bestax` 3.x. Both packages release
+automatically from `main` (semantic-release), so the latest published version
+is always the patched one. Older majors may still work but receive no security
+updates; please upgrade.
 
-| Version | Supported                                   |
-| ------- | ------------------------------------------- |
-| 2.x.x   | ✅                                          |
-| 1.x.x   | ✅ (use v2.x.x, it has no breaking changes) |
-| < 1.0   | ❌                                          |
+| Package                   | Supported    | Unsupported |
+| ------------------------- | ------------ | ----------- |
+| `@allxsmith/bestax-bulma` | 5.x (latest) | < 5.0       |
+| `create-bestax`           | 3.x (latest) | < 3.0       |
+
+## Supply-Chain Security
+
+Measures active in this repository and its release pipeline:
+
+- **Install scripts blocked by default** — pnpm refuses dependency
+  install/postinstall scripts unless explicitly allow-listed
+  (`allowBuilds` in `pnpm-workspace.yaml`).
+- **Dependency cooldown** — versions published less than 3 days ago won't
+  install (`minimumReleaseAge`), defending against just-published malicious
+  releases.
+- **Isolated `node_modules`** — pnpm's isolated linker prevents phantom
+  (undeclared) dependencies from being imported.
+- **Frozen lockfile in CI** — builds and releases install with
+  `pnpm install --frozen-lockfile`, so what ships is exactly what the
+  reviewed lockfile resolves. (The React 18/19 compatibility matrix is the
+  one deliberate exception: it re-resolves to pin the requested React major
+  for testing, and never publishes.)
+- **npm provenance** — both published packages set
+  `publishConfig.provenance`, so every release carries a signed attestation
+  linking the tarball to the exact commit and CI run that built it.
+- **OIDC trusted publishing** — releases authenticate to npm with
+  short-lived OIDC tokens minted per run; there is no long-lived `NPM_TOKEN`
+  to steal.
+- **SHA-pinned GitHub Actions** — every third-party action is pinned to a
+  full commit SHA, not a movable tag.
+- **CodeQL** — GitHub code scanning runs on JavaScript/TypeScript and the
+  workflow files themselves.
+- **Dependency review** — a workflow blocks PRs that introduce dependencies
+  with known advisories.
+- **Dependabot** — weekly, grouped dependency update PRs.
+
+Consumers can verify provenance themselves: the npm package pages show the
+attestation ("Provenance" section), and `npm audit signatures` checks
+registry signatures and provenance attestations for everything in your tree.
 
 ## Reporting a Vulnerability
 

--- a/docs/docs/guides/security.md
+++ b/docs/docs/guides/security.md
@@ -31,9 +31,11 @@ the full policy.
   [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
   and [`create-bestax`](https://www.npmjs.com/package/create-bestax) show a
   _Provenance_ section linking each version to its source commit and build.
-- **`npm audit signatures`** — run it in your project to check registry
-  signatures and provenance attestations for every package in your tree,
-  Bestax included.
+- **`npm audit signatures`** — in projects installed with the npm CLI, run it
+  to check registry signatures and provenance attestations for every package
+  in your tree, Bestax included. (It's an npm command — for pnpm or yarn
+  projects, rely on the lockfile guidance below and the provenance UI on
+  npmjs.com.)
 - **Lockfiles** — commit your lockfile and install with a frozen/ci install
   (`npm ci`, `pnpm install --frozen-lockfile`) so your builds resolve exactly
   what you reviewed. Bestax's own CI does the same.
@@ -44,10 +46,11 @@ The monorepo applies defense-in-depth against supply-chain attacks:
 
 - **Dependency install scripts are blocked by default.** pnpm only runs
   install/postinstall scripts for an explicit allow-list of native builders —
-  a compromised transitive dependency can't execute code at install time.
-- **A 3-day dependency cooldown.** Versions published less than 3 days ago
-  refuse to install, which defeats the common pattern where a hijacked
-  package's malicious release is yanked within hours.
+  any dependency outside that short list can't execute code at install time.
+- **A 3-day dependency cooldown.** By default, versions published less than 3
+  days ago refuse to install, which defeats the common pattern where a
+  hijacked package's malicious release is yanked within hours. (The dev-only
+  `prettier` formatter is the one pinned exclusion.)
 - **Isolated `node_modules`.** pnpm's isolated linker makes undeclared
   (phantom) dependencies fail loudly instead of silently resolving.
 - **Frozen-lockfile CI.** Build and release jobs install with
@@ -70,6 +73,6 @@ Please report privately — don't open a public issue:
   vulnerability** on the
   [repository](https://github.com/allxsmith/bestax/security).
 
-You'll get an acknowledgment within 48 hours and triage within 7 days; the
-full disclosure process is in
+You'll get an acknowledgment within 48 hours, and we aim to triage and
+confirm within 7 days; the full disclosure process is in
 [SECURITY.md](https://github.com/allxsmith/bestax/blob/main/SECURITY.md).

--- a/docs/docs/guides/security.md
+++ b/docs/docs/guides/security.md
@@ -1,0 +1,75 @@
+---
+title: Security
+sidebar_label: Security
+sidebar_position: 10
+---
+
+# Security
+
+How Bestax protects its supply chain, how you can verify what you install, and
+where to report a vulnerability.
+
+## What you install is what we built
+
+Both published packages — `@allxsmith/bestax-bulma` and `create-bestax` — are
+released with **npm provenance**: every version carries a signed attestation
+generated at publish time that links the tarball on the registry to the exact
+source commit and the public CI run that built it. Releases authenticate to
+npm via **OIDC trusted publishing** (short-lived, per-run tokens), so there is
+no long-lived npm token that could leak and be used to push a rogue release.
+
+Only the **latest release line** of each package receives security fixes
+(currently bestax-bulma 5.x and create-bestax 3.x). Releases are fully
+automated from `main` via semantic-release, so the newest published version is
+always the patched one — staying current is the supported posture. See
+[SECURITY.md](https://github.com/allxsmith/bestax/blob/main/SECURITY.md) for
+the full policy.
+
+## Verify it yourself
+
+- **Provenance on npmjs.com** — the package pages for
+  [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+  and [`create-bestax`](https://www.npmjs.com/package/create-bestax) show a
+  _Provenance_ section linking each version to its source commit and build.
+- **`npm audit signatures`** — run it in your project to check registry
+  signatures and provenance attestations for every package in your tree,
+  Bestax included.
+- **Lockfiles** — commit your lockfile and install with a frozen/ci install
+  (`npm ci`, `pnpm install --frozen-lockfile`) so your builds resolve exactly
+  what you reviewed. Bestax's own CI does the same.
+
+## How the repository is protected
+
+The monorepo applies defense-in-depth against supply-chain attacks:
+
+- **Dependency install scripts are blocked by default.** pnpm only runs
+  install/postinstall scripts for an explicit allow-list of native builders —
+  a compromised transitive dependency can't execute code at install time.
+- **A 3-day dependency cooldown.** Versions published less than 3 days ago
+  refuse to install, which defeats the common pattern where a hijacked
+  package's malicious release is yanked within hours.
+- **Isolated `node_modules`.** pnpm's isolated linker makes undeclared
+  (phantom) dependencies fail loudly instead of silently resolving.
+- **Frozen-lockfile CI.** Build and release jobs install with
+  `--frozen-lockfile`; the only exception is the React 18/19 compatibility
+  matrix, which deliberately re-resolves React for testing and never
+  publishes.
+- **SHA-pinned GitHub Actions.** Every third-party action is pinned to a full
+  commit SHA, so a moved tag can't inject code into the pipeline.
+- **CodeQL, dependency review, and Dependabot.** Code scanning covers the
+  TypeScript sources and the workflow files themselves; a dependency-review
+  gate blocks PRs that introduce dependencies with known advisories; grouped
+  Dependabot PRs keep the tree current on a weekly cadence.
+
+## Reporting a vulnerability
+
+Please report privately — don't open a public issue:
+
+- Email [security@bestax.io](mailto:security@bestax.io), or
+- Use GitHub's private reporting: **Security → Advisories → Report a
+  vulnerability** on the
+  [repository](https://github.com/allxsmith/bestax/security).
+
+You'll get an acknowledgment within 48 hours and triage within 7 days; the
+full disclosure process is in
+[SECURITY.md](https://github.com/allxsmith/bestax/blob/main/SECURITY.md).

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -232,6 +232,10 @@ const config = {
                 label: 'NPM',
                 href: 'https://www.npmjs.com/package/@allxsmith/bestax-bulma',
               },
+              {
+                label: 'Security',
+                to: '/docs/guides/security',
+              },
             ],
           },
         ],


### PR DESCRIPTION
Closes #182 — part 3 of 3 of the supply-chain initiative (① Actions hardening and ② the pnpm migration #180 already shipped; this documents what's live).

## What

- **`SECURITY.md`**
  - Supported Versions corrected to **latest only** — the table listed stale 2.x/1.x; it now says bestax-bulma 5.x / create-bestax 3.x, with the rationale (semantic-release from `main` means latest is always the patched line).
  - New **Supply-Chain Security** section listing the live measures. Every claim was verified against the repo before writing: `allowBuilds` + `minimumReleaseAge` + isolated linker in `pnpm-workspace.yaml`, `--frozen-lockfile` in `ci.yml` (with the React-matrix exception called out honestly), `publishConfig.provenance` in both package.json files, OIDC trusted publishing (no `NPM_TOKEN`) in the release job, SHA-pinned actions, CodeQL default setup (js/ts + actions), `dependency-review.yml`, weekly grouped Dependabot.
  - Reporting flow kept unchanged.
- **New docs page** `docs/docs/guides/security.md` (`/docs/guides/security`) — the same posture from the consumer angle: what provenance/OIDC publishing means for them, how to verify (`npm audit signatures`, npmjs.com Provenance section, lockfile hygiene), latest-only support, and the private reporting channels.
- **Footer link**: "Security" added under *More* in `docusaurus.config.js`.

## Notes

- The guides sidebar is autogenerated, so the page slots in via `sidebar_position: 10` (last, after Helpers).
- Adding a page extends the generated LLM index (`llms.txt`) — no existing URLs move.

## Verification

`pnpm all` green, including the Docusaurus production build (which fails on broken links — the new page's internal links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security guidance covering supported release lines and vulnerability reporting.
  * Documented supply-chain protections, package provenance verification, trusted publishing, dependency safeguards, and secure installation practices.
  * Added a Security link to the documentation site footer for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->