### PR TITLE
chore(bulma-ui): wire eslint-plugin-storybook recommended rules

### DIFF
--- a/bulma-ui/src/QuickStart.stories.tsx
+++ b/bulma-ui/src/QuickStart.stories.tsx
@@ -109,5 +109,4 @@ function DemoApp() {
 
 export const InteractiveDemo: Story = {
   render: () => <DemoApp />,
-  name: 'Interactive Demo',
 };

--- a/bulma-ui/src/columns/Column.stories.tsx
+++ b/bulma-ui/src/columns/Column.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Columns } from './Columns';
 import { Column } from './Column';
 import { Notification } from '../elements/Notification';

--- a/bulma-ui/src/columns/Columns.stories.tsx
+++ b/bulma-ui/src/columns/Columns.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Columns } from './Columns';
 import type { BulmaGapValue } from '../grid/Grid';
 import { Column } from './Column';

--- a/bulma-ui/src/elements/Button.stories.tsx
+++ b/bulma-ui/src/elements/Button.stories.tsx
@@ -210,7 +210,6 @@ export const AllColors: Story = {
       )}
     </Buttons>
   ),
-  name: 'All Colors',
 };
 
 // Sizes
@@ -224,7 +223,6 @@ export const AllSizes: Story = {
       ))}
     </Buttons>
   ),
-  name: 'All Sizes',
 };
 
 // Light variant
@@ -385,7 +383,6 @@ export const ButtonGroup: Story = {
       <Button color="primary">Right</Button>
     </Buttons>
   ),
-  name: 'Button Group',
 };
 
 // Ghost — renders a button that looks like a link

--- a/bulma-ui/src/elements/Code.stories.tsx
+++ b/bulma-ui/src/elements/Code.stories.tsx
@@ -79,7 +79,6 @@ export const VariableName: Story = {
       The <Code>userName</Code> variable stores the current user&apos;s name.
     </Paragraph>
   ),
-  name: 'Variable Name',
 };
 
 export const FunctionCall: Story = {
@@ -88,7 +87,6 @@ export const FunctionCall: Story = {
       Use <Code>Array.map()</Code> to transform each element in the array.
     </Paragraph>
   ),
-  name: 'Function Call',
 };
 
 export const CommandLine: Story = {
@@ -97,7 +95,6 @@ export const CommandLine: Story = {
       Run <Code>npm install</Code> to install the dependencies.
     </Paragraph>
   ),
-  name: 'Command Line',
 };
 
 export const WithPrimaryColor: Story = {
@@ -115,7 +112,6 @@ export const WithBackground: Story = {
     textColor: 'dark',
     p: '1',
   },
-  name: 'With Background',
 };
 
 export const AllColors: Story = {
@@ -129,7 +125,6 @@ export const AllColors: Story = {
       <Code textColor="danger">danger code</Code>
     </div>
   ),
-  name: 'All Colors',
 };
 
 export const FilePath: Story = {
@@ -139,7 +134,6 @@ export const FilePath: Story = {
       change the default values.
     </Paragraph>
   ),
-  name: 'File Path',
 };
 
 export const KeyboardShortcut: Story = {
@@ -148,5 +142,4 @@ export const KeyboardShortcut: Story = {
       Press <Code>Ctrl + C</Code> to copy and <Code>Ctrl + V</Code> to paste.
     </Paragraph>
   ),
-  name: 'Keyboard Shortcut',
 };

--- a/bulma-ui/src/elements/Divider.stories.tsx
+++ b/bulma-ui/src/elements/Divider.stories.tsx
@@ -73,7 +73,6 @@ export const WithVerticalMargin: Story = {
       </div>
     ),
   ],
-  name: 'With Vertical Margin',
 };
 
 export const PrimaryBackground: Story = {
@@ -89,7 +88,6 @@ export const PrimaryBackground: Story = {
       </div>
     ),
   ],
