### PR TITLE
feat(bulma-ui): compound (dot-notation) sub-components for all parent/child families via shared withSubComponents helper

### DIFF
--- a/bulma-ui/src/columns/Columns.stories.tsx
+++ b/bulma-ui/src/columns/Columns.stories.tsx
@@ -556,3 +556,18 @@ export const MultilineCenteredColumns: StoryObj = {
     </>
   ),
 };
+
+export const CompoundUsage: StoryObj = {
+  render: () => (
+    <Columns>
+      <Columns.Column>
+        <Notification color="primary">
+          First column via dot notation
+        </Notification>
+      </Columns.Column>
+      <Columns.Column>
+        <Notification color="info">Second column via dot notation</Notification>
+      </Columns.Column>
+    </Columns>
+  ),
+};

--- a/bulma-ui/src/columns/Columns.tsx
+++ b/bulma-ui/src/columns/Columns.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
   validColors,
 } from '../helpers/useBulmaClasses';
 import type { BulmaGapValue } from '../grid/Grid';
+import { Column } from './Column';
 
 /**
  * Possible values for the Bulma columns gap size.
@@ -87,7 +89,7 @@ export interface ColumnsProps
  * @returns {JSX.Element} The rendered columns container.
  * @see {@link https://bulma.io/documentation/columns/ | Bulma Columns documentation}
  */
-export const Columns: React.FC<ColumnsProps> = ({
+const ColumnsComponent: React.FC<ColumnsProps> = ({
   className,
   textColor,
   color: _fieldColor,
@@ -162,3 +164,9 @@ export const Columns: React.FC<ColumnsProps> = ({
     </div>
   );
 };
+
+export const Columns = withSubComponents(
+  ColumnsComponent,
+  { Column },
+  'Columns'
+);

--- a/bulma-ui/src/columns/__tests__/Columns.test.tsx
+++ b/bulma-ui/src/columns/__tests__/Columns.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { Columns } from '../Columns';
+import { Column } from '../Column';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Columns', () => {
@@ -225,5 +226,22 @@ describe('Columns', () => {
       expect(columns).toHaveClass('is-1-mobile');
       expect(columns).toHaveClass('p-4');
     });
+  });
+});
+
+describe('Compound components', () => {
+  test('Columns.Column is the Column component', () => {
+    expect(Columns.Column).toBe(Column);
+  });
+
+  test('renders columns through the dot path', () => {
+    const { container } = render(
+      <Columns>
+        <Columns.Column>First</Columns.Column>
+        <Columns.Column>Second</Columns.Column>
+      </Columns>
+    );
+    expect(container.querySelector('.columns')).toBeInTheDocument();
+    expect(container.querySelectorAll('.column')).toHaveLength(2);
   });
 });

--- a/bulma-ui/src/components/Avatars.tsx
+++ b/bulma-ui/src/components/Avatars.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 import { Avatar, AvatarProps } from './Avatar';
 
