### PR TITLE
chore: force patched brace-expansion via pnpm overrides (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   prettier: 3.9.4
   serialize-javascript: '>=7.0.3'
+  brace-expansion@<1.1.16: '>=1.1.16 <2'
+  brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'
+  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
 
 importers:
 
@@ -4508,14 +4511,14 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -15370,16 +15373,16 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -18850,15 +18853,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   serialize-javascript: '>=7.0.3'
   brace-expansion@<1.1.16: '>=1.1.16 <2'
   brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3'
-  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
+  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7 <6'
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,11 @@ overrides:
   # Force the patched serialize-javascript (transitive via Docusaurus webpack
   # plugins) — <=7.0.2 has an RCE advisory (GHSA-5c6j-r48x-rmvq).
   serialize-javascript: '>=7.0.3'
+  # Force patched brace-expansion (transitive via minimatch across the jest and
+  # eslint toolchains) — DoS advisory GHSA-3jxr-9vmj-r5cp, patched per major.
+  'brace-expansion@<1.1.16': '>=1.1.16 <2'
+  'brace-expansion@>=2.0.0 <2.1.2': '>=2.1.2 <3'
+  'brace-expansion@>=3.0.0 <5.0.7': '>=5.0.7'
 
 # Strict, symlinked node_modules prevents phantom dependencies (using packages
 # we never declared). Narrow public hoists only for tooling that needs a flat

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ overrides:
   # eslint toolchains) — DoS advisory GHSA-3jxr-9vmj-r5cp, patched per major.
   'brace-expansion@<1.1.16': '>=1.1.16 <2'
   'brace-expansion@>=2.0.0 <2.1.2': '>=2.1.2 <3'
-  'brace-expansion@>=3.0.0 <5.0.7': '>=5.0.7'
+  'brace-expansion@>=3.0.0 <5.0.7': '>=5.0.7 <6'
 
 # Strict, symlinked node_modules prevents phantom dependencies (using packages
 # we never declared). Narrow public hoists only for tooling that needs a flat


### PR DESCRIPTION
# Pull Request

## Description

Fixes the post-merge CI failure on `main`: `pnpm audit --audit-level=high` newly fails because **`brace-expansion`** picked up a high-severity DoS advisory ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)) across three ranges (`<1.1.16`, `2.0.0–2.1.1`, `3.0.0–5.0.6`), reached transitively through `minimatch` in the jest and eslint toolchains (dev-only; ~100 paths). This blocked the audit step on the #331 merge commit and caused the **Publish to npm job to be skipped**, so the pending minor release hasn't gone out.

The fix adds per-major `pnpm` overrides in `pnpm-workspace.yaml`, mirroring the existing `serialize-javascript` security override, forcing the patched releases `1.1.16` / `2.1.2` / `5.0.7`. All three patched versions were published 12+ days ago, comfortably past the 3-day `minimumReleaseAge` cooldown, so no exclude entry is needed. Lockfile regenerated.

After the change, `pnpm audit --audit-level=high` passes locally (only 3 moderate advisories remain, below the CI gate), and the full `pnpm all` gate is green.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): workspace-level dependency overrides (`pnpm-workspace.yaml` + `pnpm-lock.yaml`) — no package source changes

## Related Issue(s)

Related to #331 (its merge surfaced the failure; merging this unblocks the skipped release)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

```
# before                                   # after
pnpm audit --audit-level=high              pnpm audit --audit-level=high
6 vulnerabilities found                    3 vulnerabilities found
Severity: 3 moderate | 3 high  → exit 1    Severity: 3 moderate       → exit 0
```

## Additional Context

- `chore` commit type: dev-only transitive dependency pin, no release of any package by itself — but once merged, the next green CI run on `main` will run the previously-skipped Publish job and release the pending `feat` minor from #331.
- The 3 remaining moderate advisories are below the CI gate (`--audit-level=high`); they can be handled separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuJRpjY81Dzoo92ZooE8Xt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuJRpjY81Dzoo92ZooE8Xt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependency resolution to require patched versions of a transitive package.
  * Prevented vulnerable package versions from being selected during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->