### PR TITLE
ci: triage on plain pull_request with explicit github token; skip fork PRs

### DIFF
--- a/.claude/commands/triage-dedupe.md
+++ b/.claude/commands/triage-dedupe.md
@@ -16,8 +16,9 @@ run locally), and `AUTOCLOSE` (`active` or `off`; assume `off` locally). If
 
 1. `gh issue view NUMBER --repo REPO --json state,title,body,comments` — if
    the issue is not open, stop.
-2. Marker check — does any existing comment by a claude bot account contain
-   `<!-- ai-triage:dedupe -->`?
+2. Marker check — does any existing bot-authored comment contain
+   `<!-- ai-triage:dedupe -->`? (Match the marker + a bot author, not a
+   specific login — the workflow posts as github-actions[bot].)
    - `TRIGGER=opened` and marker present → stop (already triaged).
    - `TRIGGER=labeled` and marker present → continue; at the end REFRESH
      that comment instead of posting a new one: if it is your most recent

--- a/.claude/commands/triage-find-duplicate-prs.md
+++ b/.claude/commands/triage-find-duplicate-prs.md
@@ -14,8 +14,9 @@ assume `labeled` locally). If `NUMBER` is missing, ask.
 
 1. `gh pr view NUMBER --repo REPO --json state,title,body,files,comments` —
    if the PR is not open, stop.