-  name: 'Primary Background',
 };
 
 export const AllColors: Story = {
@@ -110,7 +108,6 @@ export const AllColors: Story = {
       <Block>End</Block>
     </div>
   ),
-  name: 'All Colors',
 };
 
 export const SeparatingSections: Story = {
@@ -126,5 +123,4 @@ export const SeparatingSections: Story = {
       <p>This is the third section of content.</p>
     </div>
   ),
-  name: 'Separating Sections',
 };

--- a/bulma-ui/src/elements/Emphasis.stories.tsx
+++ b/bulma-ui/src/elements/Emphasis.stories.tsx
@@ -78,7 +78,6 @@ export const PrimaryColor: Story = {
     children: 'Primary emphasized text',
     textColor: 'primary',
   },
-  name: 'Primary Color',
 };
 
 export const InfoColor: Story = {
@@ -86,7 +85,6 @@ export const InfoColor: Story = {
     children: 'Note this important detail',
     textColor: 'info',
   },
-  name: 'Info Color',
 };
 
 export const WithBackground: Story = {
@@ -96,7 +94,6 @@ export const WithBackground: Story = {
     textColor: 'dark',
     p: '1',
   },
-  name: 'With Background',
 };
 
 export const InlineWithText: Story = {
@@ -121,7 +118,6 @@ export const AllColors: Story = {
       <Emphasis textColor="danger">Danger emphasis</Emphasis>
     </div>
   ),
-  name: 'All Colors',
 };
 
 export const QuotationStyle: Story = {
@@ -130,7 +126,6 @@ export const QuotationStyle: Story = {
       As the saying goes, <Emphasis>actions speak louder than words</Emphasis>.
     </Paragraph>
   ),
-  name: 'Quotation Style',
 };
 
 export const TechnicalTerm: Story = {
@@ -140,5 +135,4 @@ export const TechnicalTerm: Story = {
       times without changing the result beyond the initial application.
     </Paragraph>
   ),
-  name: 'Technical Term',
 };

--- a/bulma-ui/src/elements/Figure.stories.tsx
+++ b/bulma-ui/src/elements/Figure.stories.tsx
@@ -77,7 +77,6 @@ export const WithCaption: Story = {
       <Figure.Caption>This is a caption for the image</Figure.Caption>
     </Figure>
   ),
-  name: 'With Caption',
 };
 
 export const CaptionWithColor: Story = {
@@ -99,7 +98,6 @@ export const WithBackground: Story = {
       <Figure.Caption mt="2">Figure with background and padding</Figure.Caption>
     </Figure>
   ),
-  name: 'With Background',
 };
 
 export const CenteredCaption: Story = {
@@ -115,7 +113,6 @@ export const CenteredCaption: Story = {
       </Figure.Caption>
     </Figure>
   ),
-  name: 'Centered Caption',
 };
 
 export const MultipleFigures: Story = {
@@ -135,7 +132,6 @@ export const MultipleFigures: Story = {
       </Figure>
     </div>
   ),
-  name: 'Multiple Figures',
 };
 
 export const CodeFigure: Story = {
@@ -151,5 +147,4 @@ export const CodeFigure: Story = {
       </Figure.Caption>
     </Figure>
   ),
-  name: 'Code Figure',
 };

--- a/bulma-ui/src/elements/Icon.stories.tsx
+++ b/bulma-ui/src/elements/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { Icon } from './Icon';
 import {
   validColors,

--- a/bulma-ui/src/elements/Link.stories.tsx
+++ b/bulma-ui/src/elements/Link.stories.tsx
@@ -179,7 +179,6 @@ export const AllColors: Story = {
       </Link>
     </div>
   ),
-  name: 'All Colors',
 };
 
 export const InlineWithText: Story = {

--- a/bulma-ui/src/elements/LinkButton.stories.tsx
+++ b/bulma-ui/src/elements/LinkButton.stories.tsx
@@ -149,7 +149,6 @@ export const AllColors: Story = {
       ))}
     </Buttons>
   ),