@@ -73,7 +74,7 @@ function flattenChildren(
  *   {members.map(m => <Avatar key={m.id} src={m.photo} name={m.name} />)}
  * </Avatars>
  */
-export const Avatars: React.FC<AvatarsProps> & { Avatar: typeof Avatar } = ({
+const AvatarsComponent: React.FC<AvatarsProps> = ({
   className,
   max,
   size,
@@ -153,7 +154,10 @@ export const Avatars: React.FC<AvatarsProps> & { Avatar: typeof Avatar } = ({
   );
 };
 
-Avatars.displayName = 'Avatars';
-Avatars.Avatar = Avatar;
+export const Avatars = withSubComponents(
+  AvatarsComponent,
+  { Avatar },
+  'Avatars'
+);
 
 export default Avatars;

--- a/bulma-ui/src/components/Card.tsx
+++ b/bulma-ui/src/components/Card.tsx
@@ -4,6 +4,7 @@ import {
   usePrefixedClassNames,
   prefixedClassNames,
 } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -463,37 +464,24 @@ const CardFooterItem: React.FC<CardFooterItemProps> = ({
   </span>
 );
 
-/** Card component type with Header, Image, Content, Footer, and FooterItem sub-components. */
-type CardWithCompounds = typeof CardComponent & {
-  Header: typeof CardHeader & {
-    Title: typeof CardHeaderTitle;
-    Icon: typeof CardHeaderIcon;
-  };
-  Image: typeof CardImage;
-  Content: typeof CardContent;
-  Footer: typeof CardFooter;
-  FooterItem: typeof CardFooterItem;
-};
+// Attach nested Title and Icon components to CardHeader
+const CardHeaderCompound = withSubComponents(CardHeader, {
+  Title: CardHeaderTitle,
+  Icon: CardHeaderIcon,
+});
 
-// Cast Card to the compound type and assign compound components
-const CardWithSubComponents = CardComponent as CardWithCompounds;
-
-// Create CardHeader with nested Title and Icon components
-const CardHeaderWithTitle = CardHeader as typeof CardHeader & {
-  Title: typeof CardHeaderTitle;
-  Icon: typeof CardHeaderIcon;
-};
-CardHeaderWithTitle.Title = CardHeaderTitle;
-CardHeaderWithTitle.Icon = CardHeaderIcon;
-
-CardWithSubComponents.Header = CardHeaderWithTitle;
-CardWithSubComponents.Image = CardImage;
-CardWithSubComponents.Content = CardContent;
-CardWithSubComponents.Footer = CardFooter;
-CardWithSubComponents.FooterItem = CardFooterItem;
-
-// Export the compound component
-export { CardWithSubComponents as Card };
+/** Card component with Header, Image, Content, Footer, and FooterItem sub-components. */
+export const Card = withSubComponents(
+  CardComponent,
+  {
+    Header: CardHeaderCompound,
+    Image: CardImage,
+    Content: CardContent,
+    Footer: CardFooter,
+    FooterItem: CardFooterItem,
+  },
+  'Card'
+);
 
 /** Internal test-only exports. Not part of the public API. */
 export const __test_exports__ = { renderFooter };

--- a/bulma-ui/src/components/Dropdown.tsx
+++ b/bulma-ui/src/components/Dropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
+import { withSubComponents } from '../helpers/withSubComponents';
 
 /**
  * Checks if code is running in a browser environment.
@@ -242,9 +243,13 @@ export const DropdownDivider: React.FC = () => (
 );
 
 /** Bulma Dropdown component with Item and Divider sub-components. */
-export const Dropdown = Object.assign(DropdownComponent, {
-  Item: DropdownItem,
-  Divider: DropdownDivider,
-});
+export const Dropdown = withSubComponents(
+  DropdownComponent,
+  {
+    Item: DropdownItem,
+    Divider: DropdownDivider,
+  },
+  'Dropdown'
+);
 
 export default Dropdown;

--- a/bulma-ui/src/components/Menu.tsx
+++ b/bulma-ui/src/components/Menu.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
+import { withSubComponents } from '../helpers/withSubComponents';
 
 // Context to track MenuList nesting level
 const MenuListLevelContext = createContext(0);
@@ -216,10 +217,14 @@ export const MenuItem: React.FC<MenuItemProps> = ({
 };
 
 // Attach static subcomponents
-export const Menu = Object.assign(MenuComponent, {
-  Label: MenuLabel,
-  List: MenuList,
-  Item: MenuItem,
-});
+export const Menu = withSubComponents(
+  MenuComponent,
+  {
+    Label: MenuLabel,
+    List: MenuList,
+    Item: MenuItem,
+  },
+  'Menu'
+);
 
 export default Menu;

--- a/bulma-ui/src/components/Message.tsx
+++ b/bulma-ui/src/components/Message.tsx
@@ -4,6 +4,7 @@ import {
   usePrefixedClassNames,
   prefixedClassNames,
 } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -166,18 +167,14 @@ const MessageBody: React.FC<MessageBodyProps> = ({
   </div>
 );
 
-// Create a type that extends the Message component with compound components
-type MessageWithCompounds = typeof MessageComponent & {
-  Header: typeof MessageHeader;
-  Body: typeof MessageBody;
-};
+// Attach compound components
+export const Message = withSubComponents(
+  MessageComponent,
+  {
+    Header: MessageHeader,
+    Body: MessageBody,
+  },
+  'Message'
+);
 
-// Cast Message to the compound type and assign compound components
-const MessageWithSubComponents = MessageComponent as MessageWithCompounds;
-MessageWithSubComponents.Header = MessageHeader;
-MessageWithSubComponents.Body = MessageBody;
-
-// Export the compound component
-export { MessageWithSubComponents as Message };
-
-export default MessageWithSubComponents;
+export default Message;

--- a/bulma-ui/src/components/Modal.tsx
+++ b/bulma-ui/src/components/Modal.tsx
@@ -4,6 +4,7 @@ import {
   usePrefixedClassNames,
   prefixedClassNames,
 } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -227,20 +228,20 @@ const ModalCardFoot: React.FC<ModalCardFootProps> = ({
  * @param {ModalCardProps} props - Component props.
  * @returns {JSX.Element} Modal card element.
  */
-const ModalCard: React.FC<ModalCardProps> & {
-  Head: typeof ModalCardHead;
-  Title: typeof ModalCardTitle;
-  Body: typeof ModalCardBody;
-  Foot: typeof ModalCardFoot;
-} = ({ className, ...props }) => {
+const ModalCardComponent: React.FC<ModalCardProps> = ({
+  className,
+  ...props
+}) => {
   const classes = classNames(usePrefixedClassNames('modal-card'), className);
   return <div className={classes} {...props} />;
 };
 
-ModalCard.Head = ModalCardHead;
-ModalCard.Title = ModalCardTitle;
-ModalCard.Body = ModalCardBody;
-ModalCard.Foot = ModalCardFoot;
+const ModalCard = withSubComponents(ModalCardComponent, {
+  Head: ModalCardHead,
+  Title: ModalCardTitle,
+  Body: ModalCardBody,
+  Foot: ModalCardFoot,
+});
 
 /**
  * Modal.Close - Renders modal close button with two variant styles.
@@ -303,12 +304,7 @@ const ModalClose: React.FC<ModalCloseProps> = ({
  *
  * @see {@link https://bulma.io/documentation/components/modal/ | Bulma Modal documentation}
  */
-const ModalRoot: React.FC<ModalProps> & {
-  Background: typeof ModalBackground;
-  Content: typeof ModalContent;
-  Card: typeof ModalCard;
-  Close: typeof ModalClose;
-} = ({
+const ModalRoot: React.FC<ModalProps> = ({
   active,
   isActive,
   onClose,
@@ -429,10 +425,14 @@ const ModalRoot: React.FC<ModalProps> & {
   );
 };
 
-ModalRoot.Background = ModalBackground;
-ModalRoot.Content = ModalContent;
-ModalRoot.Card = ModalCard;
-ModalRoot.Close = ModalClose;
-
-export const Modal = ModalRoot;
+export const Modal = withSubComponents(
+  ModalRoot,
+  {
+    Background: ModalBackground,
+    Content: ModalContent,
+    Card: ModalCard,
+    Close: ModalClose,
+  },
+  'Modal'
+);
 export default Modal;

--- a/bulma-ui/src/components/Navbar.tsx
+++ b/bulma-ui/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -48,18 +49,7 @@ export interface NavbarProps
  * @returns {JSX.Element} The rendered navbar.
  * @see {@link https://bulma.io/documentation/components/navbar/ | Bulma Navbar documentation}
  */
-export const Navbar: React.FC<NavbarProps> & {
-  Brand: typeof NavbarBrand;
-  Item: typeof NavbarItem;
-  Link: typeof NavbarLink;
-  Burger: typeof NavbarBurger;
-  Menu: typeof NavbarMenu;
-  Start: typeof NavbarStart;
-  End: typeof NavbarEnd;
-  Dropdown: typeof NavbarDropdown;
-  DropdownMenu: typeof NavbarDropdownMenu;
-  Divider: typeof NavbarDivider;
-} = ({
+const NavbarComponent: React.FC<NavbarProps> = ({
   className,
   textColor,
   bgColor,
@@ -573,15 +563,21 @@ export const NavbarDivider: React.FC<
 );
 
 // Attach subcomponents
-Navbar.Brand = NavbarBrand;
-Navbar.Item = NavbarItem;
-Navbar.Link = NavbarLink;
-Navbar.Burger = NavbarBurger;
-Navbar.Menu = NavbarMenu;
-Navbar.Start = NavbarStart;
-Navbar.End = NavbarEnd;
-Navbar.Dropdown = NavbarDropdown;
-Navbar.DropdownMenu = NavbarDropdownMenu;
-Navbar.Divider = NavbarDivider;
+export const Navbar = withSubComponents(
+  NavbarComponent,
+  {
+    Brand: NavbarBrand,
+    Item: NavbarItem,
+    Link: NavbarLink,
+    Burger: NavbarBurger,
+    Menu: NavbarMenu,
+    Start: NavbarStart,
+    End: NavbarEnd,
+    Dropdown: NavbarDropdown,
+    DropdownMenu: NavbarDropdownMenu,
+    Divider: NavbarDivider,
+  },
+  'Navbar'
+);
 
 export default Navbar;

--- a/bulma-ui/src/components/Pagination.tsx
+++ b/bulma-ui/src/components/Pagination.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -139,13 +140,7 @@ export const PaginationNext: React.FC<PaginationPreviousNextProps> = ({
  * @returns {JSX.Element} The rendered pagination.
  * @see {@link https://bulma.io/documentation/components/pagination/ | Bulma Pagination documentation}
  */
-export const Pagination: React.FC<PaginationProps> & {
-  Link: typeof PaginationLink;
-  List: typeof PaginationList;
-  Ellipsis: typeof PaginationEllipsis;
-  Previous: typeof PaginationPrevious;
-  Next: typeof PaginationNext;
-} = ({
+const PaginationComponent: React.FC<PaginationProps> = ({
   color,
   textColor,
   bgColor,
@@ -340,10 +335,16 @@ export const PaginationEllipsis: React.FC<
   </li>
 );
 
-Pagination.Link = PaginationLink;
-Pagination.List = PaginationList;
-Pagination.Ellipsis = PaginationEllipsis;
-Pagination.Previous = PaginationPrevious;
-Pagination.Next = PaginationNext;
+export const Pagination = withSubComponents(
+  PaginationComponent,
+  {
+    Link: PaginationLink,
+    List: PaginationList,
+    Ellipsis: PaginationEllipsis,
+    Previous: PaginationPrevious,
+    Next: PaginationNext,
+  },
+  'Pagination'
+);
 
 export default Pagination;

--- a/bulma-ui/src/components/Panel.tsx
+++ b/bulma-ui/src/components/Panel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 import { Icon, IconProps } from '../elements/Icon';
 
@@ -118,15 +119,12 @@ export interface PanelButtonBlockProps extends React.ButtonHTMLAttributes<HTMLBu
  * @returns {JSX.Element} The rendered panel.
  * @see {@link https://bulma.io/documentation/components/panel/ | Bulma Panel documentation}
  */
-export const Panel: React.FC<PanelProps> & {
-  Heading: typeof PanelHeading;
-  Tabs: typeof PanelTabs;
-  Block: typeof PanelBlock;
-  Icon: typeof PanelIcon;
-  InputBlock: typeof PanelInputBlock;
-  CheckboxBlock: typeof PanelCheckboxBlock;
-  ButtonBlock: typeof PanelButtonBlock;
-} = ({ color, className, children, ...props }) => {
+const PanelComponent: React.FC<PanelProps> = ({
+  color,
+  className,
+  children,
+  ...props
+}) => {
   const { bulmaHelperClasses, rest } = useBulmaClasses({
     color,
     ...props,
@@ -314,12 +312,18 @@ export const PanelButtonBlock: React.FC<PanelButtonBlockProps> = ({
   </div>
 );
 
-Panel.Heading = PanelHeading;
-Panel.Tabs = PanelTabs;
-Panel.Block = PanelBlock;
-Panel.Icon = PanelIcon;
-Panel.InputBlock = PanelInputBlock;
-Panel.CheckboxBlock = PanelCheckboxBlock;
-Panel.ButtonBlock = PanelButtonBlock;
+export const Panel = withSubComponents(
+  PanelComponent,
+  {
+    Heading: PanelHeading,
+    Tabs: PanelTabs,
+    Block: PanelBlock,
+    Icon: PanelIcon,
+    InputBlock: PanelInputBlock,
+    CheckboxBlock: PanelCheckboxBlock,
+    ButtonBlock: PanelButtonBlock,
+  },
+  'Panel'
+);
 
 export default Panel;

--- a/bulma-ui/src/components/Sidebar.tsx
+++ b/bulma-ui/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
+import { withSubComponents } from '../helpers/withSubComponents';
 
 /** Position of the sidebar relative to the viewport. */
 export type SidebarPosition = 'left' | 'right';
@@ -222,8 +223,6 @@ const SidebarComponent = forwardRef<HTMLElement, SidebarProps>(
   }
 );
 
-SidebarComponent.displayName = 'Sidebar';
-
 // Sub-components
 
 /**
@@ -374,12 +373,16 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({
 };
 
 // Attach static subcomponents
-export const Sidebar = Object.assign(SidebarComponent, {
-  Header: SidebarHeader,
-  Title: SidebarTitle,
-  Close: SidebarClose,
-  Body: SidebarBody,
-  Footer: SidebarFooter,
-});
+export const Sidebar = withSubComponents(
+  SidebarComponent,
+  {
+    Header: SidebarHeader,
+    Title: SidebarTitle,
+    Close: SidebarClose,
+    Body: SidebarBody,
+    Footer: SidebarFooter,
+  },
+  'Sidebar'
+);
 
 export default Sidebar;

--- a/bulma-ui/src/components/Steps.tsx
+++ b/bulma-ui/src/components/Steps.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 
 /** Available size modifiers for the Steps component. */
@@ -221,7 +222,7 @@ export const Step: React.FC<StepProps> = ({
  *   ]}
  * />
  */
-export const Steps: React.FC<StepsProps> & { Step: typeof Step } = ({
+const StepsComponent: React.FC<StepsProps> = ({
   value = 0,
   items,
   size,
@@ -345,6 +346,6 @@ export const Steps: React.FC<StepsProps> & { Step: typeof Step } = ({
 };
 
 // Attach Step as static property
-Steps.Step = Step;
+export const Steps = withSubComponents(StepsComponent, { Step }, 'Steps');
 
 export default Steps;

--- a/bulma-ui/src/components/Tabs.tsx
+++ b/bulma-ui/src/components/Tabs.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 import { Icon } from '../elements/Icon';
 
@@ -93,12 +94,7 @@ export interface TabsProps
  *   </Tabs.Content>
  * </Tabs>
  */
-export const Tabs: React.FC<TabsProps> & {
-  List: typeof TabList;
-  Tab: typeof Tab;
-  Item: typeof TabItem;
-  Content: typeof TabsContent & { Item: typeof TabContentItem };
-} = ({
+const TabsComponent: React.FC<TabsProps> = ({
   align,
   size,
   fullwidth,
@@ -425,9 +421,11 @@ export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
  * @param {TabsContentProps} props - Props for the TabsContent component.
  * @returns {JSX.Element} The rendered tabs content wrapper.
  */
-export const TabsContent: React.FC<TabsContentProps> & {
-  Item: typeof TabContentItem;
-} = ({ className, children, ...props }) => {
+const TabsContentComponent: React.FC<TabsContentProps> = ({
+  className,
+  children,
+  ...props
+}) => {
   const contentClass = usePrefixedClassNames('tabs-content');
   return (
     <div className={classNames(contentClass, className)} {...props}>
@@ -489,11 +487,19 @@ export const TabContentItem: React.FC<TabContentItemProps> = ({
 // Static property attachment
 // ---------------------------------------------------------------------------
 
-TabsContent.Item = TabContentItem;
+export const TabsContent = withSubComponents(TabsContentComponent, {
+  Item: TabContentItem,
+});
 
-Tabs.List = TabList;
-Tabs.Tab = Tab;
-Tabs.Item = TabItem;
-Tabs.Content = Object.assign(TabsContent, { Item: TabContentItem });
+export const Tabs = withSubComponents(
+  TabsComponent,
+  {
+    List: TabList,
+    Tab,
+    Item: TabItem,
+    Content: TabsContent,
+  },
+  'Tabs'
+);
 
 export default Tabs;

--- a/bulma-ui/src/elements/Buttons.stories.tsx
+++ b/bulma-ui/src/elements/Buttons.stories.tsx
@@ -209,3 +209,13 @@ export const WithIconTextAndAddons: Story = {
     },
   },
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Buttons>
+      <Buttons.Button color="primary">Save</Buttons.Button>
+      <Buttons.Button>Cancel</Buttons.Button>
+      <Buttons.LinkButton>Learn more</Buttons.LinkButton>
+    </Buttons>
+  ),
+};

--- a/bulma-ui/src/elements/Buttons.tsx
+++ b/bulma-ui/src/elements/Buttons.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
+import { Button } from './Button';
+import { LinkButton } from './LinkButton';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -40,7 +43,7 @@ interface ButtonsProps
  * @returns {JSX.Element} The rendered group of buttons.
  * @see {@link https://bulma.io/documentation/elements/button/#group | Bulma Button Group documentation}
  */
-export const Buttons: React.FC<ButtonsProps> = ({
+const ButtonsComponent: React.FC<ButtonsProps> = ({
   className,
   textColor,
   bgColor,
@@ -77,3 +80,12 @@ export const Buttons: React.FC<ButtonsProps> = ({
     </div>
   );
 };
+
+export const Buttons = withSubComponents(
+  ButtonsComponent,
+  {
+    Button,
+    LinkButton,
+  },
+  'Buttons'
+);

--- a/bulma-ui/src/elements/Figure.tsx
+++ b/bulma-ui/src/elements/Figure.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -122,6 +123,10 @@ const FigureComponent: React.FC<FigureProps> = ({
  *   <Figure.Caption>Image caption text</Figure.Caption>
  * </Figure>
  */
-export const Figure = Object.assign(FigureComponent, {
-  Caption: FigureCaption,
-});
+export const Figure = withSubComponents(
+  FigureComponent,
+  {
+    Caption: FigureCaption,
+  },
+  'Figure'
+);

--- a/bulma-ui/src/elements/IconText.stories.tsx
+++ b/bulma-ui/src/elements/IconText.stories.tsx
@@ -307,3 +307,12 @@ export const IconTextWithFlex: Story = {
     },
   },
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <IconText>
+      <IconText.Icon name="star" ariaLabel="star icon" />
+      <span>Starred via dot notation</span>
+    </IconText>
+  ),
+};

--- a/bulma-ui/src/elements/IconText.tsx
+++ b/bulma-ui/src/elements/IconText.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -50,7 +51,7 @@ interface IconTextProps
  * @returns {JSX.Element} The rendered icon text element.
  * @see {@link https://bulma.io/documentation/elements/icon/#icon-text | Bulma IconText documentation}
  */
-export const IconText: React.FC<IconTextProps> = ({
+const IconTextComponent: React.FC<IconTextProps> = ({
   className,
   textColor,
   bgColor,
@@ -93,3 +94,9 @@ export const IconText: React.FC<IconTextProps> = ({
     </span>
   );
 };
+
+export const IconText = withSubComponents(
+  IconTextComponent,
+  { Icon },
+  'IconText'
+);

--- a/bulma-ui/src/elements/OrderedList.stories.tsx
+++ b/bulma-ui/src/elements/OrderedList.stories.tsx
@@ -193,3 +193,14 @@ export const NestedList: Story = {
     </Content>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Content>
+      <OrderedList>
+        <OrderedList.Item>First item via dot notation</OrderedList.Item>
+        <OrderedList.Item>Second item via dot notation</OrderedList.Item>
+      </OrderedList>
+    </Content>
+  ),
+};

--- a/bulma-ui/src/elements/OrderedList.tsx
+++ b/bulma-ui/src/elements/OrderedList.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
+import { ListItem } from './ListItem';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -38,7 +40,7 @@ export interface OrderedListProps
  * @param {OrderedListProps} props - Props for the OrderedList component.
  * @returns {JSX.Element} The rendered ol element.
  */
-export const OrderedList: React.FC<OrderedListProps> = ({
+const OrderedListComponent: React.FC<OrderedListProps> = ({
   className,
   textColor,
   bgColor,
@@ -63,3 +65,9 @@ export const OrderedList: React.FC<OrderedListProps> = ({
     </ol>
   );
 };
+
+export const OrderedList = withSubComponents(
+  OrderedListComponent,
+  { Item: ListItem },
+  'OrderedList'
+);

--- a/bulma-ui/src/elements/Table.stories.tsx
+++ b/bulma-ui/src/elements/Table.stories.tsx
@@ -354,3 +354,32 @@ export const AllModifiers: Story = {
     ),
   },
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Table isStriped>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Team</Table.Th>
+          <Table.Th>Points</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        <Table.Tr>
+          <Table.Td>Maple Leafs</Table.Td>
+          <Table.Td>98</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Td>Canadiens</Table.Td>
+          <Table.Td>91</Table.Td>
+        </Table.Tr>
+      </Table.Tbody>
+      <Table.Tfoot>
+        <Table.Tr>
+          <Table.Td>Total</Table.Td>
+          <Table.Td>189</Table.Td>
+        </Table.Tr>
+      </Table.Tfoot>
+    </Table>
+  ),
+};

--- a/bulma-ui/src/elements/Table.tsx
+++ b/bulma-ui/src/elements/Table.tsx
@@ -3,7 +3,14 @@
  */
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
+import { Thead } from './Thead';
+import { Tbody } from './Tbody';
+import { Tfoot } from './Tfoot';
+import { Tr } from './Tr';
+import { Th } from './Th';
+import { Td } from './Td';
 
 /**
  * Props for the Table component.
@@ -41,7 +48,7 @@ export interface TableProps
  * @returns {JSX.Element} The rendered table element.
  * @see {@link https://bulma.io/documentation/elements/table/ | Bulma Table documentation}
  */
-export const Table: React.FC<TableProps> = ({
+const TableComponent: React.FC<TableProps> = ({
   className,
   isBordered,
   isStriped,
@@ -80,3 +87,16 @@ export const Table: React.FC<TableProps> = ({
 
   return tableElement;
 };
+
+export const Table = withSubComponents(
+  TableComponent,
+  {
+    Thead,
+    Tbody,
+    Tfoot,
+    Tr,
+    Th,
+    Td,
+  },
+  'Table'
+);

--- a/bulma-ui/src/elements/Tags.stories.tsx
+++ b/bulma-ui/src/elements/Tags.stories.tsx
@@ -120,3 +120,13 @@ export const AddonsWithDeleteTag: Story = {
     },
   },
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Tags>
+      <Tags.Tag color="primary">React</Tags.Tag>
+      <Tags.Tag color="info">TypeScript</Tags.Tag>
+      <Tags.Tag color="success">Bulma</Tags.Tag>
+    </Tags>
+  ),
+};

--- a/bulma-ui/src/elements/Tags.tsx
+++ b/bulma-ui/src/elements/Tags.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
+import { Tag } from './Tag';
 
 /**
  * Props for the Tags component.
@@ -30,7 +32,7 @@ export interface TagsProps
  * @returns {JSX.Element} The rendered tags container.
  * @see {@link https://bulma.io/documentation/elements/tag/#list-of-tags | Bulma Tags documentation}
  */
-export const Tags: React.FC<TagsProps> = ({
+const TagsComponent: React.FC<TagsProps> = ({
   className,
   hasAddons,
   isMultiline,
@@ -55,3 +57,5 @@ export const Tags: React.FC<TagsProps> = ({
     </div>
   );
 };
+
+export const Tags = withSubComponents(TagsComponent, { Tag }, 'Tags');

--- a/bulma-ui/src/elements/UnorderedList.stories.tsx
+++ b/bulma-ui/src/elements/UnorderedList.stories.tsx
@@ -143,3 +143,14 @@ export const WithSpacing: Story = {
     </Content>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Content>
+      <UnorderedList>
+        <UnorderedList.Item>First item via dot notation</UnorderedList.Item>
+        <UnorderedList.Item>Second item via dot notation</UnorderedList.Item>
+      </UnorderedList>
+    </Content>
+  ),
+};

--- a/bulma-ui/src/elements/UnorderedList.tsx
+++ b/bulma-ui/src/elements/UnorderedList.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
+import { ListItem } from './ListItem';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -35,7 +37,7 @@ export interface UnorderedListProps
  * @param {UnorderedListProps} props - Props for the UnorderedList component.
  * @returns {JSX.Element} The rendered ul element.
  */
-export const UnorderedList: React.FC<UnorderedListProps> = ({
+const UnorderedListComponent: React.FC<UnorderedListProps> = ({
   className,
   textColor,
   bgColor,
@@ -60,3 +62,9 @@ export const UnorderedList: React.FC<UnorderedListProps> = ({
     </ul>
   );
 };
+
+export const UnorderedList = withSubComponents(
+  UnorderedListComponent,
+  { Item: ListItem },
+  'UnorderedList'
+);

--- a/bulma-ui/src/elements/__tests__/Buttons.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Buttons.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { Buttons } from '../Buttons';
 import { Button } from '../Button';
+import { LinkButton } from '../LinkButton';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Buttons Component', () => {
@@ -160,5 +161,23 @@ describe('Buttons Component', () => {
       expect(buttons).toHaveClass('has-addons');
       expect(buttons).toHaveClass('p-3');
     });
+  });
+});
+
+describe('Compound components', () => {
+  test('Buttons.Button and Buttons.LinkButton are the exported components', () => {
+    expect(Buttons.Button).toBe(Button);
+    expect(Buttons.LinkButton).toBe(LinkButton);
+  });
+
+  test('renders buttons through the dot path', () => {
+    render(
+      <Buttons>
+        <Buttons.Button>Save</Buttons.Button>
+        <Buttons.LinkButton>Docs</Buttons.LinkButton>
+      </Buttons>
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toHaveClass('button');
+    expect(screen.getByRole('button', { name: 'Docs' })).toHaveClass('button');
   });
 });

--- a/bulma-ui/src/elements/__tests__/IconText.test.tsx
+++ b/bulma-ui/src/elements/__tests__/IconText.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { IconText } from '../IconText';
+import { Icon } from '../Icon';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('IconText Component', () => {
@@ -175,5 +176,22 @@ describe('IconText Component', () => {
       expect(iconText).toHaveClass('icon-text');
       expect(iconText).toHaveClass('has-text-danger');
     });
+  });
+});
+
+describe('Compound components', () => {
+  test('IconText.Icon is the Icon component', () => {
+    expect(IconText.Icon).toBe(Icon);
+  });
+
+  test('renders an icon through the dot path', () => {
+    const { container } = render(
+      <IconText>
+        <IconText.Icon name="star" ariaLabel="star icon" />
+        Starred
+      </IconText>
+    );
+    expect(container.querySelector('.icon-text')).toBeInTheDocument();
+    expect(container.querySelector('.icon')).toBeInTheDocument();
   });
 });

--- a/bulma-ui/src/elements/__tests__/OrderedList.test.tsx
+++ b/bulma-ui/src/elements/__tests__/OrderedList.test.tsx
@@ -141,3 +141,20 @@ describe('OrderedList Component', () => {
     });
   });
 });
+
+describe('Compound components', () => {
+  test('OrderedList.Item is the ListItem component', () => {
+    expect(OrderedList.Item).toBe(ListItem);
+  });
+
+  test('renders items through the dot path', () => {
+    render(
+      <OrderedList>
+        <OrderedList.Item>First</OrderedList.Item>
+        <OrderedList.Item>Second</OrderedList.Item>
+      </OrderedList>
+    );
+    expect(screen.getByText('First').tagName).toBe('LI');
+    expect(screen.getByRole('list').tagName).toBe('OL');
+  });
+});

--- a/bulma-ui/src/elements/__tests__/Table.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Table.test.tsx
@@ -1,5 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import { Table, TableProps } from '../Table';
+import { Thead } from '../Thead';
+import { Tbody } from '../Tbody';
+import { Tfoot } from '../Tfoot';
+import { Tr } from '../Tr';
+import { Th } from '../Th';
+import { Td } from '../Td';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Table Component', () => {
@@ -168,5 +174,42 @@ describe('Table Component', () => {
       expect(table).toHaveClass('is-hoverable');
       expect(table).toHaveClass('p-3');
     });
+  });
+});
+
+describe('Compound components', () => {
+  test('statics are the separately exported components', () => {
+    expect(Table.Thead).toBe(Thead);
+    expect(Table.Tbody).toBe(Tbody);
+    expect(Table.Tfoot).toBe(Tfoot);
+    expect(Table.Tr).toBe(Tr);
+    expect(Table.Th).toBe(Th);
+    expect(Table.Td).toBe(Td);
+  });
+
+  test('renders a full table through the dot path', () => {
+    render(
+      <Table>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Name</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          <Table.Tr>
+            <Table.Td>Alice</Table.Td>
+          </Table.Tr>
+        </Table.Tbody>
+        <Table.Tfoot>
+          <Table.Tr>
+            <Table.Td>Total</Table.Td>
+          </Table.Tr>
+        </Table.Tfoot>
+      </Table>
+    );
+    expect(screen.getByRole('table')).toHaveClass('table');
+    expect(screen.getByText('Name').tagName).toBe('TH');
+    expect(screen.getByText('Alice').closest('tbody')).not.toBeNull();
+    expect(screen.getByText('Total').closest('tfoot')).not.toBeNull();
   });
 });

--- a/bulma-ui/src/elements/__tests__/Tags.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Tags.test.tsx
@@ -137,3 +137,20 @@ describe('Tags Component', () => {
     });
   });
 });
+
+describe('Compound components', () => {
+  test('Tags.Tag is the Tag component', () => {
+    expect(Tags.Tag).toBe(Tag);
+  });
+
+  test('renders tags through the dot path', () => {
+    render(
+      <Tags>
+        <Tags.Tag>alpha</Tags.Tag>
+        <Tags.Tag>beta</Tags.Tag>
+      </Tags>
+    );
+    expect(screen.getByText('alpha')).toHaveClass('tag');
+    expect(screen.getByText('beta')).toHaveClass('tag');
+  });
+});

--- a/bulma-ui/src/elements/__tests__/UnorderedList.test.tsx
+++ b/bulma-ui/src/elements/__tests__/UnorderedList.test.tsx
@@ -128,3 +128,20 @@ describe('UnorderedList Component', () => {
     });
   });
 });
+
+describe('Compound components', () => {
+  test('UnorderedList.Item is the ListItem component', () => {
+    expect(UnorderedList.Item).toBe(ListItem);
+  });
+
+  test('renders items through the dot path', () => {
+    render(
+      <UnorderedList>
+        <UnorderedList.Item>First</UnorderedList.Item>
+        <UnorderedList.Item>Second</UnorderedList.Item>
+      </UnorderedList>
+    );
+    expect(screen.getByText('First').tagName).toBe('LI');
+    expect(screen.getByRole('list').tagName).toBe('UL');
+  });
+});

--- a/bulma-ui/src/form/Checkboxes.stories.tsx
+++ b/bulma-ui/src/form/Checkboxes.stories.tsx
@@ -252,3 +252,13 @@ export const UncontrolledGroup: Story = {
     );
   },
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Checkboxes name="frameworks" label="Frameworks">
+      <Checkboxes.Checkbox value="react">React</Checkboxes.Checkbox>
+      <Checkboxes.Checkbox value="vue">Vue</Checkboxes.Checkbox>
+      <Checkboxes.Checkbox value="svelte">Svelte</Checkboxes.Checkbox>
+    </Checkboxes>
+  ),
+};

--- a/bulma-ui/src/form/Checkboxes.tsx
+++ b/bulma-ui/src/form/Checkboxes.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 import {
   useInsideField,
@@ -10,6 +11,7 @@ import {
 import { Field } from './Field';
 import { Control } from './Control';
 import { FormFieldProps } from './fieldProps';
+import { Checkbox } from './Checkbox';
 
 /**
  * Props for the Checkboxes component.
@@ -69,7 +71,7 @@ export interface CheckboxesProps
  *   <Checkbox value="angular">Angular</Checkbox>
  * </Checkboxes>
  */
-export const Checkboxes: React.FC<CheckboxesProps> = ({
+const CheckboxesComponent: React.FC<CheckboxesProps> = ({
   label,
   labelSize,
   labelProps,
@@ -158,5 +160,11 @@ export const Checkboxes: React.FC<CheckboxesProps> = ({
     </>
   );
 };
+
+export const Checkboxes = withSubComponents(
+  CheckboxesComponent,
+  { Checkbox },
+  'Checkboxes'
+);
 
 export default Checkboxes;

--- a/bulma-ui/src/form/Field.stories.tsx
+++ b/bulma-ui/src/form/Field.stories.tsx
@@ -408,3 +408,16 @@ export const AddonsRight: Story = {
     </Field>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Field horizontal>
+      <Field.Label>Name</Field.Label>
+      <Field.Body>
+        <Field.Control>
+          <Input placeholder="Jane Doe" />
+        </Field.Control>
+      </Field.Body>
+    </Field>
+  ),
+};

--- a/bulma-ui/src/form/Field.tsx
+++ b/bulma-ui/src/form/Field.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
   validColors,
 } from '../helpers/useBulmaClasses';
 import { FieldProvider } from './FormContext';
+import { Control } from './Control';
 
 /**
  * Props for the Field component.
@@ -175,10 +177,7 @@ export const FieldBody: React.FC<FieldBodyProps> = ({
  *   <input className="input" />
  * </Field>
  */
-export const Field: React.FC<FieldProps> & {
-  Label: typeof FieldLabel;
-  Body: typeof FieldBody;
-} = ({
+const FieldComponent: React.FC<FieldProps> = ({
   horizontal,
   grouped,
   hasAddons,
@@ -284,7 +283,15 @@ export const Field: React.FC<FieldProps> & {
 
 FieldLabel.displayName = 'FieldLabel';
 FieldBody.displayName = 'FieldBody';
-Field.Label = FieldLabel;
-Field.Body = FieldBody;
+
+export const Field = withSubComponents(
+  FieldComponent,
+  {
+    Label: FieldLabel,
+    Body: FieldBody,
+    Control,
+  },
+  'Field'
+);
 
 export default Field;

--- a/bulma-ui/src/form/Radios.stories.tsx
+++ b/bulma-ui/src/form/Radios.stories.tsx
@@ -260,3 +260,13 @@ export const UncontrolledGroup: Story = {
     );
   },
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Radios name="color" label="Favorite color">
+      <Radios.Radio value="red">Red</Radios.Radio>
+      <Radios.Radio value="green">Green</Radios.Radio>
+      <Radios.Radio value="blue">Blue</Radios.Radio>
+    </Radios>
+  ),
+};

--- a/bulma-ui/src/form/Radios.tsx
+++ b/bulma-ui/src/form/Radios.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 import {
   useInsideField,
@@ -10,6 +11,7 @@ import {
 import { Field } from './Field';
 import { Control } from './Control';
 import { FormFieldProps } from './fieldProps';
+import { Radio } from './Radio';
 
 /**
  * Props for the Radios component.
@@ -69,7 +71,7 @@ export interface RadiosProps
  *   <Radio value="green">Green</Radio>
  * </Radios>
  */
-export const Radios: React.FC<RadiosProps> = ({
+const RadiosComponent: React.FC<RadiosProps> = ({
   label,
   labelSize,
   labelProps,
@@ -161,5 +163,7 @@ export const Radios: React.FC<RadiosProps> = ({
     </>
   );
 };
+
+export const Radios = withSubComponents(RadiosComponent, { Radio }, 'Radios');
 
 export default Radios;

--- a/bulma-ui/src/form/__tests__/Checkboxes.test.tsx
+++ b/bulma-ui/src/form/__tests__/Checkboxes.test.tsx
@@ -192,3 +192,19 @@ describe('Checkboxes', () => {
     });
   });
 });
+
+describe('Compound components', () => {
+  test('Checkboxes.Checkbox is the Checkbox component', () => {
+    expect(Checkboxes.Checkbox).toBe(Checkbox);
+  });
+
+  test('renders checkboxes through the dot path', () => {
+    render(
+      <Checkboxes name="tags">
+        <Checkboxes.Checkbox value="react">React</Checkboxes.Checkbox>
+        <Checkboxes.Checkbox value="vue">Vue</Checkboxes.Checkbox>
+      </Checkboxes>
+    );
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+  });
+});

--- a/bulma-ui/src/form/__tests__/Field.test.tsx
+++ b/bulma-ui/src/form/__tests__/Field.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Field from '../Field';
+import { Control } from '../Control';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Field', () => {
@@ -317,5 +318,27 @@ describe('Field', () => {
       expect(field).toHaveClass('has-addons');
       expect(field).toHaveClass('p-3');
     });
+  });
+});
+
+describe('Compound components', () => {
+  test('Field.Control is the Control component', () => {
+    expect(Field.Control).toBe(Control);
+  });
+
+  test('renders a horizontal field through Field.Label and Field.Body', () => {
+    const { container } = render(
+      <Field horizontal>
+        <Field.Label>Name</Field.Label>
+        <Field.Body>
+          <Field.Control>
+            <input className="input" />
+          </Field.Control>
+        </Field.Body>
+      </Field>
+    );
+    expect(container.querySelector('.field-label')).toBeInTheDocument();
+    expect(container.querySelector('.field-body')).toBeInTheDocument();
+    expect(container.querySelector('.control')).toBeInTheDocument();
   });
 });

--- a/bulma-ui/src/form/__tests__/Radios.test.tsx
+++ b/bulma-ui/src/form/__tests__/Radios.test.tsx
@@ -190,3 +190,19 @@ describe('Radios', () => {
     });
   });
 });
+
+describe('Compound components', () => {
+  test('Radios.Radio is the Radio component', () => {
+    expect(Radios.Radio).toBe(Radio);
+  });
+
+  test('renders radios through the dot path', () => {
+    render(
+      <Radios name="color">
+        <Radios.Radio value="red">Red</Radios.Radio>
+        <Radios.Radio value="green">Green</Radios.Radio>
+      </Radios>
+    );
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+});

--- a/bulma-ui/src/grid/Grid.stories.tsx
+++ b/bulma-ui/src/grid/Grid.stories.tsx
@@ -252,3 +252,14 @@ export const FixedGridAutoCount = () => {
     </Grid>
   );
 };
+
+export const CompoundUsage = () => (
+  <Grid>
+    <Grid.Cell>
+      <Notification color="primary">Cell via dot notation</Notification>
+    </Grid.Cell>
+    <Grid.Cell>
+      <Notification color="info">Another cell via dot notation</Notification>
+    </Grid.Cell>
+  </Grid>
+);

--- a/bulma-ui/src/grid/Grid.tsx
+++ b/bulma-ui/src/grid/Grid.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
+import { Cell } from './Cell';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -125,7 +127,7 @@ export interface GridProps
  * @returns {JSX.Element} The rendered grid.
  * @see {@link https://bulma.io/documentation/grid/ | Bulma Grid documentation}
  */
-export const Grid: React.FC<GridProps> = ({
+const GridComponent: React.FC<GridProps> = ({
   isFixed = false,
   gap,
   columnGap,
@@ -202,3 +204,5 @@ export const Grid: React.FC<GridProps> = ({
     </div>
   );
 };
+
+export const Grid = withSubComponents(GridComponent, { Cell }, 'Grid');

--- a/bulma-ui/src/grid/__tests__/Grid.test.tsx
+++ b/bulma-ui/src/grid/__tests__/Grid.test.tsx
@@ -244,3 +244,20 @@ describe('Grid', () => {
     });
   });
 });
+
+describe('Compound components', () => {
+  test('Grid.Cell is the Cell component', () => {
+    expect(Grid.Cell).toBe(Cell);
+  });
+
+  test('renders cells through the dot path', () => {
+    const { container } = render(
+      <Grid>
+        <Grid.Cell>One</Grid.Cell>
+        <Grid.Cell>Two</Grid.Cell>
+      </Grid>
+    );
+    expect(container.querySelector('.grid')).toBeInTheDocument();
+    expect(container.querySelectorAll('.cell')).toHaveLength(2);
+  });
+});

--- a/bulma-ui/src/helpers/__tests__/withSubComponents.test.tsx
+++ b/bulma-ui/src/helpers/__tests__/withSubComponents.test.tsx
@@ -1,0 +1,55 @@
+import React, { forwardRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { withSubComponents } from '../withSubComponents';
+
+describe('withSubComponents', () => {
+  const Sub: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+    <span data-testid="sub">{children}</span>
+  );
+
+  it('returns the same object it was given (identity preserved)', () => {
+    const Base: React.FC = () => <div />;
+    const result = withSubComponents(Base, { Sub });
+    expect(result).toBe(Base);
+  });
+
+  it('attaches sub-components as statics', () => {
+    const Base: React.FC = () => <div />;
+    const result = withSubComponents(Base, { Sub });
+    expect(result.Sub).toBe(Sub);
+  });
+
+  it('sets displayName on the parent when provided', () => {
+    const Base: React.FC = () => <div />;
+    const result = withSubComponents(Base, { Sub }, 'Base');
+    expect(result.displayName).toBe('Base');
+  });
+
+  it('leaves displayName untouched when omitted', () => {
+    const Base: React.FC = () => <div />;
+    Base.displayName = 'Existing';
+    const result = withSubComponents(Base, { Sub });
+    expect(result.displayName).toBe('Existing');
+  });
+
+  it('works on a forwardRef base component', () => {
+    const Base = forwardRef<HTMLDivElement, { children?: React.ReactNode }>(
+      ({ children }, ref) => (
+        <div data-testid="base" ref={ref}>
+          {children}
+        </div>
+      )
+    );
+    const Compound = withSubComponents(Base, { Sub }, 'Compound');
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <Compound ref={ref}>
+        <Compound.Sub>inner</Compound.Sub>
+      </Compound>
+    );
+    expect(screen.getByTestId('base')).toBeInTheDocument();
+    expect(screen.getByTestId('sub')).toHaveTextContent('inner');
+    expect(ref.current).toBe(screen.getByTestId('base'));
+    expect(Compound.displayName).toBe('Compound');
+  });
+});

--- a/bulma-ui/src/helpers/withSubComponents.ts
+++ b/bulma-ui/src/helpers/withSubComponents.ts
@@ -1,0 +1,23 @@
+/**
+ * Attaches compound sub-components as statics on a base component and
+ * optionally sets the parent's displayName.
+ *
+ * Internal helper — it MUST mutate and return the same function object
+ * (`Object.assign`), never wrap the base in a new function: identity checks
+ * like `child.type === ModalCard` (Modal) and Field's displayName-based
+ * child detection rely on the attached component being the same object as
+ * the separately exported one.
+ *
+ * displayName is only ever set on the parent (and only when provided) —
+ * sub-components keep whatever displayName they declare themselves.
+ */
+export function withSubComponents<
+  Base extends { displayName?: string },
+  Subs extends Record<string, unknown>,
+>(base: Base, subs: Subs, displayName?: string): Base & Subs {
+  const compound = Object.assign(base, subs) as Base & Subs;
+  if (displayName !== undefined) {
+    compound.displayName = displayName;
+  }
+  return compound;
+}

--- a/bulma-ui/src/layout/Hero.tsx
+++ b/bulma-ui/src/layout/Hero.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -42,11 +43,7 @@ export interface HeroProps
  * @returns {JSX.Element} The rendered hero.
  * @see {@link https://bulma.io/documentation/layout/hero/ | Bulma Hero documentation}
  */
-export const Hero: React.FC<HeroProps> & {
-  Head: typeof HeroHead;
-  Body: typeof HeroBody;
-  Foot: typeof HeroFoot;
-} = ({
+const HeroComponent: React.FC<HeroProps> = ({
   className,
   color,
   size,
@@ -223,8 +220,14 @@ export const HeroFoot: React.FC<HeroFootProps> = ({
 };
 
 // Attach subcomponents
-Hero.Head = HeroHead;
-Hero.Body = HeroBody;
-Hero.Foot = HeroFoot;
+export const Hero = withSubComponents(
+  HeroComponent,
+  {
+    Head: HeroHead,
+    Body: HeroBody,
+    Foot: HeroFoot,
+  },
+  'Hero'
+);
 
 export default Hero;

--- a/bulma-ui/src/layout/Level.tsx
+++ b/bulma-ui/src/layout/Level.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -36,11 +37,7 @@ export interface LevelProps
  * @returns {JSX.Element} The rendered level.
  * @see {@link https://bulma.io/documentation/layout/level/ | Bulma Level documentation}
  */
-export const Level: React.FC<LevelProps> & {
-  Left: typeof LevelLeft;
-  Right: typeof LevelRight;
-  Item: typeof LevelItem;
-} = ({
+const LevelComponent: React.FC<LevelProps> = ({
   isMobile,
   className,
   children,
@@ -253,8 +250,14 @@ export const LevelItem: React.FC<LevelItemProps> = ({
   );
 };
 
-Level.Left = LevelLeft;
-Level.Right = LevelRight;
-Level.Item = LevelItem;
+export const Level = withSubComponents(
+  LevelComponent,
+  {
+    Left: LevelLeft,
+    Right: LevelRight,
+    Item: LevelItem,
+  },
+  'Level'
+);
 
 export default Level;

--- a/bulma-ui/src/layout/Media.tsx
+++ b/bulma-ui/src/layout/Media.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { classNames, usePrefixedClassNames } from '../helpers/classNames';
+import { withSubComponents } from '../helpers/withSubComponents';
 import {
   useBulmaClasses,
   BulmaClassesProps,
@@ -36,7 +37,7 @@ export interface MediaProps
  * @returns {JSX.Element} The rendered media container.
  * @see {@link https://bulma.io/documentation/layout/media-object/ | Bulma Media documentation}
  */
-export const Media: React.FC<MediaProps> = ({
+const MediaComponent: React.FC<MediaProps> = ({
   as = 'article',
   className,
   children,
@@ -219,16 +220,15 @@ export const MediaRight: React.FC<MediaRightProps> = ({
   );
 };
 
-/** Media component type with Left, Content, and Right sub-components. */
-interface MediaComponent extends React.FC<MediaProps> {
-  Left: React.FC<MediaLeftProps>;
-  Content: React.FC<MediaContentProps>;
-  Right: React.FC<MediaRightProps>;
-}
+/** Media component with Left, Content, and Right sub-components. */
+export const Media = withSubComponents(
+  MediaComponent,
+  {
+    Left: MediaLeft,
+    Content: MediaContent,
+    Right: MediaRight,
+  },
+  'Media'
+);
 
-const MediaWithSubcomponents = Media as MediaComponent;
-MediaWithSubcomponents.Left = MediaLeft;
-MediaWithSubcomponents.Content = MediaContent;
-MediaWithSubcomponents.Right = MediaRight;
-
-export default MediaWithSubcomponents;
+export default Media;

--- a/docs/docs/api/columns/columns.md
+++ b/docs/docs/api/columns/columns.md
@@ -610,6 +610,23 @@ This example shows how to combine the `isCentered` prop with multiline columns. 
 
 ---
 
+### Compound (dot-notation) usage
+
+`Column` is also available as `Columns.Column`, so the whole layout can be composed from the single `Columns` import.
+
+```tsx live
+<Columns>
+  <Columns.Column>
+    <Notification color="primary">First column</Notification>
+  </Columns.Column>
+  <Columns.Column>
+    <Notification color="info">Second column</Notification>
+  </Columns.Column>
+</Columns>
+```
+
+---
+
 ## Notes
 
 - Use `Column` as a direct child of `Columns` for proper grid behavior.

--- a/docs/docs/api/elements/buttons.md
+++ b/docs/docs/api/elements/buttons.md
@@ -117,6 +117,20 @@ The `isRight` prop aligns the button group to the right edge of its container. T
 
 ---
 
+### Compound (dot-notation) usage
+
+`Button` and `LinkButton` are also available as `Buttons.Button` and `Buttons.LinkButton`, so a button group can be composed from the single `Buttons` import.
+
+```tsx live
+<Buttons>
+  <Buttons.Button color="primary">Save</Buttons.Button>
+  <Buttons.Button>Cancel</Buttons.Button>
+  <Buttons.LinkButton>Learn more</Buttons.LinkButton>
+</Buttons>
+```
+
+---
+
 ## Accessibility
 
 - Grouping buttons in a `<div class="buttons">` has no negative impact on accessibility.

--- a/docs/docs/api/elements/icontext.md
+++ b/docs/docs/api/elements/icontext.md
@@ -258,6 +258,19 @@ The `display` prop can be used to apply Bulma's flexbox helpers, allowing for fl
 
 ---
 
+### Compound (dot-notation) usage
+
+`Icon` is also available as `IconText.Icon`, so an icon-and-text pairing can be composed from the single `IconText` import.
+
+```tsx live
+<IconText>
+  <IconText.Icon name="star" ariaLabel="star icon" />
+  <span>Starred</span>
+</IconText>
+```
+
+---
+
 ## Accessibility
 
 - **ARIA labels:** Always set an `ariaLabel` for icons for screen readers.

--- a/docs/docs/api/elements/orderedlist.md
+++ b/docs/docs/api/elements/orderedlist.md
@@ -164,6 +164,21 @@ Create nested ordered lists with different numbering types.
 
 ---
 
+### Compound (dot-notation) usage
+
+`ListItem` is also available as `OrderedList.Item`, so a list can be composed from the single `OrderedList` import.
+
+```tsx live
+<Content>
+  <OrderedList>
+    <OrderedList.Item>First item</OrderedList.Item>
+    <OrderedList.Item>Second item</OrderedList.Item>
+  </OrderedList>
+</Content>
+```
+
+---
+
 ## Accessibility
 
 - **List Structure:** Screen readers announce ordered lists with their numbering, helping users understand sequential content.

--- a/docs/docs/api/elements/table.md
+++ b/docs/docs/api/elements/table.md
@@ -248,6 +248,29 @@ To control the alignment and width of table header cells, use the `isAligned` an
 
 ---
 
+### Compound (dot-notation) usage
+
+Every table sub-component is also available as a static on `Table` under its exact export name — `Table.Thead`, `Table.Tbody`, `Table.Tfoot`, `Table.Tr`, `Table.Th`, and `Table.Td` — so a full table can be composed from the single `Table` import.
+
+```tsx live
+<Table isStriped>
+  <Table.Thead>
+    <Table.Tr>
+      <Table.Th>Team</Table.Th>
+      <Table.Th>Points</Table.Th>
+    </Table.Tr>
+  </Table.Thead>
+  <Table.Tbody>
+    <Table.Tr>
+      <Table.Td>Maple Leafs</Table.Td>
+      <Table.Td>98</Table.Td>
+    </Table.Tr>
+  </Table.Tbody>
+</Table>
+```
+
+---
+
 ## Accessibility
 
 - **Semantics:** Uses `<table>`, `<thead>`, `<tbody>`, `<tfoot>`, `<tr>`, `<th>`, and `<td>`—all proper HTML table elements.

--- a/docs/docs/api/elements/tags.md
+++ b/docs/docs/api/elements/tags.md
@@ -122,6 +122,19 @@ You can combine `hasAddons` with a delete tag to create a tightly grouped, dismi
 
 ---
 
+### Compound (dot-notation) usage
+
+`Tag` is also available as `Tags.Tag`, so a tag group can be composed from the single `Tags` import.
+
+```tsx live
+<Tags>
+  <Tags.Tag color="primary">React</Tags.Tag>
+  <Tags.Tag color="info">TypeScript</Tags.Tag>
+</Tags>
+```
+
+---
+
 ## Accessibility
 
 - **Grouping:** The container is a `<div class="tags">`, which is semantically neutral.

--- a/docs/docs/api/elements/unorderedlist.md
+++ b/docs/docs/api/elements/unorderedlist.md
@@ -120,6 +120,21 @@ Apply different colors to individual list items.
 
 ---
 
+### Compound (dot-notation) usage
+
+`ListItem` is also available as `UnorderedList.Item`, so a list can be composed from the single `UnorderedList` import.
+
+```tsx live
+<Content>
+  <UnorderedList>
+    <UnorderedList.Item>First item</UnorderedList.Item>
+    <UnorderedList.Item>Second item</UnorderedList.Item>
+  </UnorderedList>
+</Content>
+```
+
+---
+
 ## Accessibility
 
 - **List Structure:** Screen readers announce the list and the number of items, helping users understand the content structure.

--- a/docs/docs/api/form/checkboxes.md
+++ b/docs/docs/api/form/checkboxes.md
@@ -124,6 +124,19 @@ function example() {
 
 ---
 
+### Compound (dot-notation) usage
+
+`Checkbox` is also available as `Checkboxes.Checkbox`, so a checkbox group can be composed from the single `Checkboxes` import.
+
+```tsx live
+<Checkboxes name="frameworks" label="Frameworks">
+  <Checkboxes.Checkbox value="react">React</Checkboxes.Checkbox>
+  <Checkboxes.Checkbox value="vue">Vue</Checkboxes.Checkbox>
+</Checkboxes>
+```
+
+---
+
 ## Group State
 
 `Checkboxes` can manage the selected-values array for the entire group, matching the pattern used by React Aria's `CheckboxGroup`. Three usage modes:

--- a/docs/docs/api/form/field.md
+++ b/docs/docs/api/form/field.md
@@ -479,6 +479,23 @@ This example demonstrates using the `Field` component to create a group of contr
 
 ---
 
+### Compound (dot-notation) usage
+
+Alongside the existing `Field.Label` and `Field.Body` statics, `Control` is now also available as `Field.Control`, so a field can be composed from the single `Field` import.
+
+```tsx live
+<Field horizontal>
+  <Field.Label>Name</Field.Label>
+  <Field.Body>
+    <Field.Control>
+      <Input placeholder="Jane Doe" />
+    </Field.Control>
+  </Field.Body>
+</Field>
+```
+
+---
+
 ## Accessibility
 
 - Uses `<label>` for accessible field labeling.

--- a/docs/docs/api/form/radios.md
+++ b/docs/docs/api/form/radios.md
@@ -126,6 +126,19 @@ function example() {
 
 ---
 
+### Compound (dot-notation) usage
+
+`Radio` is also available as `Radios.Radio`, so a radio group can be composed from the single `Radios` import.
+
+```tsx live
+<Radios name="color" label="Favorite color">
+  <Radios.Radio value="red">Red</Radios.Radio>
+  <Radios.Radio value="green">Green</Radios.Radio>
+</Radios>
+```
+
+---
+
 ## Group State
 
 `Radios` can manage selection state for the entire group, matching the pattern used by MUI's `RadioGroup`, Radix's `RadioGroup`, and React Aria's `RadioGroup`. Three usage modes:

--- a/docs/docs/api/grid/grid.md
+++ b/docs/docs/api/grid/grid.md
@@ -204,6 +204,23 @@ This example shows how to use `fixedCols="auto"` to let the grid automatically d
 
 ---
 
+### Compound (dot-notation) usage
+
+`Cell` is also available as `Grid.Cell`, so a grid can be composed from the single `Grid` import.
+
+```tsx live
+<Grid>
+  <Grid.Cell>
+    <Notification color="primary">Cell 1</Notification>
+  </Grid.Cell>
+  <Grid.Cell>
+    <Notification color="info">Cell 2</Notification>
+  </Grid.Cell>
+</Grid>
+```
+
+---
+
 ## Cell Placement Examples
 
 See [Cell documentation](./cell.md) for granular placement using `colStart`, `colFromEnd`, `colSpan`, `rowStart`, `rowSpan`, etc.

--- a/scripts/gen-component-catalog.mjs
+++ b/scripts/gen-component-catalog.mjs
@@ -228,8 +228,8 @@ instead of hand-writing markup.
   (\`m\`/\`p\` spacing, \`textColor\`/\`bgColor\`, \`textAlign\`, \`display\`, flex, …) —
   documented once in \`references/api.md\`.
 - **Compound components** expose sub-parts via dot access (e.g. \`Card.Header\`,
-  \`Navbar.Item\`, \`Tabs.Tab\`, \`Hero.Body\`); see the component's linked page for the
-  full set.
+  \`Navbar.Item\`, \`Tabs.Tab\`, \`Hero.Body\`, \`Columns.Column\`, \`Table.Tr\`); see the
+  component's linked page for the full set.
 - Raw \`*Base\` form exports (\`InputBase\`, \`SelectBase\`, \`TextAreaBase\`, …) are
   escape-hatch variants of the convenience wrappers above them; see the Form docs.
 

--- a/skills/bestax-custom-component/references/component-catalog.md
+++ b/skills/bestax-custom-component/references/component-catalog.md
@@ -14,8 +14,8 @@ instead of hand-writing markup.
   (`m`/`p` spacing, `textColor`/`bgColor`, `textAlign`, `display`, flex, …) —
   documented once in `references/api.md`.
 - **Compound components** expose sub-parts via dot access (e.g. `Card.Header`,
-  `Navbar.Item`, `Tabs.Tab`, `Hero.Body`); see the component's linked page for the
-  full set.
+  `Navbar.Item`, `Tabs.Tab`, `Hero.Body`, `Columns.Column`, `Table.Tr`); see the
+  component's linked page for the full set.
 - Raw `*Base` form exports (`InputBase`, `SelectBase`, `TextAreaBase`, …) are
   escape-hatch variants of the convenience wrappers above them; see the Form docs.
 

--- a/skills/bestax-layout-scaffold/references/layout-components.md
+++ b/skills/bestax-layout-scaffold/references/layout-components.md
@@ -91,7 +91,8 @@ Every component also accepts the shared Bulma helper props (`m`/`p` spacing, `te
 
 ## Columns / Column
 
-The responsive grid. `Columns` is the row; `Column` is a cell.
+The responsive grid. `Columns` is the row; `Column` is a cell (also reachable as
+`Columns.Column`).
 
 **Columns**
 
@@ -156,7 +157,7 @@ the column's auto height). Make the `Column` a flex container and let the card g
 
 ## Grid / Cell
 
-Bulma's CSS Grid. **Preferred for uniform grids** — same-shaped items in a repeating pattern
+Bulma's CSS Grid (`Cell` is also reachable as `Grid.Cell`). **Preferred for uniform grids** — same-shaped items in a repeating pattern
 (card grids, galleries, dashboards): CSS Grid gives **equal-height cells for free** (per row —
 each row's cells match its tallest), with no flex recipe needed. Reach for `Columns`/`Column` instead when you need proportional or
 per-breakpoint column _sizes_ (a 2/3 + 1/3 split, different counts per breakpoint).


### PR DESCRIPTION
# Pull Request

## Description

Adds compound (dot-notation) sub-component access across the library and converges every compound parent onto one shared, typed attachment helper. Two commits:

1. **`refactor(bulma-ui)`** — new internal helper `src/helpers/withSubComponents.ts` that attaches statics by mutating the base component (identity-preserving — `Modal`'s `child.type === ModalCard` check and `Field`'s displayName-based child detection depend on it) and sets `displayName` on the parent. All 17 existing compound parents (Card, Navbar, Tabs, Modal, Message, Field, Media, Level, Hero, Panel, Pagination, Dropdown, Menu, Sidebar, Steps, Avatars, Figure) migrated off three divergent idioms (`Object.assign` / inline intersection types / `*WithCompounds` casts). Also fixes the named `Media` export, which previously lacked the statics in its type (only the default export had them).
2. **`feat(bulma-ui)`** — 10 new compound families, every existing named export unchanged (purely additive): `Columns.Column`, `Grid.Cell`, `Table.Thead/.Tbody/.Tfoot/.Tr/.Th/.Td` (exact export names), `Buttons.Button`/`Buttons.LinkButton`, `Tags.Tag`, `OrderedList.Item`, `UnorderedList.Item`, `IconText.Icon`, `Checkboxes.Checkbox`, `Radios.Radio`, and `Field.Control` (joining `Field.Label`/`Field.Body`).

Each new family ships with identity + dot-path render tests, a `CompoundUsage` story, and a `### Compound (dot-notation) usage` live example on its API docs page. The skill catalog header now cites the new dot paths (`Columns.Column`, `Table.Tr`) and the layout-scaffold skill references mention them; catalog regenerated via `pnpm gen:catalog`.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): skills (generated catalog + layout-scaffold references), `scripts/gen-component-catalog.mjs` header text

## Related Issue(s)

Refs #330 (follow-up: parity artifacts for the 17 pre-existing compound families + codifying the standard in CLAUDE.md)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [x] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

```tsx
// Before: separate imports required          // After: dot notation also works
<Columns>                                     <Columns>
  <Column>One</Column>                          <Columns.Column>One</Columns.Column>
</Columns>                                    </Columns>

<Table>
  <Table.Thead>
    <Table.Tr><Table.Th>Name</Table.Th></Table.Tr>
  </Table.Thead>
</Table>
```

Live examples render on each affected API docs page (the live-codeblock scope spreads the full library, so dot statics resolve in the browser preview).

## Additional Context

- Full gate green locally: `pnpm all` (build, typecheck, tests + 99% coverage on all metrics, bundle:stats, lint, format:check, storybook build) and `pnpm check:conformance`; catalog freshness verified.
- Net release: one **minor** bump of `@allxsmith/bestax-bulma` (`feat` outranks the `refactor` patch).
- The helper is internal-only (not exported from `src/index.ts`), so no new public API beyond the statics themselves.
- CLAUDE.md convention updates are deliberately deferred to #330 alongside the parity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuJRpjY81Dzoo92ZooE8Xt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuJRpjY81Dzoo92ZooE8Xt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dot-notation compound component access across layout, form, element, and navigation components, including `Table.Tr`, `Columns.Column`, `Field.Control`, and others.
  * Added Storybook examples demonstrating compound component composition.
* **Documentation**
  * Added usage guidance and examples for compound components throughout the component documentation.
  * Updated component catalog references with additional dot-notation examples.
* **Tests**
  * Added coverage validating compound component references, rendering, and ref forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->