-2. Marker check — a claude-bot comment containing
-   `<!-- ai-triage:find-duplicate-prs -->`:
+2. Marker check — a bot-authored comment containing
+   `<!-- ai-triage:find-duplicate-prs -->` (match marker + bot author, not
+   a specific login — the workflow posts as github-actions[bot]):
    - `TRIGGER=opened` and marker present → stop.
    - `TRIGGER=labeled` and marker present → continue; at the end refresh
      that comment (`gh pr comment NUMBER --repo REPO --edit-last --body ...`

--- a/.claude/commands/triage-find-issues.md
+++ b/.claude/commands/triage-find-issues.md
@@ -14,8 +14,9 @@ EXACTLY ONE comment (or nothing). Context from the caller: `REPO`, `NUMBER`
 
 1. `gh pr view NUMBER --repo REPO --json state,title,body,comments` — if the
    PR is not open, stop.
-2. Marker check — a claude-bot comment containing
-   `<!-- ai-triage:find-issues -->`:
+2. Marker check — a bot-authored comment containing
+   `<!-- ai-triage:find-issues -->` (match marker + bot author, not a
+   specific login — the workflow posts as github-actions[bot]):
    - `TRIGGER=opened` and marker present → stop.
    - `TRIGGER=labeled` and marker present → continue; at the end refresh
      that comment (`gh pr comment NUMBER --repo REPO --edit-last --body ...`

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -42,12 +42,26 @@ name: AI Triage
 #   - auto runs skip bot authors (bestaxbot, *[bot]), claude/* heads, and
 #     PRs whose body already links an issue — AI-loop PRs self-link by
 #     construction, so auto-triage would only duplicate the loop.
+#   - SAME-REPO PRs ONLY (both the auto and label paths). This uses plain
+#     `pull_request`, NOT `pull_request_target`, and the job `if` skips
+#     fork heads explicitly. Fork PRs therefore never get triage — the
+#     same trade-off oven-sh/bun makes. Deliberate, two reasons:
+#       1. `pull_request_target` hands fork-triggered runs our secrets and
+#          a write token; the no-PR-checkout + allowlist hardening below
+#          made that survivable, but same-repo-only removes the risk class
+#          instead of mitigating it.
+#       2. The Claude action's OIDC→app-token exchange 401s under
+#          `pull_request_target` anyway (#312) — it was never exercisable.
+#     Do not switch this back to `pull_request_target` without reading
+#     #312. Fork runs would also lack secrets under `pull_request`; the
+#     explicit guard just turns that failure into a clean, silent skip.
 #   - This never checks out PR head code — only the base repo's default
-#     branch — so `pull_request_target` is safe here. The Claude tool
-#     allowlist is GET-only gh commands + the two comment commands + Task
-#     (the fan-out sub-agents) — no `gh api`, which could also
-#     POST/PATCH/DELETE, and no file-editing tools, because the session
-#     ingests untrusted issue/PR text.
+#     branch (defense in depth, and it keeps the job honest if the fork
+#     guard is ever loosened). The Claude tool allowlist is GET-only gh
+#     commands + the two comment commands + Task (the fan-out sub-agents)
+#     — no `gh api`, which could also POST/PATCH/DELETE, and no
+#     file-editing tools, because the session ingests untrusted issue/PR
+#     text.
 #
 # KILL SWITCHES: AI_TRIAGE_MODE=off (this workflow only) or
 # AI_LOOP_ENABLED=false (all Claude spend, repo-wide).
@@ -56,7 +70,7 @@ name: AI Triage
 # "Run one-shot AI triage: related issues + duplicates (sonnet; triage+ only)".
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, labeled]
   issues:
     types: [opened, labeled]
@@ -92,9 +106,14 @@ jobs:
     #   - 'auto' ⇒ both paths live.
     # labeled events additionally require the ai-triage label from a real
     # user; anything else is a silent no-op that spends no usage.
+    # The head-repo guard kills fork PRs (auto AND label paths) before any
+    # step runs — see SECURITY above; issue events have no pull_request and
+    # pass the null arm.
     if: |
       vars.AI_LOOP_ENABLED == 'true' &&
       vars.AI_TRIAGE_MODE != 'off' &&
+      (github.event.pull_request == null ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
       (
         (github.event.action == 'labeled' &&
          github.event.label.name == 'ai-triage' &&
@@ -108,7 +127,8 @@ jobs:
       contents: read # checkout of the base default branch
       pull-requests: write # post the triage comment on PRs; remove the label
       issues: write # post the triage comment on issues; budget marker; remove the label
-      id-token: write # OIDC exchange for the Claude OAuth token
+      # No id-token: the Claude step gets github_token explicitly, which
+      # short-circuits the action's OIDC→app-token exchange (#312).
     steps:
       # Layer 2 (authoritative, zero Claude usage). Two shapes:
       #   labeled → GitHub already restricts labeling to triage+; re-verify
@@ -238,12 +258,12 @@ jobs:
           echo "budget charged: $NEXT/$LIMIT for $TODAY — running triage"
           out run true
 
-      # Check out ONLY the base repo's default branch — never the PR head.
-      # Under pull_request_target that keeps untrusted PR code out of the
-      # workspace; the triage agent reads PR content via read-only gh
-      # commands. The checkout also provides the .claude/commands/ triage
-      # commands the session runs. No pnpm/node setup and no dependency
-      # install: this job never runs project code.
+      # Check out ONLY the base repo's default branch — never the PR head
+      # (untrusted PR code stays out of the workspace; the triage agent
+      # reads PR content via read-only gh commands). The checkout also
+      # provides the .claude/commands/ triage commands the session runs.
+      # No pnpm/node setup and no dependency install: this job never runs
+      # project code.
       - name: Checkout base default branch
         if: steps.gate.outputs.run == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -255,10 +275,14 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
-          # OAuth token only — posts as claude[bot]. Safe: these are plain
-          # top-level comments; the loop's state machine only classifies
-          # review threads.
+          # CLAUDE_CODE_OAUTH_TOKEN pays for the session. github_token is
+          # passed explicitly (Bun-style) so the action skips its OIDC→app
+          # token exchange (#312); triage comments therefore post as
+          # github-actions[bot] — anything probing for them must match the
+          # marker + a Bot-type author, never a specific login. Bonus:
+          # GITHUB_TOKEN-authored comments can't re-trigger workflows.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Task is required for the commands' fan-out search sub-agents
           # (they inherit this same allowlist). Still no `gh api` and no
           # Edit/Write — the session ingests untrusted issue/PR text.

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -333,6 +333,14 @@ jobs:
       # re-pressable button and never wedges "on". Removal uses only
       # GITHUB_TOKEN, so an unauthorized labeling still spends zero Claude
       # usage. Opened runs have no label to remove.
+      #
+      # Known residual: labeling a FORK PR wedges the label (the job-level
+      # fork guard skips this step too), and it is not fixable under plain
+      # `pull_request` — fork-triggered runs cap GITHUB_TOKEN at read-only,
+      # so even a standalone unlabel job's DELETE would 403. Accepted:
+      # fork PRs are never triaged anyway, the stuck label is inert, and a
+      # maintainer removes it by hand. Unwedging would need
+      # `pull_request_target`, which this workflow deliberately dropped.
       - name: Remove ai-triage label
         if: always() && github.event.action == 'labeled'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,8 @@ Separately, `ai-triage` runs a one-shot sonnet triage session that comments with
 issues/duplicates: automatic on new issues/PRs when `AI_TRIAGE_MODE=auto` (outside authors
 capped at `AI_TRIAGE_DAILY_LIMIT`/day via a counter comment on issue #290; items opened by
 triage+ collaborators are uncapped), or on demand via the label
-(triage+ only, budget-exempt; auto-removed after the run). Flagged duplicates may be
+(triage+ only, budget-exempt; auto-removed after the run). Fork PRs are never triaged
+(same-repo `pull_request` only — never `pull_request_target`; see #312). Flagged duplicates may be
 auto-closed after 14 days per `AI_TRIAGE_AUTOCLOSE` (see the ai-development docs guide).
 Stale automation: PRs go `stale` at 30 days and close 14 days later — except Claude-assisted
 PRs (`claude-assisted` label or bestaxbot author), which skip that sweep and instead close

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -62,7 +62,11 @@ PRs authored by the loop move through a small label lifecycle:
 ### AI triage
 
 New issues and PRs can get an automatic triage comment: likely duplicates (issues), the open
-issues a PR probably resolves, and overlapping PRs. Three repository variables control it:
+issues a PR probably resolves, and overlapping PRs. Triage comments are posted by
+`github-actions[bot]`. **Only same-repo PRs are triaged** — PRs opened from forks are always
+skipped, automatic and label alike (the workflow deliberately avoids GitHub's
+`pull_request_target` trigger, so fork-originated events can never run with repository
+secrets); issues have no such restriction. Three repository variables control it:
 
 - **`AI_TRIAGE_MODE`** — `auto` (new issues/PRs are triaged automatically and the label still
   works), `label` (opt-in only; the default when unset), or `off` (disables both automatic

--- a/scripts/auto-close-duplicates.mjs
+++ b/scripts/auto-close-duplicates.mjs
@@ -5,7 +5,7 @@
  * Ported from oven-sh/bun's scripts/auto-close-duplicates.ts, with the
  * objection window widened from 3 to 14 days (deliberate owner choice).
  *
- * An issue is a close candidate when its LATEST claude[bot] comment carries
+ * An issue is a close candidate when its LATEST bot-authored comment carries
  * the `<!-- ai-triage:dedupe -->` idempotency marker AND a machine-parseable
  * `Duplicate of #N` line (posted by the ai-triage workflow, PR A of #289).
  * The candidate is closed only if ALL of these hold:
@@ -81,15 +81,17 @@ export function isBot(user) {
 }
 
 /**
- * Find the LATEST comment authored by claude[bot] that carries the dedupe
- * marker and a parseable `Duplicate of #N`. Returns
- * { comment, target } or null. `comments` must be in ascending created order
- * (the REST API default for issue comments).
+ * Find the LATEST bot-authored comment that carries the dedupe marker and a
+ * parseable `Duplicate of #N`. Matched by marker + Bot author, never a
+ * specific login (Bun's convention): the triage workflow posts via
+ * GITHUB_TOKEN as github-actions[bot] since #312, while pre-#312 comments
+ * are claude[bot]. Returns { comment, target } or null. `comments` must be
+ * in ascending created order (the REST API default for issue comments).
  */
 export function findMarkerComment(comments) {
   for (let i = comments.length - 1; i >= 0; i--) {
     const c = comments[i];
-    if (c.user?.login !== 'claude[bot]' || c.user?.type !== 'Bot') continue;
+    if (!isBot(c.user)) continue;
     if (!c.body?.includes(MARKER)) continue;
     const m = c.body.match(DUPLICATE_RE);
     if (!m) continue;


### PR DESCRIPTION
# Pull Request

## Description

Fixes #312 — the ai-triage Claude step died at startup with `401 Unauthorized - Invalid OIDC token`: the claude-code-action's OIDC→app-token exchange rejects tokens minted under `pull_request_target` (the `issues` and `pull_request` paths were never affected — the July 11 triage on #240 and every deep review prove the exchange works there).

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`) — ai-development guide notes the new scope + comment author
- [x] Other: `.github/workflows/ai-triage.yml`, `.claude/commands/triage-*.md`, `scripts/auto-close-duplicates.mjs`, root `CLAUDE.md`

**The fix (Bun-style), plus a deliberate scope cut:**

1. **Trigger: `pull_request_target` → plain `pull_request`**, and the job `if` gains a head-repo guard. **Fork PRs are no longer triaged at all** — auto and label paths alike, exactly the trade-off oven-sh/bun makes. Rationale in the workflow header: rather than mitigating the `pull_request_target` risk class (secrets + write token exposed to fork-triggered runs), we remove it. Fork runs would lack secrets under `pull_request` anyway; the guard turns that failure mode into a clean silent skip.
2. **`github_token: ${{ secrets.GITHUB_TOKEN }}` on the Claude step** — verified against the pinned action's source: a provided token short-circuits before any OIDC code runs. `id-token: write` is dropped from the job. Bonus: GITHUB_TOKEN-authored comments can never re-trigger workflows.
3. **Authorship ripple, handled everywhere:** triage comments now post as `github-actions[bot]` instead of `claude[bot]`. Everything that probes for them is now author-agnostic (marker + Bot-type author, never a specific login — Bun's convention):
   - the three `.claude/commands/triage-*.md` marker pre-checks (their `--edit-last` refresh already had the "only if it's your most recent comment" guard, so no clobber risk);
   - `scripts/auto-close-duplicates.mjs` `findMarkerComment`, which hard-required `claude[bot]` and **would have matched nothing ever again** after this change. Old `claude[bot]` comments still match (smoke-tested: latest-bot-wins across both identities; human comments containing a spoofed marker are still ignored).

## Related Issue(s)

Fixes #312

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [x] Other: CI workflow + automation scripts

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed (ai-development guide, root CLAUDE.md, workflow header comments)
- [x] All new and existing tests passed (workflow YAML parses; `node --check` + behavioral smoke of `findMarkerComment`; prettier + `check:conformance` green)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (root CLAUDE.md updated)

Note: this PR touches `.github/**`, a loop-refused path — it's driven manually, not by the AI loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pohc8xLkdx4gwXkW3xd7up)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved triage marker detection by matching any bot-authored triage comment markers (not a specific bot identity).
  * Updated duplicate auto-close to prefer the latest qualifying bot-authored triage comment.

* **Security & Reliability**
  * Automatic triage now runs only for same-repository pull requests; fork-originated pull requests are skipped.
  * Tightened permissions and token handling to avoid broader access during triage.

* **Documentation**
  * Clarified same-repository-only triage behavior and updated workflow/marker notes accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->