-  name: 'All Colors',
 };
 
 // All colors in ghost variant
@@ -188,7 +187,6 @@ export const AllSizes: Story = {
       ))}
     </Buttons>
   ),
-  name: 'All Sizes',
 };
 
 // Click counter showing all variants fire onClick
@@ -220,7 +218,6 @@ const LinkButtonStateDemo = () => {
 
 export const ClickCounter: Story = {
   render: () => <LinkButtonStateDemo />,
-  name: 'Click Counter',
 };
 
 // In-form context
@@ -276,7 +273,6 @@ const LinkButtonInFormDemo = () => {
 
 export const InFormContext: Story = {
   render: () => <LinkButtonInFormDemo />,
-  name: 'In Form Context',
 };
 
 // Polymorphic `as` — render as a custom component (e.g. a router Link)

--- a/bulma-ui/src/elements/ListItem.stories.tsx
+++ b/bulma-ui/src/elements/ListItem.stories.tsx
@@ -117,7 +117,6 @@ export const WithBackground: Story = {
       </Content>
     ),
   ],
-  name: 'With Background',
 };
 
 export const AllColors: Story = {
@@ -133,7 +132,6 @@ export const AllColors: Story = {
       </UnorderedList>
     </Content>
   ),
-  name: 'All Colors',
 };
 
 export const InOrderedList: Story = {
@@ -146,7 +144,6 @@ export const InOrderedList: Story = {
       </OrderedList>
     </Content>
   ),
-  name: 'In Ordered List',
 };
 
 export const WithValue: Story = {
@@ -178,5 +175,4 @@ export const WithSpacing: Story = {
       </UnorderedList>
     </Content>
   ),
-  name: 'With Spacing',
 };

--- a/bulma-ui/src/elements/OrderedList.stories.tsx
+++ b/bulma-ui/src/elements/OrderedList.stories.tsx
@@ -99,7 +99,6 @@ export const AlphabeticLowercase: Story = {
       </OrderedList>
     </Content>
   ),
-  name: 'Alphabetic Lowercase',
 };
 
 export const AlphabeticUppercase: Story = {
@@ -112,7 +111,6 @@ export const AlphabeticUppercase: Story = {
       </OrderedList>
     </Content>
   ),
-  name: 'Alphabetic Uppercase',
 };
 
 export const RomanNumerals: Story = {
@@ -125,7 +123,6 @@ export const RomanNumerals: Story = {
       </OrderedList>
     </Content>
   ),
-  name: 'Roman Numerals',
 };
 
 export const StartingNumber: Story = {
@@ -177,7 +174,6 @@ export const WithBackground: Story = {
       </OrderedList>
     </Content>
   ),
-  name: 'With Background',
 };
 
 export const NestedList: Story = {
@@ -196,5 +192,4 @@ export const NestedList: Story = {
       </OrderedList>
     </Content>
   ),
-  name: 'Nested List',
 };

--- a/bulma-ui/src/elements/Paragraph.stories.tsx
+++ b/bulma-ui/src/elements/Paragraph.stories.tsx
@@ -145,7 +145,6 @@ export const AllColors: Story = {
       <Paragraph textColor="danger">Danger paragraph</Paragraph>
     </div>
   ),
-  name: 'All Colors',
 };
 
 export const StackedParagraphs: Story = {
@@ -165,7 +164,6 @@ export const StackedParagraphs: Story = {
       </Paragraph>
     </div>
   ),
-  name: 'Stacked Paragraphs',
 };
 
 export const HighlightedParagraph: Story = {
@@ -175,5 +173,4 @@ export const HighlightedParagraph: Story = {
     textColor: 'white',
     p: '4',
   },
-  name: 'Highlighted Paragraph',
 };

--- a/bulma-ui/src/elements/Pre.stories.tsx
+++ b/bulma-ui/src/elements/Pre.stories.tsx
@@ -80,7 +80,6 @@ const name = "World";
 console.log(\`\${greeting}, \${name}!\`);`}</Code>
     </Pre>
   ),
