### PR TITLE
ci: least-privilege workflow tokens; pin AI thread ops to gh-thread helper

### DIFF
--- a/.github/scripts/gh-thread.sh
+++ b/.github/scripts/gh-thread.sh
@@ -16,6 +16,9 @@
 #
 # Usage:
 #   gh-thread list <pr-number>            # unresolved+resolved threads, JSON
+#                                         # (paginated: output is an ARRAY of
+#                                         # response pages; read every page's
+#                                         # ...reviewThreads.nodes)
 #   gh-thread reply <thread-id> <body>    # reply inside a review thread
 #   gh-thread resolve <thread-id>         # resolve a review thread
 set -euo pipefail
@@ -37,12 +40,19 @@ case "$CMD" in
     case "$PR" in
       *[!0-9]*) echo "gh-thread: pr-number must be numeric, got: $PR" >&2; exit 64 ;;
     esac
-    gh api graphql \
-      -f query='query($o:String!,$r:String!,$n:Int!){
+    # --paginate follows reviewThreads.pageInfo so >100 threads can't be
+    # silently dropped (the convergence gate reads this list); --slurp wraps
+    # the pages in a JSON array. comments(first:100) is the per-thread API
+    # maximum — a thread longer than that is pathological, and the tail is
+    # the part that matters least.
+    gh api graphql --paginate --slurp \
+      -f query='query($o:String!,$r:String!,$n:Int!,$endCursor:String){
         repository(owner:$o,name:$r){pullRequest(number:$n){
-          reviewThreads(first:100){nodes{
-            id isResolved path line
-            comments(first:50){nodes{author{login} body url}}}}}}}' \
+          reviewThreads(first:100,after:$endCursor){
+            pageInfo{hasNextPage endCursor}
+            nodes{
+              id isResolved path line
+              comments(first:100){nodes{author{login} body url}}}}}}}' \
       -f o="${REPO%/*}" -f r="${REPO#*/}" -F n="$PR"
     ;;
   reply)

--- a/.github/scripts/gh-thread.sh
+++ b/.github/scripts/gh-thread.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# gh-thread — the ONLY GitHub GraphQL surface for the AI-loop Claude sessions
+# that ingest untrusted review-thread text (claude-pr-loop.yml fix/verify,
+# bestaxbot-reply.yml).
+#
+# Those sessions deliberately do NOT get `Bash(gh api:*)`: anyone on a public
+# repo can reply inside a review thread, and a prompt-injected agent holding
+# the bestaxbot PAT plus raw `gh api` could write to anything the token can
+# reach (merge/close/label/release) or post secrets publicly. This wrapper
+# pins the API surface to exactly the three thread operations the loop needs.
+#
+# The workflows stage this file onto PATH from origin/main (never from the PR
+# branch being worked on), so a checked-out branch can neither miss it nor
+# substitute its own copy. Keep it under .github/ — the loop's protected-path
+# gate and the agents' Edit/Write deny rules both cover that prefix.
+#
+# Usage:
+#   gh-thread list <pr-number>            # unresolved+resolved threads, JSON
+#   gh-thread reply <thread-id> <body>    # reply inside a review thread
+#   gh-thread resolve <thread-id>         # resolve a review thread
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is not set}"
+
+usage() {
+  echo "usage: gh-thread list <pr-number> | reply <thread-id> <body> | resolve <thread-id>" >&2
+  exit 64
+}
+
+[ $# -ge 1 ] || usage
+CMD="$1"
+shift
+
+case "$CMD" in
+  list)
+    PR="${1:?usage: gh-thread list <pr-number>}"
+    case "$PR" in
+      *[!0-9]*) echo "gh-thread: pr-number must be numeric, got: $PR" >&2; exit 64 ;;
+    esac
+    gh api graphql \
+      -f query='query($o:String!,$r:String!,$n:Int!){
+        repository(owner:$o,name:$r){pullRequest(number:$n){
+          reviewThreads(first:100){nodes{
+            id isResolved path line
+            comments(first:50){nodes{author{login} body url}}}}}}}' \
+      -f o="${REPO%/*}" -f r="${REPO#*/}" -F n="$PR"
+    ;;
+  reply)
+    THREAD="${1:?usage: gh-thread reply <thread-id> <body>}"
+    BODY="${2:?usage: gh-thread reply <thread-id> <body>}"
+    gh api graphql \
+      -f query='mutation($t:ID!,$b:String!){
+        addPullRequestReviewThreadReply(
+          input:{pullRequestReviewThreadId:$t,body:$b}){comment{id url}}}' \
+      -f t="$THREAD" -f b="$BODY"
+    ;;
+  resolve)
+    THREAD="${1:?usage: gh-thread resolve <thread-id>}"
+    gh api graphql \
+      -f query='mutation($t:ID!){
+        resolveReviewThread(input:{threadId:$t}){thread{id isResolved}}}' \
+      -f t="$THREAD"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/.github/workflows/bestaxbot-reply.yml
+++ b/.github/workflows/bestaxbot-reply.yml
@@ -125,6 +125,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Stage the review-thread helper onto PATH from origin/main. The Claude
+      # session below reads whole PR threads — including replies from
+      # untrusted commenters — and holds the bestaxbot PAT, so it gets NO raw
+      # `gh api`: gh-thread (list/reply/resolve) is its entire GraphQL
+      # surface. Staged from origin/main so a later `git checkout` of an
+      # older PR branch can neither remove nor replace it.
+      - name: Stage gh-thread helper
+        if: steps.perm.outputs.allowed == 'true'
+        run: |
+          set -euo pipefail
+          git show origin/main:.github/scripts/gh-thread.sh > /tmp/gh-thread
+          sudo install -m 0755 /tmp/gh-thread /usr/local/bin/gh-thread
+
       - name: Setup pnpm
         if: steps.perm.outputs.allowed == 'true'
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -162,7 +175,7 @@ jobs:
             --max-turns 120
             --model claude-opus-4-8
             --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*),Edit(scripts/check-conformance.mjs),MultiEdit(scripts/check-conformance.mjs),Write(scripts/check-conformance.mjs),Edit(scripts/conformance-baseline.json),MultiEdit(scripts/conformance-baseline.json),Write(scripts/conformance-baseline.json)"
