### PR TITLE
docs: honest bundle-size story — measured CSS sizes, JS-only claim fixed

### DIFF
--- a/docs/docs/guides/getting-started/installation.md
+++ b/docs/docs/guides/getting-started/installation.md
@@ -337,9 +337,9 @@ pnpm dlx webpack-bundle-analyzer stats.json
 
 ### Expected Sizes
 
-- **bestax-bulma**: ~40KB (gzipped)
-- **Bulma CSS**: ~30KB (gzipped)
-- **With PurgeCSS**: Can reduce Bulma CSS further
+- **bestax-bulma JS**: ~49KB min+gzip for the _entire_ library — with named imports, tree shaking means your app ships only the components it uses.
+- **CSS (`bestax.css`, the combined Bulma + extras bundle)**: ~800KB minified on disk, ~82KB gzipped over the wire. CSS is not tree-shaken — the whole file ships regardless of which components you use. Leaner prebuilt variations and a modular Sass path exist; see [CSS Variations](/docs/guides/getting-started/variations#file-size-comparison) for measured sizes and [Optimizing CSS Size](/docs/guides/getting-started/optimizing-css) for the full trimming playbook.
+- **PurgeCSS** can strip unused selectors further, but it is not wired into any scaffold or template — [Optimizing CSS Size](/docs/guides/getting-started/optimizing-css#lever-2--purge-unused-selectors-build-step-biggest-win) covers the opt-in setup and the safelist patterns dynamic class names need to survive the purge.
 
 ---
 

--- a/docs/docs/guides/getting-started/modular.md
+++ b/docs/docs/guides/getting-started/modular.md
@@ -278,15 +278,15 @@ These require no SCSS toolchain — swap the import path and you're done.
 
 ## Bundle size expectations
 
-- **`bestax.css`**: ~80KB gzipped (Bulma + extras, minified). Fine for most apps.
-- **Hand-rolled modular SCSS**: can cut that significantly if you only use a handful of components, but expect diminishing returns after gzip.
-- **JS bundle**: tree shaking is automatic with named imports — you don't need to do anything beyond avoiding `import * as ...`.
+- **`bestax.css`**: ~800KB minified on disk, **~82KB gzipped** over the wire (Bulma + extras). The raw number is what your bundler reports at build time; the gzipped number is what users download. Fine for most apps — but it ships in full regardless of how many components you use, because bundlers don't tree-shake CSS. See the full [File Size Comparison](/docs/guides/getting-started/variations#file-size-comparison) for every prebuilt variation, and [Optimizing CSS Size](/docs/guides/getting-started/optimizing-css) for the complete trimming playbook.
+- **Hand-rolled modular SCSS**: can cut the CSS significantly if you only use a handful of components, but expect diminishing returns after gzip.
+- **JS bundle**: the entire library is ~49KB min+gzip, and tree shaking is automatic with named imports — you don't need to do anything beyond avoiding `import * as ...`.
 
 ## When to go modular
 
 Use this checklist before switching away from `bestax.css`:
 
 1. **Ship first with `bestax.css`.** Don't premature-optimize — many apps never need anything else.
-2. **Measure.** Use `webpack-bundle-analyzer`, `rollup-plugin-visualizer`, or your bundler's built-in stats to confirm CSS size is actually a problem.
-3. **Try a prebuilt variant** (`bestax-no-helpers.css`, `bestax-no-dark-mode.css`) before reaching for SCSS — often enough to hit the target.
+2. **Measure.** Use `webpack-bundle-analyzer`, `rollup-plugin-visualizer`, or your bundler's built-in stats to confirm CSS size is actually a problem — and judge by the **gzipped** transfer size, not the raw `dist/` number.
+3. **Try a prebuilt variant** (`bestax-no-helpers.css` saves ~15KB gzipped, `bestax-no-dark-mode.css` ~12KB) before reaching for SCSS — often enough to hit the target.
 4. **Only then reach for modular SCSS**, and keep the imports in a single entry file so they're easy to audit as the app grows.

--- a/docs/docs/guides/getting-started/optimizing-css.md
+++ b/docs/docs/guides/getting-started/optimizing-css.md
@@ -6,9 +6,9 @@ sidebar_position: 6
 
 # Optimizing CSS Size
 
-The JavaScript side of bestax-bulma is lean and tree-shakable (~21 KB gzipped for typical
-usage) — but the **stylesheet** ships all of Bulma plus the bestax extras, whatever your app
-uses. With the default `complete` flavor, that's roughly **800 KB of CSS (~82 KB gzipped)** in
+The JavaScript side of bestax-bulma is lean and tree-shakable (~49 KB min+gzip for the
+_entire_ library — apps ship only the components they import) — but the **stylesheet** ships
+all of Bulma plus the bestax extras, whatever your app uses. With the default `complete` flavor, that's roughly **800 KB of CSS (~82 KB gzipped)** in
 a production build, essentially constant regardless of how many components you render.
 
 That's a reasonable default — every component just works, helpers included — but if CSS weight

--- a/docs/docs/guides/getting-started/variations.md
+++ b/docs/docs/guides/getting-started/variations.md
@@ -268,18 +268,31 @@ This approach allows you to:
 
 ## File Size Comparison
 
-| Variation            | Gzipped Size | Description                      |
-| -------------------- | ------------ | -------------------------------- |
-| Complete             | ~78KB        | Full-featured, recommended       |
-| Prefixed (`bestax-`) | ~80KB        | Full + `bestax-` class prefix    |
-| No Helpers           | ~63KB        | No helper utilities              |
-| No Helpers, Prefixed | ~64KB        | No helpers + `bestax-` prefix    |
-| No Dark Mode         | ~66KB        | Light theme only                 |
-| Custom Brand         | ~78KB        | Custom prefix, built from source |
+Measured from the published `dist/` output (minified, then gzipped). Sizes drift a little between releases — treat them as close approximations.
+
+| Variation            | Raw (minified) | Gzipped | Description                      |
+| -------------------- | -------------- | ------- | -------------------------------- |
+| Complete             | ~800KB         | ~82KB   | Full-featured, recommended       |
+| Prefixed (`bestax-`) | ~875KB         | ~84KB   | Full + `bestax-` class prefix    |
+| No Helpers           | ~595KB         | ~67KB   | No helper utilities              |
+| No Helpers, Prefixed | ~655KB         | ~69KB   | No helpers + `bestax-` prefix    |
+| No Dark Mode         | ~680KB         | ~70KB   | Light theme only                 |
+| Custom Brand         | varies         | ~82KB   | Custom prefix, built from source |
 
 :::tip
-All sizes are approximate gzipped transfer sizes. Enable gzip compression on your server to achieve these transfer sizes.
+**Both columns matter, for different reasons.** The raw size is what lands in your `dist/` folder and what bundlers like Vite report at build time — seeing `~800KB` of CSS there is expected with the Complete variation, not a build misconfiguration. The gzipped size is what users actually download, provided your server or CDN has compression enabled (most do by default; Brotli compresses a little further).
 :::
+
+### What ends up in your build
+
+Bundlers don't tree-shake CSS: the variation you import lands in your production build essentially as-is, no matter how many components you use. That makes the numbers above your floor, and there are two levers to lower it:
+
+1. **Pick a leaner variation** (this page) — a one-line change to your import. Skipping helpers saves ~15KB gzipped; skipping dark mode saves ~12KB.
+2. **Build only what you use with modular Sass** — see [Modular](/docs/guides/getting-started/modular) for importing individual Bulma and bestax partials.
+
+For the full playbook — including an opt-in PurgeCSS step that strips unused selectors — see [Optimizing CSS Size](/docs/guides/getting-started/optimizing-css).
+
+The bestax React library itself is a separate, much smaller cost: ~49KB min+gzip of JS for the _entire_ library, and tree-shaking means your app only ships the components it imports.
 
 ---
 

--- a/docs/src/components/HomepageFeatures/index.js
+++ b/docs/src/components/HomepageFeatures/index.js
@@ -21,9 +21,10 @@ const FeatureList = [
     Svg: require('@site/static/img/card/iconmonstr-connection-2.svg').default,
     description: (
       <>
-        Ultra-lightweight: Only 21KB gzipped. 3-20x smaller than most React UI
-        libraries. Just one dependency — Bulma — shipped automatically. Clean
-        installs, reduced bundle size, and fewer security concerns.
+        Lean runtime: the entire library is ~49KB min+gzip of JS, and
+        tree-shakeable ESM means your app ships only what it imports. Styles are
+        your call — pick a prebuilt Bulma CSS flavor or trim further with
+        modular Sass. Just one dependency: Bulma.
       </>
     ),
   },


### PR DESCRIPTION
## Summary

Fixes #193.

The homepage claimed "Ultra-lightweight: Only 21KB gzipped" — a stale JS-only number presented as the whole story, while a default scaffold ships ~800KB (~82KB gzip) of CSS. This PR makes every size figure in the docs measured, consistent, and honest about the JS/CSS split. The **active** half of #193's ask (a skill that optimizes a project's CSS) is split out to #323 (`bestax-optimize`).

## Measurements (fresh build of main; the source of every figure in this PR)

| File | Raw (minified) | Gzipped |
|---|---|---|
| `bestax.css` (complete) | 801 KB | ~81-82 KB |
| `versions/bestax-prefixed.css` | 873 KB | ~83-84 KB |
| `versions/bestax-no-helpers.css` | 595 KB | ~66-67 KB |
| `versions/bestax-no-helpers-prefixed.css` | 654 KB | ~68-69 KB |
| `versions/bestax-no-dark-mode.css` | 679 KB | ~69-70 KB |
| JS, **entire** library (esbuild `--minify` + gzip on `dist/index.esm.js`) | 170 KB | **~49 KB** |

(Gzip ranges = level 9 vs default level 6. Doc tables standardized on the set already published in `optimizing-css.md`, which sits at the top of these ranges.)

## Changes

- **Homepage** (`docs/src/components/HomepageFeatures/index.js`): replaced the 21KB claim with the honest split — ~49KB min+gzip for the *entire* library, tree-shakeable so apps ship only what they import, CSS is a deliberate flavor choice.
- **`variations.md`**: File Size Comparison gains a **Raw (minified)** column — the raw number is what Vite reports and what #193's reporter measured; new "What ends up in your build" section states plainly that bundlers don't tree-shake CSS and names the two levers, linking `optimizing-css.md`.
- **`modular.md`**: "Bundle size expectations" updated (~80KB → measured ~800KB raw / ~82KB gzip); the variant step in the checklist now quotes real savings (no-helpers ~15KB, no-dark-mode ~12KB gzip).
- **`installation.md`**: "Expected Sizes" replaced (~40KB JS / ~30KB CSS were both wrong); PurgeCSS mention now points at the opt-in recipe instead of implying it's wired in.
- **`optimizing-css.md`**: the last remaining ~21KB claim updated; table untouched (it was already the accurate reference).

## Verification

- Docs build passes (`turbo run build --filter=@allxsmith/bestax-docs`) — link/anchor validation included.
- `grep -rn "21KB\|~40KB\|~30KB\|~78KB\|~80KB gzip"` over getting-started + homepage: clean.
- `prettier --check`: clean.

Follow-up: #323 (bestax-optimize skill).

https://claude.ai/code/session_015LmRYeZUeev2ZDXpcumGE5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bundle-size guidance with clearer raw, minified, and gzipped measurements.
  * Clarified CSS tree-shaking limitations, optional PurgeCSS usage, and modular Sass optimization.
  * Added savings estimates for leaner CSS variants and refined guidance on measuring transfer sizes.
  * Updated JavaScript bundle-size information and tree-shaking explanations.

* **Website Content**
  * Refreshed the “Lightweight and Efficient” feature description with current performance and styling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->