### PR TITLE
docs: merge README Special Thanks + Attribution sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,24 +193,20 @@ This is a pnpm + Turborepo monorepo; contributor-facing AI context lives in [`CL
 
 ---
 
-## 🙏 Special Thanks
+## 🙏 Attribution
 
-### [Bulma](https://github.com/jgthms/bulma)
+bestax-bulma is built on top of the incredible [Bulma](https://bulma.io) CSS framework,
+© [Jeremy Thomas](https://github.com/jgthms) and licensed under the
+[MIT License](https://github.com/jgthms/bulma/blob/main/LICENSE). Some example content and
+documentation is adapted from the Bulma website
+([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
 
-bestax-bulma is built on top of the incredible [@jgthms/bulma](https://github.com/jgthms/bulma) CSS framework.
+If you find Bulma useful, please consider
+[sponsoring Jeremy Thomas](https://github.com/sponsors/jgthms) to support its continued
+development.
 
-If you find Bulma useful, please consider [sponsoring Jeremy Thomas](https://github.com/sponsors/jgthms) to support the continued development of Bulma.
-
-_Note: We are not affiliated with Bulma or Jeremy Thomas in any way...We're just big fans of the Bulma framework!_
-
----
-
-## Attribution
-
-- The [Bulma CSS framework](https://bulma.io) is © Jeremy Thomas and licensed under the [MIT License](https://github.com/jgthms/bulma/blob/master/LICENSE).
-- Some example content and documentation in this site is adapted from the Bulma website ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
-
-See [Bulma's license page](https://github.com/jgthms/bulma/blob/main/LICENSE) for more details.
+_We are not affiliated with Bulma or Jeremy Thomas in any way — we're just big fans of the
+Bulma framework!_
 
 ---
 

--- a/bulma-ui/README.md
+++ b/bulma-ui/README.md
@@ -166,24 +166,20 @@ Building with an AI agent (Claude Code, Cursor, Copilot)? bestax-bulma ships LLM
 
 ---
 
-## 🙏 Special Thanks
+## 🙏 Attribution
 
-### [Bulma](https://github.com/jgthms/bulma)
+bestax-bulma is built on top of the incredible [Bulma](https://bulma.io) CSS framework,
+© [Jeremy Thomas](https://github.com/jgthms) and licensed under the
+[MIT License](https://github.com/jgthms/bulma/blob/main/LICENSE). Some example content and
+documentation is adapted from the Bulma website
+([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
 
-bestax-bulma is built on top of the incredible [@jgthms/bulma](https://github.com/jgthms/bulma) CSS framework.
+If you find Bulma useful, please consider
+[sponsoring Jeremy Thomas](https://github.com/sponsors/jgthms) to support its continued
+development.
 
-If you find Bulma useful, please consider [sponsoring Jeremy Thomas](https://github.com/sponsors/jgthms) to support the continued development of Bulma.
-
-_Note: We are not affiliated with Bulma or Jeremy Thomas in any way...We're just big fans of the Bulma framework!_
-
----
-
-## Attribution
-
-- The [Bulma CSS framework](https://bulma.io) is © Jeremy Thomas and licensed under the [MIT License](https://github.com/jgthms/bulma/blob/master/LICENSE).
-- Some example content and documentation in this site is adapted from the Bulma website ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
-
-See [Bulma's license page](https://github.com/jgthms/bulma/blob/main/LICENSE) for more details.
+_We are not affiliated with Bulma or Jeremy Thomas in any way — we're just big fans of the
+Bulma framework!_
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,11 +33,19 @@ The output will appear in the `build/` directory.
 
 Contributions are welcome! Please open issues or pull requests in the [main repo](https://github.com/allxsmith/bestax-bulma).
 
-## Attribution
+## 🙏 Attribution
 
-- The [Bulma CSS framework](https://bulma.io) is © Jeremy Thomas and licensed under the [MIT License](https://github.com/jgthms/bulma/blob/master/LICENSE).
-- Some example content and documentation in this site is adapted from the Bulma website ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
+bestax-bulma is built on top of the incredible [Bulma](https://bulma.io) CSS framework,
+© [Jeremy Thomas](https://github.com/jgthms) and licensed under the
+[MIT License](https://github.com/jgthms/bulma/blob/main/LICENSE). Some example content and
+documentation is adapted from the Bulma website
+([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)), © Jeremy Thomas.
 
-See [Bulma’s license page](https://github.com/jgthms/bulma/blob/main/LICENSE) for more details.
+If you find Bulma useful, please consider
+[sponsoring Jeremy Thomas](https://github.com/sponsors/jgthms) to support its continued
+development.
+
+_We are not affiliated with Bulma or Jeremy Thomas in any way — we're just big fans of the
+Bulma framework!_
 
 ---


### PR DESCRIPTION
# 📝 Documentation Update Pull Request

## Description

Merges the redundant `## 🙏 Special Thanks` and `## Attribution` sections into a single `## 🙏 Attribution` section, identical across all three READMEs:

- `README.md` — replaced both sections (and the `---` rule between them), keeping the `---` before `## License`
- `bulma-ui/README.md` — same replacement (this README is the npm package page)
- `docs/README.md` — replaced its `## Attribution` section (which had a stray curly apostrophe) with the same merged section

Everything from both sections is preserved: the MIT license facts, the CC BY-NC-SA note for adapted example content, the sponsor-Jeremy-Thomas nudge, and the non-affiliation disclaimer. The duplicate MIT license link collapses to one canonical `blob/main` URL, and the `### [Bulma](...)` subheading goes away.

No release / no version bump: the `docs:` commit type triggers no release under the repo's releaseRules; the refreshed `bulma-ui/README.md` reaches npm with the next ordinary release.

## Related Issue(s)

Closes #327

## Checklist

- [x] Only documentation files are affected
- [x] I have checked formatting and spelling
- [ ] Screenshots or previews added if relevant

## Additional Context

Verified no anchors link to `#special-thanks` / `#attribution` anywhere in the repo, and prettier (`format:check`) passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zYSCUhkobiaCv2MPvqvSt

---
_Generated by [Claude Code](https://claude.ai/code/session_018zYSCUhkobiaCv2MPvqvSt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated attribution sections across project documentation.
  * Clarified Bulma framework credits and licensing references.
  * Added attribution for adapted examples and documentation under CC BY-NC-SA.
  * Refined sponsorship messaging and included a non-affiliation disclaimer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->