-  name: 'With Code Element',
 };
 
 export const DarkBackground: Story = {
@@ -91,7 +90,6 @@ npm run build`,
     textColor: 'white',
     p: '4',
   },
-  name: 'Dark Background',
 };
 
 export const LightBackground: Story = {
@@ -103,7 +101,6 @@ export const LightBackground: Story = {
     bgColor: 'light',
     p: '4',
   },
-  name: 'Light Background',
 };
 
 export const PrimaryAccent: Story = {
@@ -116,7 +113,6 @@ const config = {
     textColor: 'primary',
     p: '3',
   },
-  name: 'Primary Accent',
 };
 
 export const TerminalOutput: Story = {
@@ -132,7 +128,6 @@ dist/index.js  45.23 kB
 ✓ built in 2.34s`}
     </Pre>
   ),
-  name: 'Terminal Output',
 };
 
 export const MultipleCodeBlocks: Story = {
@@ -148,7 +143,6 @@ const add = (a: number, b: number): number => a + b;`}</Code>
       </Pre>
     </div>
   ),
-  name: 'Multiple Code Blocks',
 };
 
 export const AsciiArt: Story = {

--- a/bulma-ui/src/elements/Span.stories.tsx
+++ b/bulma-ui/src/elements/Span.stories.tsx
@@ -130,7 +130,6 @@ export const AllColors: Story = {
       <Span textColor="danger">Danger Span</Span>
     </div>
   ),
-  name: 'All Colors',
 };
 
 export const InlineWithText: Story = {
@@ -150,5 +149,4 @@ export const HighlightedText: Story = {
     textColor: 'dark',
     p: '1',
   },
-  name: 'Highlighted Text',
 };

--- a/bulma-ui/src/elements/Strong.stories.tsx
+++ b/bulma-ui/src/elements/Strong.stories.tsx
@@ -78,7 +78,6 @@ export const PrimaryColor: Story = {
     children: 'Primary strong text',
     textColor: 'primary',
   },
-  name: 'Primary Color',
 };
 
 export const DangerColor: Story = {
@@ -86,7 +85,6 @@ export const DangerColor: Story = {
     children: 'Important warning!',
     textColor: 'danger',
   },
-  name: 'Danger Color',
 };
 
 export const WithBackground: Story = {
@@ -96,7 +94,6 @@ export const WithBackground: Story = {
     textColor: 'dark',
     p: '1',
   },
-  name: 'With Background',
 };
 
 export const InlineWithText: Story = {
@@ -121,7 +118,6 @@ export const AllColors: Story = {
       <Strong textColor="danger">Danger strong</Strong>
     </div>
   ),
-  name: 'All Colors',
 };
 
 export const Emphasis: Story = {

--- a/bulma-ui/src/elements/UnorderedList.stories.tsx
+++ b/bulma-ui/src/elements/UnorderedList.stories.tsx
@@ -99,7 +99,6 @@ export const WithBackground: Story = {
       </UnorderedList>
     </Content>
   ),
-  name: 'With Background',
 };
 
 export const NestedList: Story = {
@@ -118,7 +117,6 @@ export const NestedList: Story = {
       </UnorderedList>
     </Content>
   ),
-  name: 'Nested List',
 };
 
 export const ColoredItems: Story = {
@@ -132,7 +130,6 @@ export const ColoredItems: Story = {
       </UnorderedList>
     </Content>
   ),
-  name: 'Colored Items',
 };
 
 export const WithSpacing: Story = {
@@ -145,5 +142,4 @@ export const WithSpacing: Story = {
       </UnorderedList>
     </Content>
   ),
-  name: 'With Spacing',
 };

--- a/bulma-ui/src/form/File.stories.tsx
+++ b/bulma-ui/src/form/File.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import File from './File';
 import { Icon } from '../elements/Icon';
 import { Field } from './Field';

--- a/bulma-ui/src/grid/Cell.stories.tsx
+++ b/bulma-ui/src/grid/Cell.stories.tsx
@@ -32,8 +32,6 @@ export const ColumnStart = () => (
   </Grid>
 );
 
-ColumnStart.storyName = 'Column Start';
-
 export const ColumnFromEnd = () => (
   <Grid isFixed fixedCols={4}>
     <Cell>
@@ -56,8 +54,6 @@ export const ColumnFromEnd = () => (
     </Cell>
   </Grid>
 );
-
-ColumnFromEnd.storyName = 'Column From End';
 
 export const ColumnSpan = () => (
   <Grid isFixed fixedCols={4}>
@@ -82,8 +78,6 @@ export const ColumnSpan = () => (
   </Grid>
 );
 
-ColumnSpan.storyName = 'Column Span';
-
 export const RowStart = () => (
   <Grid isFixed fixedCols={4}>
     <Cell>
@@ -106,8 +100,6 @@ export const RowStart = () => (
     </Cell>
   </Grid>
 );
-
-RowStart.storyName = 'Row Start';
 
 export const RowSpan = () => (
   <Grid isFixed fixedCols={4}>
@@ -133,5 +125,3 @@ export const RowSpan = () => (
     </Cell>
   </Grid>
 );
-
-RowSpan.storyName = 'Row Span';

--- a/bulma-ui/src/grid/Grid.stories.tsx
+++ b/bulma-ui/src/grid/Grid.stories.tsx
@@ -25,8 +25,6 @@ const cellNodes = Array.from({ length: cellCount }, (_, i) => (
 
 export const SmartGrid = () => <Grid>{cellNodes}</Grid>;
 
-SmartGrid.storyName = 'Smart Grid';
-
 export const MinimumColumnWidth = () => {
   const [minCol, setMinCol] = useState<number>(4);
 
@@ -48,8 +46,6 @@ export const MinimumColumnWidth = () => {
     </div>
   );
 };
-
-MinimumColumnWidth.storyName = 'Minimum Column Width';
 
 export const Gap = () => {
   const [gap, setGap] = useState<number>(2);
@@ -73,8 +69,6 @@ export const Gap = () => {
   );
 };
 
-Gap.storyName = 'Gap';
-
 export const ColumnGap = () => {
   const [columnGap, setColumnGap] = useState<number>(2);
 
@@ -96,8 +90,6 @@ export const ColumnGap = () => {
     </div>
   );
 };
-
-ColumnGap.storyName = 'Column Gap';
 
 export const RowGap = () => {
   const [rowGap, setRowGap] = useState<number>(2);
@@ -121,8 +113,6 @@ export const RowGap = () => {
   );
 };
 
-RowGap.storyName = 'Row Gap';
-
 export const FixedGrid = () => {
   // Only 12 cells for this story
   const fixedCellNodes = Array.from({ length: 12 }, (_, i) => (
@@ -133,7 +123,6 @@ export const FixedGrid = () => {
 
   return <Grid isFixed>{fixedCellNodes}</Grid>;
 };
-FixedGrid.storyName = 'Fixed Grid';
 
 export const FixedGridCols = () => {
   const [fixedCols, setFixedCols] = useState<number>(4);
@@ -165,7 +154,6 @@ export const FixedGridCols = () => {
     </div>
   );
 };
-FixedGridCols.storyName = 'Fixed Grid Cols';
 
 const breakpoints = [
   { label: 'Mobile', key: 'Mobile', prop: 'fixedColsMobile' },
@@ -247,7 +235,6 @@ export const FixedGridColsByBreakpoint = () => {
     </div>
   );
 };
-FixedGridColsByBreakpoint.storyName = 'Fixed Grid Cols By Breakpoint';
 
 export const FixedGridAutoCount = () => {
   // 16 cells for this story
@@ -265,4 +252,3 @@ export const FixedGridAutoCount = () => {
     </Grid>
   );
 };
-FixedGridAutoCount.storyName = 'Fixed Grid Auto Count';

--- a/bulma-ui/src/helpers/useBulmaClasses.stories.tsx
+++ b/bulma-ui/src/helpers/useBulmaClasses.stories.tsx
@@ -248,7 +248,6 @@ export const Colors: Story = {
       <Button color="danger">Danger</Button>
     </Buttons>
   ),
-  name: 'Colors',
 };
 
 export const BackgroundColors: Story = {
@@ -280,7 +279,6 @@ export const BackgroundColors: Story = {
       </Column>
     </Columns>
   ),
-  name: 'Background Colors',
 };
 
 export const ColorShades: Story = {
@@ -303,7 +301,6 @@ export const ColorShades: Story = {
       </Button>
     </Buttons>
   ),
-  name: 'Color Shades',
 };
 
 export const BackgroundColorShades: Story = {
@@ -336,7 +333,6 @@ export const BackgroundColorShades: Story = {
       </Column>
     </Columns>
   ),
-  name: 'Background Color Shades',
 };
 
 export const CombinedColorShades: Story = {
@@ -384,7 +380,6 @@ export const CombinedColorShades: Story = {
       </Column>
     </Columns>
   ),
-  name: 'Combined Color Shades',
 };
 
 export const Margin: Story = {
@@ -401,7 +396,6 @@ export const Margin: Story = {
       </Buttons>
     </>
   ),
-  name: 'Margin',
 };
 
 export const TextSize: Story = {
@@ -413,7 +407,6 @@ export const TextSize: Story = {
       <Notification textSize="7">Size 7</Notification>
     </>
   ),
-  name: 'Text Size',
 };
 
 export const TextAlign: Story = {
@@ -424,7 +417,6 @@ export const TextAlign: Story = {
       <Box textAlign="left">Left aligned text</Box>
     </>
   ),
-  name: 'Text Align',
 };
 
 export const TextTransform: Story = {
@@ -456,7 +448,6 @@ export const TextTransform: Story = {
       </Content>
     </>
   ),
-  name: 'Text Transform',
 };
 
 export const TextWeight: Story = {
@@ -488,7 +479,6 @@ export const TextWeight: Story = {
       </Content>
     </>
   ),
-  name: 'Text Weight',
 };
 
 export const FontFamily: Story = {
@@ -526,7 +516,6 @@ export const FontFamily: Story = {
       </Content>
     </>
   ),
-  name: 'Font Family',
 };
 
 export const Visibility: Story = {
@@ -538,7 +527,6 @@ export const Visibility: Story = {
       <Button>Visible</Button>
     </Buttons>
   ),
-  name: 'Visibility',
 };
 
 export const Overflow: Story = {
@@ -548,7 +536,6 @@ export const Overflow: Story = {
       box.
     </Box>
   ),
-  name: 'Overflow',
 };
 
 export const Overlay: Story = {
@@ -568,7 +555,6 @@ export const Overlay: Story = {
       />
     </Box>
   ),
-  name: 'Overlay',
 };
 
 export const Interaction: Story = {
@@ -578,7 +564,6 @@ export const Interaction: Story = {
       <Box interaction="clickable">This box is clickable.</Box>
     </>
   ),
-  name: 'Interaction',
 };
 
 export const Cursor: Story = {
@@ -588,7 +573,6 @@ export const Cursor: Story = {
       <Box cursor="help">Cursor: help</Box>
     </>
   ),
-  name: 'Cursor',
 };
 
 export const Radius: Story = {
@@ -598,12 +582,10 @@ export const Radius: Story = {
       <Button>Normal</Button>
     </Buttons>
   ),
-  name: 'Radius',
 };
 
 export const Shadowless: Story = {
   render: () => <Box shadow="shadowless">This box has no shadow.</Box>,
-  name: 'Shadowless',
 };
 
 export const ClassName: Story = {
@@ -715,7 +697,6 @@ export const DisplayValues: Story = {
       </Block>
     </Box>
   ),
-  name: 'Display Values',
 };
 
 export const ViewportSpecificDisplay: Story = {
@@ -1204,7 +1185,6 @@ export const ComplexResponsiveLayout: Story = {
       </Box>
     </Box>
   ),
-  name: 'Complex Responsive Layout',
 };
 
 export const Float: Story = {
@@ -1427,7 +1407,6 @@ export const ClearfixDemo: Story = {
       </div>
     </Box>
   ),
-  name: 'Clearfix Demo',
 };
 
 export const RelativePosition: Story = {
@@ -1579,7 +1558,6 @@ export const RelativePosition: Story = {
       </div>
     </Box>
   ),
-  name: 'Relative Position',
 };
 
 // --- Viewport-Specific Properties Stories ---
@@ -1953,5 +1931,4 @@ export const FlexItemProperties: Story = {
       </Block>
     </Box>
   ),
-  name: 'Flex Item Properties',
 };

--- a/bulma-ui/src/layout/Container.stories.tsx
+++ b/bulma-ui/src/layout/Container.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { Container } from './Container';
 import { Notification } from '../elements/Notification';
 

--- a/bulma-ui/src/layout/Footer.stories.tsx
+++ b/bulma-ui/src/layout/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import Footer from './Footer';
 import Content from '../elements/Content';
 

--- a/bulma-ui/src/layout/Hero.stories.tsx
+++ b/bulma-ui/src/layout/Hero.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import Hero from './Hero';
 import Navbar from '../components/Navbar';
 import Tabs from '../components/Tabs';
@@ -33,7 +33,6 @@ export const Default: StoryObj<typeof Hero> = {
 
 // Colors stories
 export const Link: StoryObj<typeof Hero> = {
-  name: 'Link',
   render: () => (
     <Hero color="link">
       <Hero.Body>
@@ -47,7 +46,6 @@ export const Link: StoryObj<typeof Hero> = {
 };
 
 export const Primary: StoryObj<typeof Hero> = {
-  name: 'Primary',
   render: () => (
     <Hero color="primary">
       <Hero.Body>
@@ -61,7 +59,6 @@ export const Primary: StoryObj<typeof Hero> = {
 };
 
 export const Info: StoryObj<typeof Hero> = {
-  name: 'Info',
   render: () => (
     <Hero color="info">
       <Hero.Body>
@@ -75,7 +72,6 @@ export const Info: StoryObj<typeof Hero> = {
 };
 
 export const Success: StoryObj<typeof Hero> = {
-  name: 'Success',
   render: () => (
     <Hero color="success">
       <Hero.Body>
@@ -89,7 +85,6 @@ export const Success: StoryObj<typeof Hero> = {
 };
 
 export const Warning: StoryObj<typeof Hero> = {
-  name: 'Warning',
   render: () => (
     <Hero color="warning">
       <Hero.Body>
@@ -103,7 +98,6 @@ export const Warning: StoryObj<typeof Hero> = {
 };
 
 export const Danger: StoryObj<typeof Hero> = {
-  name: 'Danger',
   render: () => (
     <Hero color="danger">
       <Hero.Body>
@@ -118,7 +112,6 @@ export const Danger: StoryObj<typeof Hero> = {
 
 // Sizes stories
 export const Small: StoryObj<typeof Hero> = {
-  name: 'Small',
   render: () => (
     <Hero color="info" size="small">
       <Hero.Body>
@@ -132,7 +125,6 @@ export const Small: StoryObj<typeof Hero> = {
 };
 
 export const Medium: StoryObj<typeof Hero> = {
-  name: 'Medium',
   render: () => (
     <Hero color="primary" size="medium">
       <Hero.Body>
@@ -146,7 +138,6 @@ export const Medium: StoryObj<typeof Hero> = {
 };
 
 export const Large: StoryObj<typeof Hero> = {
-  name: 'Large',
   render: () => (
     <Hero color="success" size="large">
       <Hero.Body>

--- a/bulma-ui/src/layout/Level.stories.tsx
+++ b/bulma-ui/src/layout/Level.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import Level from './Level';
 import { Title } from '../elements/Title';
 import { Button } from '../elements/Button';

--- a/bulma-ui/src/layout/Media.stories.tsx
+++ b/bulma-ui/src/layout/Media.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import Media from './Media';
 import { Image } from '../elements/Image';
 import { Icon } from '../elements/Icon';

--- a/bulma-ui/src/layout/Section.stories.tsx
+++ b/bulma-ui/src/layout/Section.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Section } from './Section';
 import { Title } from '../elements/Title';
 import { SubTitle } from '../elements/SubTitle';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import typescriptPlugin from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
 import prettierPlugin from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier';
+import storybookPlugin from 'eslint-plugin-storybook';
 import globals from 'globals';
 
 function cleanGlobals(obj) {
@@ -160,4 +161,9 @@ export default [
       },
     },
   },
+
+  // Storybook CSF hygiene for story files (story-exports, await-interactions,
+  // no-renderer-packages, no-redundant-story-name, etc.). Also scoped to
+  // .storybook/main.* — inert today since lint only covers src.
+  ...storybookPlugin.configs['flat/recommended'],
 ];


### PR DESCRIPTION
Closes #288 (the PR-1 deferral from #263, documented in #267's deviation note).

## What

Wires `eslint-plugin-storybook`'s `flat/recommended` preset into the root flat config, activating the CSF-hygiene rules for `*.stories.tsx` (`story-exports`, `await-interactions`, `no-renderer-packages`, `no-redundant-story-name`, `use-storybook-expect`, …), and fixes the fallout the rules surfaced:

- **10 files** imported the renderer package `@storybook/react` (an *undeclared* transitive dep) instead of the declared framework package `@storybook/react-vite` — the other 74 stories already did it right. Fixed; this also removes a phantom-dependency reliance under the isolated node linker.
- **105 redundant story `name` annotations across 22 files** removed (including 14 legacy `X.storyName = …` statements in the grid stories). All were byte-identical to the name Storybook generates from the export, so rendered story/autodocs titles are unchanged.

## Why the issue's wontfix concern doesn't apply

#288 flagged the root-dep addition under the supply-chain policy as the main cost. Turns out the plugin is **already installed** — declared in `bulma-ui/package.json` and resolved in the lockfile since the Storybook 10 upgrade, just never referenced by the config. No new dependency, no `minimumReleaseAge` wait, no `allowBuilds` entry; the root config imports it via the same `publicHoistPattern: ['*eslint*']` route as the other eslint plugins declared in bulma-ui.

The rules are complementary to (not redundant with) the conformance script and stories meta-test, which cover house-specific rules only (autodocs tags, argType descriptions, inline-style ratchet, story-per-component).

## Verification

- `pnpm lint`: 0 errors, and only the 7 pre-existing `react-hooks/exhaustive-deps` warnings (verified identical with the change stashed).
- Negative test: transiently re-adding a redundant `name` and an `@storybook/react` import makes lint warn/error respectively (then reverted).
- `pnpm all` passes end-to-end, including the Storybook build and the story smoke gate.

Commit type is `chore(bulma-ui)` deliberately: nothing shipped in `dist` changes, so no semantic-release bump.

https://claude.ai/code/session_015LmRYeZUeev2ZDXpcumGE5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized component examples and interactive demos to use consistent default names in the component catalog.
  * Updated story presentation across buttons, typography, layout, grid, form, and helper examples.
* **Bug Fixes**
  * Improved Storybook configuration checks to help identify and prevent common story-definition issues.
* **Developer Experience**
  * Improved compatibility and reliability for the catalog’s modern build and preview workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->