-            --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"
+            --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh-thread:*)"
           prompt: |
             REPO: ${{ github.repository }}
             NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -172,7 +185,8 @@ jobs:
             You are bestaxbot, replying to a TRUSTED human (verified
             write/triage access) who either reviewed a PR you authored or
             tagged @bestaxbot. Read the triggering review/comment
-            (`gh pr view`, `gh api`, `gh issue view`) and the PR diff, and
+            (`gh pr view --json reviews,comments,body`, `gh-thread list <PR>`
+            for review threads, `gh issue view`) and the PR diff, and
             respond like a helpful, straight-talking human engineer.
 
             CAN_FIX tells you whether a code fix is even possible here. When
@@ -208,8 +222,9 @@ jobs:
             Commit messages are Conventional Commits; feat|fix|perf|refactor|
             style REQUIRE a scope of bulma-ui, docs, or create-bestax.
 
-            REPLY in a review thread with `gh api`, not an MCP reply tool:
-              gh api graphql -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' -f t=<thread-id> -f b="<your reply>"
+            REPLY in a review thread with the gh-thread helper, not an MCP
+            reply tool (raw `gh api` is not available here):
+              gh-thread reply <thread-id> "<your reply>"
             For a top-level note use `gh pr comment` (or `gh issue comment`).
             Write in plain English, first person — say what you did and why.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Read-only by default: the test jobs execute PR-authored code (pnpm install,
+# tests, builds) — including AI-pushed claude/* branches — so the token they
+# can reach must not be able to write. The publish job re-declares the write
+# scopes semantic-release needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   build-and-test:
@@ -20,6 +23,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          # This job runs PR code; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -122,6 +127,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # This job runs PR code; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -333,6 +333,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Stage the review-thread helper onto PATH from origin/main — NEVER
+      # from the PR branch (an older claude/* branch may predate it, and the
+      # branch's own copy must never be the one that runs). The Claude
+      # session below ingests untrusted review-thread text, so it gets NO
+      # raw `gh api`: gh-thread (list/reply/resolve) is its entire GraphQL
+      # surface (fetch-depth: 0 above guarantees origin/main exists).
+      - name: Stage gh-thread helper
+        run: |
+          set -euo pipefail
+          git show origin/main:.github/scripts/gh-thread.sh > /tmp/gh-thread
+          sudo install -m 0755 /tmp/gh-thread /usr/local/bin/gh-thread
+
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
@@ -373,11 +385,14 @@ jobs:
           # The prompt's protected-path exclusions are enforced here, not just
           # stated: --disallowedTools deny rules take precedence over the
           # Edit/MultiEdit/Write allows in --allowedTools.
+          # No Bash(gh api:*): this session reads review threads that anyone
+          # on a public repo can reply into, and it holds the bestaxbot PAT —
+          # thread ops go through the pinned gh-thread helper instead.
           claude_args: |
             --max-turns 120
             --model claude-opus-4-8[1m]
             --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*),Edit(scripts/check-conformance.mjs),MultiEdit(scripts/check-conformance.mjs),Write(scripts/check-conformance.mjs),Edit(scripts/conformance-baseline.json),MultiEdit(scripts/conformance-baseline.json),Write(scripts/conformance-baseline.json)"
