### PR TITLE
feat(create-bestax): add bestax-optimize skill for shrinking built CSS

### DIFF
--- a/create-bestax/scripts/sync-skills.mjs
+++ b/create-bestax/scripts/sync-skills.mjs
@@ -19,6 +19,7 @@ const SKILLS = [
   'bestax-theming',
   'bestax-layout-scaffold',
   'bestax-icons',
+  'bestax-optimize',
 ];
 
 if (!fs.existsSync(skillsSrc)) {

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -127,6 +127,7 @@ automatically when the task matches:
 - **bestax-theming** — colors, branding, and dark mode via the \`Theme\` component (\`colorMode\`).
 - **bestax-layout-scaffold** — scaffold full pages (app shell, landing, centered, card grid).
 - **bestax-icons** — icons via \`Icon\`/\`IconText\`: library setup, name formats, variants, a11y.
+- **bestax-optimize** — shrink the built CSS: measure raw+gzip, then flavor switch or a modular Sass build.
 
 Prefer the library's components and these skills over hand-written Bulma markup or custom CSS.
 

--- a/docs/docs/guides/getting-started/optimizing-css.md
+++ b/docs/docs/guides/getting-started/optimizing-css.md
@@ -108,6 +108,9 @@ of maintaining the import list as your usage grows.
 
 ## Related
 
+- [Optimize skill](../../skills/optimize.mdx) — an Agent Skill that applies this guide's
+  levers to your app (measure, flavor switch, modular build) via Claude Code or any
+  skills.sh-compatible agent.
 - [CSS Variations](./variations.md) — what each flavor includes.
 - [Modular](./modular.md) — JS tree-shaking and the three CSS loading strategies.
 - [Dark Mode & Contrast](../features/css-variables.md#dark-mode--contrast) — pin the scheme

--- a/docs/docs/skills/intro.md
+++ b/docs/docs/skills/intro.md
@@ -17,6 +17,7 @@ npx skills add https://github.com/allxsmith/bestax --skill bestax-form
 npx skills add https://github.com/allxsmith/bestax --skill bestax-theming
 npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
 npx skills add https://github.com/allxsmith/bestax --skill bestax-icons
+npx skills add https://github.com/allxsmith/bestax --skill bestax-optimize
 ```
 
 Starting a new app? `pnpm create bestax@latest` offers to **preinstall these skills** into the
@@ -35,3 +36,5 @@ Then explore each skill — what it does, how to install it, and live examples:
   to a complete responsive page using the layout archetypes.
 - **[Icons](./icons)** — use `Icon`/`IconText` with any of the five supported icon libraries:
   per-library setup, name formats, variants, and decorative-vs-labeled accessibility.
+- **[Optimize](./optimize)** — reduce the built CSS size: measure raw+gzip, then the cheapest
+  first-party lever that fits (lighter flavor, modular Sass build, import/asset hygiene).

--- a/docs/docs/skills/optimize.mdx
+++ b/docs/docs/skills/optimize.mdx
@@ -43,6 +43,12 @@ npx skills add https://github.com/allxsmith/bestax --skill bestax-optimize
 
   ```scss
   // src/styles.scss
+  // Configure shared variables FIRST — omit this and is-primary reverts
+  // to Bulma's default turquoise instead of the bestax brand color:
+  @use 'bulma/sass/utilities' with (
+    $primary: #1e6b99
+  );
+
   @use 'bulma/sass/base';
   @use 'bulma/sass/themes';
   @use 'bulma/sass/elements/button';

--- a/docs/docs/skills/optimize.mdx
+++ b/docs/docs/skills/optimize.mdx
@@ -1,0 +1,71 @@
+---
+title: Optimize
+sidebar_label: Optimize
+sidebar_position: 6
+---
+
+# Optimize skill
+
+The [`bestax-optimize`](https://github.com/allxsmith/bestax/blob/main/skills/bestax-optimize/SKILL.md)
+skill teaches an agent to reduce the built CSS size of an app using
+`@allxsmith/bestax-bulma`: measure raw and gzip size first, then apply the cheapest lever
+that fits — a lighter prebuilt CSS flavor, a hand-rolled modular Sass build, or import and
+icon-asset hygiene. First-party levers only: it uses the library's own shipped CSS builds and
+SCSS sources, never third-party build plugins.
+
+## Install
+
+```bash
+npx skills add https://github.com/allxsmith/bestax --skill bestax-optimize
+```
+
+## What it teaches
+
+- **Measure first, and know when to stop** — build, then measure the CSS raw (`wc -c`) and
+  gzipped (`gzip -c … | wc -c`), and judge by the **gzip** number: the ~800&nbsp;KB of CSS in
+  `dist/` is ~82&nbsp;KB over the wire. If that's within budget, the honest answer is "your
+  CSS is already fine" — and the skill says so instead of inventing work.
+- **Lever 1: a lighter prebuilt flavor** — a one-line import change between the shipped
+  builds, with the measured size table and the hard gate: `no-helpers` may only be
+  recommended after checking the app uses **no helper props** (`mt="4"`,
+  `textColor="primary"`, `display="flex"`, …), because that flavor drops the classes those
+  props compile to.
+
+  ```tsx
+  // before
+  import '@allxsmith/bestax-bulma/bestax.css'; // ~82 KB gzip
+  // after — the app pins a single color scheme
+  import '@allxsmith/bestax-bulma/versions/bestax-no-dark-mode.css'; // ~70 KB gzip
+  ```
+
+- **Lever 2: a modular Sass build** — compile only the Bulma modules and bestax extras
+  partials the app actually imports, derived component-by-component:
+
+  ```scss
+  // src/styles.scss
+  @use 'bulma/sass/base';
+  @use 'bulma/sass/themes';
+  @use 'bulma/sass/elements/button';
+  @use 'bulma/sass/components/card';
+  @use '@allxsmith/bestax-bulma/scss/components/dialog';
+  @use 'bulma/sass/helpers/flexbox';
+  ```
+
+- **Lever 3: import & icon-asset hygiene** — convert `import * as` to named imports so JS
+  tree shaking works, and delete icon-library packages/CDN scripts the app never renders —
+  icon fonts often outweigh Bulma itself.
+
+## Reference material the agent reads on demand
+
+- [`references/modular-build.md`](https://github.com/allxsmith/bestax/blob/main/skills/bestax-optimize/references/modular-build.md)
+  — the full Lever&nbsp;2 procedure: the component→partial mapping rule, the authoritative
+  bestax extras partial inventory (more complete than the docs example), Bulma helper
+  categories, and a worked `styles.scss` for the starter app.
+
+## Related
+
+- [Optimizing CSS Size](../guides/getting-started/optimizing-css.md) — the guide this skill
+  acts on, with the measured flavor table.
+- [Modular](../guides/getting-started/modular.md) — JS tree-shaking and the three CSS loading
+  strategies (Option C is the modular Sass pattern).
+- [CSS Variations](../guides/getting-started/variations.md) — what each flavor includes.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -37,6 +37,7 @@ const sidebars = {
         'skills/theming',
         'skills/layout-scaffold',
         'skills/icons',
+        'skills/optimize',
       ],
     },
   ],

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,6 +16,7 @@ directory the agent reads on demand.
 | [`bestax-theming`](./bestax-theming/SKILL.md)                   | **Theming** — customize colors, branding, fonts/radius tokens, and dark mode by overriding Bulma's `--bulma-*` variables with the `Theme` component.                                       |
 | [`bestax-layout-scaffold`](./bestax-layout-scaffold/SKILL.md)   | **Layout scaffolding** — turn a high-level request (dashboard, landing page, auth page, catalog) into a complete responsive page from named layout archetypes.                             |
 | [`bestax-icons`](./bestax-icons/SKILL.md)                       | **Icons** — the `Icon`/`IconText` components and the five supported libraries (Font Awesome, MDI, Ionicons, Material Icons/Symbols): setup, name formats, variants, and accessibility.     |
+| [`bestax-optimize`](./bestax-optimize/SKILL.md)                 | **CSS size** — measure raw+gzip and shrink the built stylesheet: a lighter prebuilt flavor, a hand-rolled modular Sass build, and import/icon-asset hygiene. First-party levers only.      |
 
 ## Install
 
@@ -27,6 +28,7 @@ npx skills add https://github.com/allxsmith/bestax --skill bestax-form
 npx skills add https://github.com/allxsmith/bestax --skill bestax-theming
 npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffold
 npx skills add https://github.com/allxsmith/bestax --skill bestax-icons
+npx skills add https://github.com/allxsmith/bestax --skill bestax-optimize
 ```
 
 ## Layout
@@ -72,6 +74,10 @@ skills/
       icon-libraries.md        # per-library setup, name formats, variants, troubleshooting
     examples/
       icon-usage.tsx           # ConfigProvider + sizes/variants/colors + a11y patterns
+  bestax-optimize/
+    SKILL.md
+    references/
+      modular-build.md         # component→partial mapping, extras inventory, worked styles.scss
 ```
 
 > `component-catalog.md` is generated from the API docs by `scripts/gen-component-catalog.mjs`

--- a/skills/bestax-optimize/SKILL.md
+++ b/skills/bestax-optimize/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: bestax-optimize
+description: Reduce the built CSS size of an app using @allxsmith/bestax-bulma — measure raw and gzip size, then apply the cheapest lever that fits (lighter prebuilt CSS flavor, hand-rolled modular Sass build, import and icon-asset hygiene). Use when the CSS bundle looks too big, a size budget or Lighthouse audit flags stylesheet weight, switching bestax.css to a versions/*.css flavor, or setting up a modular @use Bulma/Sass build.
+license: MIT
+---
+
+# Optimizing CSS size with @allxsmith/bestax-bulma
+
+The JS side is tree-shakable (the **entire** library is ~49 KB min+gzip). The stylesheet is
+not: a prebuilt flavor ships all of Bulma + the bestax extras regardless of which components
+the app renders. Judge stylesheet weight by the **gzipped** transfer size — never the raw
+`dist/` number.
+
+## Always measure first
+
+Run the production build, then measure the built CSS — raw and gzip:
+
+```sh
+npm run build
+wc -c dist/assets/*.css            # raw bytes (what Vite reports)
+gzip -c dist/assets/*.css | wc -c  # transfer bytes (what users download)
+```
+
+Re-measure after **every** step below and report the before/after delta (raw + gzip). Never
+claim a saving without a number.
+
+⚠️ **~800 KB raw is ~82 KB over the wire.** Seeing ~800 KB of CSS in `dist/` is expected
+with the default flavor, not a build misconfiguration — servers and CDNs gzip/brotli by
+default. If the gzip number is already within the app's budget, say so and stop: "your CSS is
+already fine" is a valid, honest outcome.
+
+## Decision flow
+
+Cheapest first. Use only the library's own shipped CSS builds and SCSS sources — do not add
+third-party build plugins (no CSS purgers/post-processors).
+
+1. **Flavor switch** — one-line import change, minutes (up to ~15 KB gzip).
+2. **Modular Sass build** — small `@use` file, the biggest honest win.
+3. **Import & icon-asset hygiene** — minor; JS and icon fonts, not the Bulma CSS.
+
+## Lever 1 — lighter prebuilt flavor
+
+Swap the single CSS import (in `src/main.tsx` / `src/main.jsx`) between the shipped flavors.
+Measured sizes drift slightly between releases — hence measure:
+
+| Flavor       | Import                                                               |    Raw |   Gzip |
+| ------------ | -------------------------------------------------------------------- | -----: | -----: |
+| complete     | `import '@allxsmith/bestax-bulma/bestax.css';`                       | ~800KB | ~82 KB |
+| no-dark-mode | `import '@allxsmith/bestax-bulma/versions/bestax-no-dark-mode.css';` | ~680KB | ~70 KB |
+| no-helpers   | `import '@allxsmith/bestax-bulma/versions/bestax-no-helpers.css';`   | ~595KB | ~67 KB |
+
+Prefixed variants (`versions/bestax-prefixed.css` ~875 KB/~84 KB,
+`versions/bestax-no-helpers-prefixed.css` ~655 KB/~69 KB) exist for CSS-collision
+**compatibility, not size** — a prefixed flavor must pair with
+`<ConfigProvider classPrefix="bestax-">` at the app root, and switching a non-prefixed app to
+one is never a size optimization.
+
+- `no-dark-mode` (~12 KB gzip saved) — only when the app pins a single color scheme (a fixed
+  `Theme colorMode` / `data-theme`).
+- `no-helpers` (~15 KB gzip saved) — **hard gate below**.
+
+⚠️ **The `no-helpers` gate: check for helper props first.** That flavor drops every class the
+helper props compile to — components still render, but the props silently do nothing. Before
+recommending it, grep the app's source for helper props on bestax components:
+
+- spacing: `m`, `mt`, `mr`, `mb`, `ml`, `mx`, `my`, `p`, `pt`, `pr`, `pb`, `pl`, `px`, `py`
+- color: `color`, `backgroundColor` (+ `colorShade`/`backgroundColorShade`), `textColor`, `bgColor`
+- typography: `textSize`, `textAlign`, `textTransform`, `textWeight`, `fontFamily`
+- display/visibility: `display`, `visibility` (+ `displayMobile`…`visibilityFullhd` viewport variants)
+- flexbox: `flexDirection`, `flexWrap`, `justifyContent`, `alignContent`, `alignItems`, `alignSelf`, `flexGrow`, `flexShrink`
+- misc: `float`, `overflow`, `overlay`, `interaction`, `cursor`, `radius`, `shadow`, `skeleton`, `clearfix`, `relative`, `fullHeight`
+
+…and for raw Bulma helper classes in `className` strings (`is-*`, `has-*`, `m*-*`, `p*-*`,
+`is-size-*`, `is-hidden*`, `is-flex*`). **Any hit → do not use `no-helpers`**; fall back to
+`no-dark-mode` or Lever 2. The bestax extras helpers (`is-cursor-*`, sizing) are dropped too.
+
+## Lever 2 — modular Sass build
+
+Compile only the Bulma modules + bestax extras partials the app actually uses. Needs the
+`sass` compiler as a dev dependency (Bulma's own build tool — Vite compiles `.scss` natively):
+
+```sh
+npm install -D sass
+```
+
+Create `src/styles.scss` — base + themes always come first:
+
+```scss
+// Configure shared variables FIRST (before anything loads utilities) —
+// the prebuilt flavors set this brand primary; omit it and buttons revert
+// to Bulma's default turquoise:
+@use 'bulma/sass/utilities' with (
+  $primary: #1e6b99
+);
+
+// Required base: reset + CSS variable definitions
+@use 'bulma/sass/base';
+@use 'bulma/sass/themes';
+
+// One line per stock Bulma component the app imports…
+@use 'bulma/sass/elements/button';
+@use 'bulma/sass/components/navbar';
+// …and per bestax extras component:
+@use '@allxsmith/bestax-bulma/scss/components/dialog';
+// Helper categories only if the app uses those helper props:
+@use 'bulma/sass/helpers/spacing';
+```
+
+Then replace the prebuilt CSS import in `src/main.tsx` with `import './styles.scss';`,
+build, and measure. Derive the `@use` list from the components the app imports from
+`@allxsmith/bestax-bulma` — the full component→partial mapping, the authoritative extras
+partial inventory, and a worked example are in `references/modular-build.md`.
+
+## Lever 3 — import & icon-asset hygiene (minor)
+
+- **Named imports.** `import * as Bestax from '@allxsmith/bestax-bulma'` defeats tree
+  shaking. Convert to named imports (`import { Button, Card } from …`) — a JS-side saving
+  (whole library ≈ 49 KB min+gzip), so report it honestly as minor.
+- **Unused icon libraries.** Scaffolded apps may carry an icon library the app never uses:
+  icon-font packages in `package.json` (`@fortawesome/fontawesome-free`, `@mdi/font`,
+  `material-icons`, `material-symbols`) with their CSS imports in `src/main.*`, or Ionicons
+  CDN `<script>` tags in `index.html`. Icon fonts often outweigh Bulma itself — if no
+  `<Icon>` uses that library, delete the dependency/import/script. Pure win, no tooling.
+
+## References
+
+- `references/modular-build.md` — full Lever 2 procedure: component→partial mapping, the
+  authoritative extras partial inventory, helper categories, and a worked `styles.scss`.
+- Docs: [Optimizing CSS Size](https://bestax.io/docs/guides/getting-started/optimizing-css) ·
+  [Modular — Option C](https://bestax.io/docs/guides/getting-started/modular#option-c--hand-rolled-modular-scss-advanced) ·
+  [CSS Variations](https://bestax.io/docs/guides/getting-started/variations#file-size-comparison)

--- a/skills/bestax-optimize/references/modular-build.md
+++ b/skills/bestax-optimize/references/modular-build.md
@@ -1,0 +1,173 @@
+# Modular Sass build — component→partial mapping and procedure
+
+Build a stylesheet containing only what the app uses, from the library's own SCSS sources.
+This is the "Option C" pattern from the
+[Modular guide](https://bestax.io/docs/guides/getting-started/modular#option-c--hand-rolled-modular-scss-advanced).
+
+## Prerequisites
+
+```sh
+npm install -D sass
+```
+
+`sass` is Bulma's own compiler, dev-only. Vite compiles `.scss` out of the box — no plugin.
+`bulma` is already present as a dependency of `@allxsmith/bestax-bulma`, and the library
+publishes its SCSS sources (`src/scss` ships in the npm package, exposed via the
+`@allxsmith/bestax-bulma/scss/*` export).
+
+## The required base — always first
+
+```scss
+// Configure shared variables FIRST — a Sass module can only be configured on
+// its first load, and every Bulma module loads utilities internally. The
+// prebuilt bestax flavors set this brand primary; omit it and is-primary
+// reverts to Bulma's default turquoise (verified failure mode).
+@use 'bulma/sass/utilities' with (
+  $primary: #1e6b99
+);
+
+// Required: reset + CSS variable definitions
+@use 'bulma/sass/base';
+@use 'bulma/sass/themes';
+```
+
+- `base` — minireset, generic element styles, keyframes.
+- `themes` — registers the `--bulma-*` custom properties (colors, radii, schemes) and
+  light/dark setup. Without it, components render unstyled-looking because every color
+  resolves to nothing.
+- Exception: `bulma/sass/grid/columns` and `bulma/sass/grid/grid` register their own CSS
+  vars and can technically stand alone — include base + themes anyway; it is the safe
+  default.
+
+## Component → partial mapping
+
+**Rule:** stock Bulma components map to `bulma/sass/<category>/<lowercased-name>`; bestax
+extras map to `@allxsmith/bestax-bulma/scss/<category>/<lowercased-name>`. Components that
+are pure stock Bulma (Button, Box, Card, Navbar, Modal, Hero, …) have **no** extras partial —
+Bulma's own module is all they need.
+
+Stock Bulma examples:
+
+```scss
+@use 'bulma/sass/elements/button'; // Button, Buttons
+@use 'bulma/sass/elements/box'; // Box
+@use 'bulma/sass/elements/notification'; // Notification
+@use 'bulma/sass/elements/title'; // Title, SubTitle
+@use 'bulma/sass/form/input'; // Input
+@use 'bulma/sass/form/select'; // Select
+@use 'bulma/sass/components/card'; // Card
+@use 'bulma/sass/components/modal'; // Modal
+@use 'bulma/sass/components/navbar'; // Navbar
+@use 'bulma/sass/grid/columns'; // Columns, Column
+@use 'bulma/sass/grid/grid'; // Grid, Cell
+@use 'bulma/sass/layout/container'; // Container
+@use 'bulma/sass/layout/section'; // Section
+```
+
+## Authoritative bestax extras inventory
+
+Every extras partial that exists (from the library's `src/scss/**/_index.scss` — this list
+is **more complete** than the docs page's Option C example, which omits several):
+
+**Components** (`@allxsmith/bestax-bulma/scss/components/<name>`):
+`loading`, `collapse`, `tooltip`, `steps`, `sidebar`, `toast`, `dialog`, `carousel`, `tabs`,
+`reveal`, `avatar`, `avatars`, `badge`
+
+**Form** (`@allxsmith/bestax-bulma/scss/form/<name>`):
+`checkbox`, `radio`, `switch`, `slider`, `numberinput`, `rate`, `autocomplete`, `taginput`,
+`picker-popover`, `dateinput`, `timeinput`, `datetimeinput`
+
+**Elements** (`@allxsmith/bestax-bulma/scss/elements/<name>`): `linkbutton`
+
+**Helpers** (`@allxsmith/bestax-bulma/scss/helpers/<name>`): `cursor`, `sizing`
+
+Notes:
+
+- The extras partial name is the component name lowercased (`Dialog` →
+  `scss/components/dialog`; `NumberInput` → `scss/form/numberinput`).
+- Extras `Tabs` **extends** stock Bulma tabs (vertical variant) — an app using `Tabs` needs
+  both `bulma/sass/components/tabs` and `@allxsmith/bestax-bulma/scss/components/tabs`.
+- `DateInput`/`TimeInput`/`DateTimeInput` also need `picker-popover`.
+- Stock-Bulma form controls still need their Bulma module (`bulma/sass/form/…`); the extras
+  form partials above style only the bestax-specific behavior.
+- Bulma component modules pull their own internal sub-elements — e.g.
+  `elements/notification` styles its `delete` close button itself (verified). No extra
+  `@use` lines are needed for pieces rendered _inside_ a component you've already included.
+
+## Bulma helper categories
+
+Include a helper module **only if the app's helper props (or `className` strings) need it**:
+
+⚠️ The `display` prop (`display="flex"`, `is-flex`, `is-block`, …) lives in **`visibility`**,
+not `flexbox` — `flexbox` holds only the alignment props. Verified failure mode: omit
+`visibility` and every `display="flex"` silently renders `block`.
+
+```scss
+@use 'bulma/sass/helpers/spacing'; // m*/p* props
+@use 'bulma/sass/helpers/color'; // color/backgroundColor props, has-text-*/has-background-*
+@use 'bulma/sass/helpers/typography'; // textSize/textAlign/textTransform/textWeight/fontFamily
+@use 'bulma/sass/helpers/visibility'; // display/visibility props incl. display="flex" (is-flex/is-block/is-hidden*)
+@use 'bulma/sass/helpers/flexbox'; // flex* alignment props (justifyContent/alignItems/flexGrow…) — NOT display="flex"
+@use 'bulma/sass/helpers/other'; // overlay/interaction/radius/shadow/clearfix/relative…
+```
+
+## Procedure
+
+1. **Inventory** — list every component the app imports from `@allxsmith/bestax-bulma`
+   (grep the import statements; remember re-exports through local files).
+2. **Map** — one `@use` line per component via the rule above; add the helper categories the
+   app's helper props require; dedupe.
+3. **Write `src/styles.scss`** — the `utilities` config first, then base + themes, then the
+   mapped lines.
+4. **Swap the import** — in `src/main.tsx`/`src/main.jsx`, replace the prebuilt CSS import
+   (`bestax.css` or `versions/*.css`) with `import './styles.scss';`.
+5. **Build and measure** — raw + gzip, compare against the prebuilt baseline, report the
+   delta.
+6. **Verify visually** — open the app; a missing partial shows up as an unstyled component,
+   an omitted helper module as ignored spacing/color props. Add the missing `@use` line —
+   never paper over it with custom CSS.
+
+## Worked example — the create-bestax starter app
+
+The `npm create bestax` starter renders `Container`, `Section`, `Columns`/`Column`, `Image`,
+`Title`/`SubTitle`, `Box`, `Card`, `Buttons`/`Button`, and `Notification` — all stock Bulma,
+no bestax extras. Its helper props are `display`/`justifyContent` (visibility + flexbox),
+`textAlign` (typography), and `textColor` (color); it uses no spacing props. That inventory
+compiles to the following — verified pixel-equivalent to the prebuilt `complete` flavor in
+headless Chromium (light and dark), at 453 KB raw / 40 KB gzip vs 813 KB / 83 KB:
+
+```scss
+// src/styles.scss
+@use 'bulma/sass/utilities' with (
+  $primary: #1e6b99
+);
+
+@use 'bulma/sass/base';
+@use 'bulma/sass/themes';
+
+@use 'bulma/sass/elements/box';
+@use 'bulma/sass/elements/button'; // Button + Buttons
+@use 'bulma/sass/elements/image';
+@use 'bulma/sass/elements/notification';
+@use 'bulma/sass/elements/title'; // Title + SubTitle
+@use 'bulma/sass/components/card';
+@use 'bulma/sass/grid/columns';
+@use 'bulma/sass/layout/container';
+@use 'bulma/sass/layout/section';
+
+@use 'bulma/sass/helpers/visibility'; // display="flex"
+@use 'bulma/sass/helpers/flexbox'; // justifyContent/flexGrow/flexShrink
+@use 'bulma/sass/helpers/typography'; // textAlign
+@use 'bulma/sass/helpers/color'; // textColor
+```
+
+```tsx
+// src/main.tsx — before
+import '@allxsmith/bestax-bulma/bestax.css';
+// after
+import './styles.scss';
+```
+
+A custom class prefix is `$class-prefix` in the same `with (…)` block as `$primary`, paired
+with `<ConfigProvider classPrefix="my-">` at the app root (the library's own
+`src/scss/versions/*.scss` flavor builds use exactly this mechanism).


### PR DESCRIPTION
# Pull Request

## Description

New Agent Skill `skills/bestax-optimize/` that teaches an agent to reduce a bestax app's built CSS, cheapest lever first:

- **Measure first, stop when fine** — raw + gzip of the built CSS; judge by transfer size (~800 KB raw is ~82 KB over the wire), and "your CSS is already fine" is a valid outcome.
- **Lever 1: lighter prebuilt flavor** — one-line import swap between the shipped builds, with the measured size table and a hard gate: `no-helpers` is only recommendable after grepping the app for helper props (they compile to the classes that flavor drops).
- **Lever 2: modular Sass build** — `@use` only the Bulma modules + bestax extras partials the app imports, with the authoritative extras inventory from `src/scss/**/_index.scss` (more complete than the docs' Option C example) and a visually verified worked example for the starter app.
- **Lever 3: import & icon-asset hygiene** — named imports for tree shaking; delete unused icon-library packages/CDN scripts.

**First-party levers only** — per owner decision, the issue's "stretch" PurgeCSS strategy was dropped; the skill explicitly forbids third-party CSS purgers/post-processors and replaces that lever with the compression sanity check and icon-asset hygiene.

Ships through every skill surface in one commit (the surface that was historically forgotten in #302): the `SKILLS` array in `sync-skills.mjs`, the scaffolded `CLAUDE.md` skills list in `constants.ts`, `skills/README.md`, and the docs site (`docs/docs/skills/optimize.mdx` + intro + sidebar + a Related cross-link from the Optimizing CSS guide). No Storybook skill-example: the skill produces build config and size reports, nothing renderable, so the `skills/CLAUDE.md` showcase rule doesn't bind.

Affected packages:

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): `skills/` (shipped product)

## Related Issue(s)

Closes #323
Refs #193

## Type of Change

- [x] New feature
- [x] Documentation

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works — no unit-test changes needed (data-only additions; nothing asserts the SKILLS array); verified instead by build + scaffold smoke test + an end-to-end dry-run of the skill's own guidance (below)
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui) — N/A, nothing renderable
- [ ] My changes require a change to the documentation — included in this PR
- [x] All new and existing tests passed (`pnpm all`; create-bestax 191/191)
- [ ] Any relevant dependencies are updated — none
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated — no convention changes; the *scaffolded-app* CLAUDE_MD template is updated (part of the feature)

## Screenshots / Demos

The skill's guidance was dry-run end-to-end on a freshly scaffolded app and **visually verified in headless Chromium** (light + dark, notification open, computed-style probes on 11 elements). That probing caught and fixed two real bugs in the initial Lever 2 guidance before ship:

1. Missing `$primary` config — the modular build rendered Bulma's default turquoise instead of the brand `#1e6b99` the prebuilt flavors set. The worked example now configures `bulma/sass/utilities` first.
2. Wrong helper mapping — `display="flex"` lives in `helpers/visibility`, not `helpers/flexbox`; omitting it silently renders `block`. The helper-category table now flags this as a verified failure mode.

After the fixes the modular build is computed-style-identical to the prebuilt `complete` flavor (sole exception: a 1/255 rounding in one dark-mode color channel) at **453 KB raw / 40 KB gzip vs 813 KB / 83 KB**. Lever 1 was verified the same way (`no-dark-mode`: 689 KB / 71 KB, renders light under an emulated dark scheme — its documented contract), and the `no-helpers` gate correctly refuses the starter app (8 helper-prop hits).

## Additional Context

Release impact: `feat(create-bestax)` → minor release of `create-bestax` only; `bulma-ui` code is untouched. `sync-skills` now copies 6 skills; scaffold smoke test confirms `.claude/skills/bestax-optimize/` lands in generated apps with the CLAUDE.md bullet. Note for reviewers: #323's checklist item "fix bestax-icons missing from the SKILLS array first" was stale — that was already fixed in #310 before #323 was filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zYSCUhkobiaCv2MPvqvSt

---
_Generated by [Claude Code](https://claude.ai/code/session_018zYSCUhkobiaCv2MPvqvSt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `bestax-optimize` skill for reducing built CSS size through measurement, lighter CSS flavors, modular Sass builds, and import or asset cleanup.
  * Included the skill in generated projects and the skills installation catalog.

* **Documentation**
  * Added comprehensive optimization guidance, modular Sass build instructions, references, and navigation links throughout the documentation.
  * Documented available CSS flavors and checks for safely selecting lighter builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->