-            --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh api:*)"
+            --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh-thread:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.gate.outputs.pr }}
@@ -436,7 +451,7 @@ jobs:
             conversation unfold in real time: a reply should land on each
             thread as you address it, not 15 minutes later.
             1. List them with:
-               gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{id isResolved path line comments(first:50){nodes{author{login} body url}}}}}}}' -f o=<owner> -f r=<repo> -F n=<PR>
+               gh-thread list <PR>
                Work only on threads with isResolved=false whose FIRST comment
                author is coderabbitai, copilot*, or claude. Skip claude
                threads whose last reply already starts with "Fixed in ". ALSO
@@ -446,12 +461,13 @@ jobs:
                re-engage such a thread once the REVIEWER has replied to your
                refutation (then answer that rebuttal: fix if it convinced you,
                or hold your ground once and let the loop escalate to a human).
-               HOW TO REPLY — reply INSIDE the review thread with `gh api`, not
-               an MCP tool. The ONLY MCP tool available here is
-               mcp__github_inline_comment__create_inline_comment (a NEW inline
-               comment); there is NO MCP "reply" tool, so reaching for one just
-               burns denials. Use the thread id from the query above:
-                 gh api graphql -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' -f t=<thread-id> -f b="<your reply>"
+               HOW TO REPLY — reply INSIDE the review thread with the
+               gh-thread helper, not an MCP tool. The ONLY MCP tool available
+               here is mcp__github_inline_comment__create_inline_comment (a
+               NEW inline comment); there is NO MCP "reply" tool and NO raw
+               `gh api`, so reaching for either just burns denials. Use the
+               thread id from the listing above:
+                 gh-thread reply <thread-id> "<your reply>"
                (A brand-new top-level note is `gh pr comment`.)
             2. Handle threads ONE AT A TIME and FINISH each — including its
                reply — before starting the next. Do NOT defer replies to the
@@ -485,9 +501,9 @@ jobs:
                - CodeRabbit threads: reply conversationally (fix explanation or
                  refutation); never resolve them — CodeRabbit verifies and
                  resolves its own on its next review.
-               - Copilot threads: after replying, resolve them with the
-                 resolveReviewThread GraphQL mutation (Copilot never resolves
-                 its own).
+               - Copilot threads: after replying, resolve them with
+                 `gh-thread resolve <thread-id>` (Copilot never resolves its
+                 own).
             4. Once every thread is handled, commit any remaining changes
                (conventional; feat|fix|perf|refactor|style require scope
                bulma-ui|docs|create-bestax), run the gates for what you
@@ -601,6 +617,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Same rationale as the fix job: the verifier reads untrusted thread
+      # replies, so its only GraphQL surface is the pinned gh-thread helper,
+      # staged from origin/main rather than the PR branch.
+      - name: Stage gh-thread helper
+        run: |
+          set -euo pipefail
+          git show origin/main:.github/scripts/gh-thread.sh > /tmp/gh-thread
+          sudo install -m 0755 /tmp/gh-thread /usr/local/bin/gh-thread
+
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
@@ -625,7 +650,7 @@ jobs:
           claude_args: |
             --max-turns 25
             --model claude-opus-4-8
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*)"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh-thread:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.gate.outputs.pr }}
@@ -639,18 +664,20 @@ jobs:
             you conclude. Do not rubber-stamp.
 
             1. List unresolved review threads whose FIRST comment author is
-               claude (your earlier review) using the reviewThreads GraphQL
-               query (fetch id, path, and every comment's author + body).
-               Reply INSIDE a thread with `gh api` (you have no MCP tools here):
-                 gh api graphql -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' -f t=<thread-id> -f b="<your reply>"
-               Resolve with the resolveReviewThread mutation.
+               claude (your earlier review) with:
+                 gh-thread list <PR>
+               Reply INSIDE a thread with the gh-thread helper (you have no
+               MCP tools and no raw `gh api` here):
+                 gh-thread reply <thread-id> "<your reply>"
+               Resolve with:
+                 gh-thread resolve <thread-id>
 
             2. VERIFY — for a thread whose LAST reply STARTS WITH "Fixed in"
                (the fix agent claims a fix): re-examine the current code there
                and run the relevant test.
                - Genuinely fixed → reply "Verified fixed — <one plain sentence
-                 on what you checked>." then resolve it with the
-                 resolveReviewThread mutation.
+                 on what you checked>." then resolve it with
+                 `gh-thread resolve <thread-id>`.
                - NOT actually fixed → reply precisely what is still wrong, with
                  a code citation; do NOT resolve. The fix agent gets another
                  round.

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -20,9 +20,13 @@ on:
       - 'create-bestax/**'
       - '.github/workflows/visual-regression.yml'
 
+# Read-only by default: the matrix job executes PR-controlled code, and the
+# scaffolded-app installs run with --ignore-workspace — i.e. OUTSIDE
+# pnpm-workspace.yaml's supply-chain hardening (blocked install scripts,
+# minimumReleaseAge) — so the token in reach must not be able to write. Only
+# the workflow_dispatch-gated commit job below gets contents: write.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   visual-regression:
@@ -55,6 +59,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          # This job runs PR-controlled code; don't leave the token in
+          # .git/config.
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -169,6 +176,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: visual-regression
     if: inputs.update_snapshots && github.event_name == 'workflow_dispatch'
+    permissions:
+      # verified-commit pushes the updated baselines via the git data API.
+      # workflow_dispatch-only (never reachable from a pull_request event).
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Implements findings 1, 3, and 4 from the workflow prompt-injection security review (finding 2 — the deep reviewer's `gh api:*` — and the AI_LOOP_PAT migration are deliberately out of scope here).

## 1. AI agents lose raw `gh api` (HIGH)

The claude-pr-loop **fix**/**verify** sessions and **bestaxbot-reply** read entire review threads — including replies from arbitrary users on this public repo — while the fix/reply agents hold the bestaxbot PAT. `Bash(gh api:*)` gave a prompt-injected session read-write access to everything the token can reach, plus a public exfiltration channel.

- New `.github/scripts/gh-thread.sh`: `list <pr>` / `reply <thread-id> <body>` / `resolve <thread-id>` — the loop's three GraphQL thread operations and nothing else.
- Each affected job stages it onto PATH **from `origin/main`**, never from the checked-out PR branch, so older `claude/*` branches still work and the branch's own copy is never the one that runs. It lives under `.github/`, so the protected-path gate and the agents' Edit/Write deny rules already cover it.
- Allowlists swap `Bash(gh api:*)` → `Bash(gh-thread:*)`; prompts updated to match (listing, thread replies, Copilot/verify resolves).

## 3. ci.yml: read-only default token (MEDIUM)

`build-and-test` and `react-compat` execute PR-authored code — including AI-pushed `claude/*` branches — with a `contents: write` token persisted in `.git/config`. Workflow default is now `contents: read` (the `publish` job re-declares its own scopes), and both test jobs set `persist-credentials: false`.

## 4. visual-regression.yml: same treatment (MEDIUM)

The matrix job runs scaffolded-app installs with `--ignore-workspace`, i.e. outside pnpm-workspace.yaml's install-script blocking and release-age cooldown, while holding a write-capable persisted token. Workflow default is now `contents: read` + `persist-credentials: false`; `contents: write` moved down to the `workflow_dispatch`-gated `commit-screenshots` job (verified-commit uses the git data API, so that one scope suffices).

## Notes for review

- All `gh api` calls in trusted `run:` shell steps (gate, terminal-state, continue, handoff, halt) are unchanged — only the Claude session allowlists narrowed.
- In-flight `ai-loop` PRs don't need a rebase: the helper is staged from `origin/main`, not the PR branch.
- Defense-in-depth, not a silver bullet: an injected agent with `sed -i`/`pnpm run` can still do local mischief inside the job — the remaining hard boundary is the PAT migration (fine-grained, single-repo, no `workflow` scope), tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `gh-thread` helper CLI to list PR review threads, post replies, and resolve threads.
* **Security**
  * Tightened GitHub Actions token permissions to read-only by default.
  * Disabled git credential persistence during checkout to reduce exposure.
* **Automation**
  * Updated Claude-driven review workflows to use `gh-thread` for thread operations and adjusted tool permissions/prompts accordingly.
* **CI**
  * Ensured only the screenshot baseline update job has elevated write access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->