### PR TITLE
test(bulma-ui): compound component parity — identity tests, CompoundUsage stories, live docs sections

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docs",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "--filter",
+        "@allxsmith/bestax-docs",
+        "exec",
+        "docusaurus",
+        "start",
+        "--port",
+        "3210",
+        "--no-open"
+      ],
+      "port": 3210
+    },
+    {
+      "name": "storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["storybook"],
+      "port": 6006
+    }
+  ]
+}

--- a/bulma-ui/CLAUDE.md
+++ b/bulma-ui/CLAUDE.md
@@ -38,6 +38,14 @@ improvising.
 
 - Every component routes its Bulma helper props through `useBulmaClasses` and forwards
   `...rest`; see `src/helpers/CLAUDE.md` before adding a prop that several components share.
+- Multi-part components attach sub-components as statics via `withSubComponents`
+  (`src/helpers/withSubComponents.ts`) — it must mutate the base (identity-preserving),
+  never wrap it. A compound family ships four artifacts beyond the base anatomy rule:
+  an identity test per static (`expect(Parent.Sub).toBe(Sub)`, or `toBeDefined()` +
+  dot-path render for module-private subs) in a `describe('Compound components')` block,
+  a `CompoundUsage` story, and a `### Compound (dot-notation) usage` live example at the
+  end of the API page's `## Usage` section. Prefer exporting subs by name from the same
+  module so identity tests are possible.
 - Components must work with a custom class prefix (`ConfigProvider`) — tests assert
   `bestax-`-prefixed class output; never hardcode a `"button"`-style class string outside the
   classname helpers (`usePrefixedClassNames`).

--- a/bulma-ui/src/components/CLAUDE.md
+++ b/bulma-ui/src/components/CLAUDE.md
@@ -10,7 +10,11 @@ beyond stock Bulma (Carousel, Dialog, Toast, …). The generated
 Conventions:
 
 - Multi-part components use the compound pattern — `Card.Header`, `Navbar.Item`, `Modal.Card` —
-  subcomponents attached to the parent, exported from the same file.
+  statics attached via `withSubComponents` (`../helpers/withSubComponents.ts`, mutates the
+  base, never wraps), exported from the same file. Each compound family ships the four
+  compound artifacts listed under Conventions in `bulma-ui/CLAUDE.md`: identity tests in a
+  `describe('Compound components')` block, a dot-path render test, a `CompoundUsage` story,
+  and a `### Compound (dot-notation) usage` docs example.
 - **Stock Bulma components ship no CSS.** Extras pair with a partial in `../scss/components/`
   following the pattern in `../scss/CLAUDE.md` — and a stock component can still have an
   extending partial (Tabs gains vertical mode from `_tabs.scss`), so check

--- a/bulma-ui/src/components/Dropdown.stories.tsx
+++ b/bulma-ui/src/components/Dropdown.stories.tsx
@@ -58,3 +58,12 @@ export const Up = () => (
     </Dropdown>
   </>
 );
+
+export const CompoundUsage = () => (
+  <Dropdown label="Compound Dropdown" active>
+    <Dropdown.Item>First Item</Dropdown.Item>
+    <Dropdown.Item>Second Item</Dropdown.Item>
+    <Dropdown.Divider />
+    <Dropdown.Item>Third Item</Dropdown.Item>
+  </Dropdown>
+);

--- a/bulma-ui/src/components/Menu.stories.tsx
+++ b/bulma-ui/src/components/Menu.stories.tsx
@@ -43,3 +43,20 @@ export const Basic: Story = {
     </Menu>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Menu>
+      <Menu.Label>General</Menu.Label>
+      <Menu.List>
+        <Menu.Item active>Dashboard</Menu.Item>
+        <Menu.Item>Customers</Menu.Item>
+      </Menu.List>
+      <Menu.Label>Administration</Menu.Label>
+      <Menu.List>
+        <Menu.Item>Team Settings</Menu.Item>
+        <Menu.Item>Invitations</Menu.Item>
+      </Menu.List>
+    </Menu>
+  ),
+};

--- a/bulma-ui/src/components/Navbar.stories.tsx
+++ b/bulma-ui/src/components/Navbar.stories.tsx
@@ -309,3 +309,26 @@ export const Light: Story = {
 export const White: Story = {
   render: () => <StatefulNavbarBurgerMenu color="white" />,
 };
+
+// Compound (dot-notation) usage
+export const CompoundUsage: Story = {
+  render: () => (
+    <Navbar>
+      <Navbar.Brand>
+        <Navbar.Item href="#">
+          <img src={logo} alt="Logo" width="30" height="24" />
+        </Navbar.Item>
+        <Navbar.Burger aria-label="menu" />
+      </Navbar.Brand>
+      <Navbar.Menu active>
+        <Navbar.Start>
+          <Navbar.Item href="#">Home</Navbar.Item>
+          <Navbar.Item href="#">Docs</Navbar.Item>
+        </Navbar.Start>
+        <Navbar.End>
+          <Navbar.Item href="#">Log in</Navbar.Item>
+        </Navbar.End>
+      </Navbar.Menu>
+    </Navbar>
+  ),
+};

--- a/bulma-ui/src/components/Pagination.stories.tsx
+++ b/bulma-ui/src/components/Pagination.stories.tsx
@@ -180,3 +180,18 @@ export const PreviousNext: Story = {
     </Pagination>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Pagination>
+      <Pagination.Previous>Previous</Pagination.Previous>
+      <Pagination.Next>Next page</Pagination.Next>
+      <Pagination.List>
+        <Pagination.Link active>1</Pagination.Link>
+        <Pagination.Link>2</Pagination.Link>
+        <Pagination.Ellipsis />
+        <Pagination.Link>10</Pagination.Link>
+      </Pagination.List>
+    </Pagination>
+  ),
+};

--- a/bulma-ui/src/components/Panel.stories.tsx
+++ b/bulma-ui/src/components/Panel.stories.tsx
@@ -356,3 +356,25 @@ export const White: Story = {
     </Panel>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Panel>
+      <Panel.Heading>Continental Congress</Panel.Heading>
+      <Panel.Tabs>
+        <a className="is-active">All</a>
+        <a>Delegates</a>
+      </Panel.Tabs>
+      <Panel.Block active>
+        <Panel.Icon name="user" variant="solid" />
+        John Adams
+      </Panel.Block>
+      <Panel.Block>
+        <Panel.Icon name="user" variant="solid" />
+        Benjamin Franklin
+      </Panel.Block>
+      <Panel.CheckboxBlock>remember me</Panel.CheckboxBlock>
+      <Panel.ButtonBlock>Reset all filters</Panel.ButtonBlock>
+    </Panel>
+  ),
+};

--- a/bulma-ui/src/components/Sidebar.stories.tsx
+++ b/bulma-ui/src/components/Sidebar.stories.tsx
@@ -609,3 +609,37 @@ export const FilterSidebar: Story = {
     );
   },
 };
+
+/**
+ * Compound (dot-notation) usage: every sub-part is a static on Sidebar.
+ */
+export const CompoundUsage: Story = {
+  render: function CompoundUsageExample() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <Section>
+        <Button color="primary" onClick={() => setIsOpen(true)}>
+          Open Sidebar
+        </Button>
+        <Sidebar isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <Sidebar.Header>
+            <Sidebar.Title>Dot Notation</Sidebar.Title>
+            <Sidebar.Close onClick={() => setIsOpen(false)} />
+          </Sidebar.Header>
+          <Sidebar.Body>
+            <Paragraph>
+              Header, Title, Close, Body, and Footer are all available from the
+              single Sidebar import.
+            </Paragraph>
+          </Sidebar.Body>
+          <Sidebar.Footer>
+            <Button color="primary" onClick={() => setIsOpen(false)}>
+              Done
+            </Button>
+          </Sidebar.Footer>
+        </Sidebar>
+      </Section>
+    );
+  },
+};

--- a/bulma-ui/src/components/Tabs.stories.tsx
+++ b/bulma-ui/src/components/Tabs.stories.tsx
@@ -604,3 +604,22 @@ export const BackwardCompatible: Story = {
     </Tabs>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Tabs>
+      <Tabs.List>
+        <Tabs.Tab index={0}>Overview</Tabs.Tab>
+        <Tabs.Tab index={1}>Settings</Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Content>
+        <Tabs.Content.Item index={0}>
+          <Paragraph>Overview panel composed via dot notation.</Paragraph>
+        </Tabs.Content.Item>
+        <Tabs.Content.Item index={1}>
+          <Paragraph>Settings panel composed via dot notation.</Paragraph>
+        </Tabs.Content.Item>
+      </Tabs.Content>
+    </Tabs>
+  ),
+};

--- a/bulma-ui/src/components/__tests__/Avatars.test.tsx
+++ b/bulma-ui/src/components/__tests__/Avatars.test.tsx
@@ -163,8 +163,20 @@ describe('Avatars', () => {
     expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
   });
 
-  it('exposes Avatar as a compound static', () => {
-    expect(Avatars.Avatar).toBe(Avatar);
+  describe('Compound components', () => {
+    it('exposes Avatar as a compound static', () => {
+      expect(Avatars.Avatar).toBe(Avatar);
+    });
+
+    it('renders avatars through the dot path', () => {
+      const { container } = render(
+        <Avatars>
+          <Avatars.Avatar name="Ada Lovelace" />
+        </Avatars>
+      );
+      expect(container.querySelector('.avatars')).toBeInTheDocument();
+      expect(screen.getByText('AL')).toBeInTheDocument();
+    });
   });
 
   it('applies the spacing class (defaults to md)', () => {

--- a/bulma-ui/src/components/__tests__/Card.test.tsx
+++ b/bulma-ui/src/components/__tests__/Card.test.tsx
@@ -387,6 +387,34 @@ describe('Card Component', () => {
   });
 
   describe('Compound Components', () => {
+    test('all compound statics are defined', () => {
+      expect(Card.Header).toBeDefined();
+      expect(Card.Header.Title).toBeDefined();
+      expect(Card.Header.Icon).toBeDefined();
+      expect(Card.Image).toBeDefined();
+      expect(Card.Content).toBeDefined();
+      expect(Card.Footer).toBeDefined();
+      expect(Card.FooterItem).toBeDefined();
+    });
+
+    test('renders a card through the dot paths', () => {
+      const { container } = render(
+        <Card>
+          <Card.Header>
+            <Card.Header.Title>Title</Card.Header.Title>
+          </Card.Header>
+          <Card.Content>Body</Card.Content>
+          <Card.Footer>
+            <Card.FooterItem>Item</Card.FooterItem>
+          </Card.Footer>
+        </Card>
+      );
+      expect(container.querySelector('.card')).toBeInTheDocument();
+      expect(container.querySelector('.card-header')).toBeInTheDocument();
+      expect(container.querySelector('.card-content')).toBeInTheDocument();
+      expect(container.querySelector('.card-footer')).toBeInTheDocument();
+    });
+
     test('Card.Header renders with correct classes', () => {
       render(
         <Card.Header data-testid="header">

--- a/bulma-ui/src/components/__tests__/Card.test.tsx
+++ b/bulma-ui/src/components/__tests__/Card.test.tsx
@@ -386,7 +386,7 @@ describe('Card Component', () => {
     });
   });
 
-  describe('Compound Components', () => {
+  describe('Compound components', () => {
     test('all compound statics are defined', () => {
       expect(Card.Header).toBeDefined();
       expect(Card.Header.Title).toBeDefined();

--- a/bulma-ui/src/components/__tests__/Dropdown.test.tsx
+++ b/bulma-ui/src/components/__tests__/Dropdown.test.tsx
@@ -700,3 +700,26 @@ describe('Dropdown', () => {
     expect(screen.getByTestId('dropdown-root')).not.toHaveClass('is-active');
   });
 });
+
+describe('Compound components', () => {
+  test('Dropdown.Item is the DropdownItem component', () => {
+    expect(Dropdown.Item).toBe(DropdownItem);
+  });
+
+  test('Dropdown.Divider is the DropdownDivider component', () => {
+    expect(Dropdown.Divider).toBe(DropdownDivider);
+  });
+
+  test('renders a dropdown through the dot path', () => {
+    const { container } = render(
+      <Dropdown label="Menu" active>
+        <Dropdown.Item>First</Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item>Second</Dropdown.Item>
+      </Dropdown>
+    );
+    expect(container.querySelector('.dropdown')).toBeInTheDocument();
+    expect(container.querySelectorAll('.dropdown-item')).toHaveLength(2);
+    expect(container.querySelector('.dropdown-divider')).toBeInTheDocument();
+  });
+});

--- a/bulma-ui/src/components/__tests__/Menu.test.tsx
+++ b/bulma-ui/src/components/__tests__/Menu.test.tsx
@@ -234,3 +234,33 @@ describe('Menu', () => {
     expect(screen.getByText('Sub B')).toBeInTheDocument();
   });
 });
+
+describe('Compound components', () => {
+  it('Menu.Label is the MenuLabel component', () => {
+    expect(Menu.Label).toBe(MenuLabel);
+  });
+
+  it('Menu.List is the MenuList component', () => {
+    expect(Menu.List).toBe(MenuList);
+  });
+
+  it('Menu.Item is the MenuItem component', () => {
+    expect(Menu.Item).toBe(MenuItem);
+  });
+
+  it('renders a menu through the dot path', () => {
+    const { container } = render(
+      <Menu>
+        <Menu.Label>General</Menu.Label>
+        <Menu.List>
+          <Menu.Item>Dashboard</Menu.Item>
+          <Menu.Item>Customers</Menu.Item>
+        </Menu.List>
+      </Menu>
+    );
+    expect(container.querySelector('.menu')).toBeInTheDocument();
+    expect(container.querySelector('.menu-label')).toBeInTheDocument();
+    expect(container.querySelector('.menu-list')).toBeInTheDocument();
+    expect(container.querySelectorAll('.menu-list li')).toHaveLength(2);
+  });
+});

--- a/bulma-ui/src/components/__tests__/Message.test.tsx
+++ b/bulma-ui/src/components/__tests__/Message.test.tsx
@@ -119,6 +119,23 @@ describe('Message', () => {
   });
 
   describe('Compound Components', () => {
+    test('all compound statics are defined', () => {
+      expect(Message.Header).toBeDefined();
+      expect(Message.Body).toBeDefined();
+    });
+
+    test('renders a message through the dot paths', () => {
+      const { container } = render(
+        <Message>
+          <Message.Header>Header</Message.Header>
+          <Message.Body>Body</Message.Body>
+        </Message>
+      );
+      expect(container.querySelector('.message')).toBeInTheDocument();
+      expect(container.querySelector('.message-header')).toBeInTheDocument();
+      expect(container.querySelector('.message-body')).toBeInTheDocument();
+    });
+
     test('Message.Header renders with correct classes', () => {
       render(
         <Message.Header data-testid="header">

--- a/bulma-ui/src/components/__tests__/Message.test.tsx
+++ b/bulma-ui/src/components/__tests__/Message.test.tsx
@@ -118,7 +118,7 @@ describe('Message', () => {
     });
   });
 
-  describe('Compound Components', () => {
+  describe('Compound components', () => {
     test('all compound statics are defined', () => {
       expect(Message.Header).toBeDefined();
       expect(Message.Body).toBeDefined();

--- a/bulma-ui/src/components/__tests__/Modal.test.tsx
+++ b/bulma-ui/src/components/__tests__/Modal.test.tsx
@@ -172,7 +172,7 @@ describe('Modal', () => {
     });
   });
 
-  describe('Compound Components API', () => {
+  describe('Compound components', () => {
     it('defines all compound statics', () => {
       expect(Modal.Background).toBeDefined();
       expect(Modal.Content).toBeDefined();

--- a/bulma-ui/src/components/__tests__/Modal.test.tsx
+++ b/bulma-ui/src/components/__tests__/Modal.test.tsx
@@ -173,6 +173,39 @@ describe('Modal', () => {
   });
 
   describe('Compound Components API', () => {
+    it('defines all compound statics', () => {
+      expect(Modal.Background).toBeDefined();
+      expect(Modal.Content).toBeDefined();
+      expect(Modal.Card).toBeDefined();
+      expect(Modal.Card.Head).toBeDefined();
+      expect(Modal.Card.Title).toBeDefined();
+      expect(Modal.Card.Body).toBeDefined();
+      expect(Modal.Card.Foot).toBeDefined();
+      expect(Modal.Close).toBeDefined();
+    });
+
+    it('renders a modal card through the dot paths', () => {
+      const { container } = render(
+        <Modal isActive>
+          <Modal.Background />
+          <Modal.Card>
+            <Modal.Card.Head>
+              <Modal.Card.Title>Title</Modal.Card.Title>
+            </Modal.Card.Head>
+            <Modal.Card.Body>{latin}</Modal.Card.Body>
+            <Modal.Card.Foot>Foot</Modal.Card.Foot>
+          </Modal.Card>
+        </Modal>
+      );
+      expect(container.querySelector('.modal')).toBeInTheDocument();
+      expect(container.querySelector('.modal-background')).toBeInTheDocument();
+      expect(container.querySelector('.modal-card')).toBeInTheDocument();
+      expect(container.querySelector('.modal-card-head')).toBeInTheDocument();
+      expect(container.querySelector('.modal-card-title')).toBeInTheDocument();
+      expect(container.querySelector('.modal-card-body')).toBeInTheDocument();
+      expect(container.querySelector('.modal-card-foot')).toBeInTheDocument();
+    });
+
     it('renders Modal with compound Background component', () => {
       const onClose = jest.fn();
       render(

--- a/bulma-ui/src/components/__tests__/Navbar.test.tsx
+++ b/bulma-ui/src/components/__tests__/Navbar.test.tsx
@@ -1,6 +1,17 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { ComponentProps } from 'react';
-import Navbar from '../Navbar';
+import Navbar, {
+  NavbarBrand,
+  NavbarItem,
+  NavbarLink,
+  NavbarBurger,
+  NavbarMenu,
+  NavbarStart,
+  NavbarEnd,
+  NavbarDropdown,
+  NavbarDropdownMenu,
+  NavbarDivider,
+} from '../Navbar';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Navbar', () => {
@@ -445,5 +456,60 @@ describe('Navbar.Link', () => {
     );
     const link = screen.getByTestId('navlink');
     expect(link).toHaveClass('bulma-navbar-link');
+  });
+});
+
+describe('Compound components', () => {
+  it('statics are the separately exported components', () => {
+    expect(Navbar.Brand).toBe(NavbarBrand);
+    expect(Navbar.Item).toBe(NavbarItem);
+    expect(Navbar.Link).toBe(NavbarLink);
+    expect(Navbar.Burger).toBe(NavbarBurger);
+    expect(Navbar.Menu).toBe(NavbarMenu);
+    expect(Navbar.Start).toBe(NavbarStart);
+    expect(Navbar.End).toBe(NavbarEnd);
+    expect(Navbar.Dropdown).toBe(NavbarDropdown);
+    expect(Navbar.DropdownMenu).toBe(NavbarDropdownMenu);
+    expect(Navbar.Divider).toBe(NavbarDivider);
+  });
+
+  it('renders a full navbar through the dot path', () => {
+    const { container } = render(
+      <Navbar>
+        <Navbar.Brand>
+          <Navbar.Item href="#">Bestax</Navbar.Item>
+          <Navbar.Burger />
+        </Navbar.Brand>
+        <Navbar.Menu active>
+          <Navbar.Start>
+            <Navbar.Item href="#">Home</Navbar.Item>
+            <Navbar.Dropdown hoverable>
+              <Navbar.Link>More</Navbar.Link>
+              <Navbar.DropdownMenu>
+                <Navbar.Item href="#">About</Navbar.Item>
+                <Navbar.Divider />
+                <Navbar.Item href="#">Contact</Navbar.Item>
+              </Navbar.DropdownMenu>
+            </Navbar.Dropdown>
+          </Navbar.Start>
+          <Navbar.End>
+            <Navbar.Item href="#">Log in</Navbar.Item>
+          </Navbar.End>
+        </Navbar.Menu>
+      </Navbar>
+    );
+    expect(container.querySelector('.navbar')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-brand')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-burger')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-menu')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-start')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-end')).toBeInTheDocument();
+    expect(container.querySelector('.has-dropdown')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-link')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-dropdown')).toBeInTheDocument();
+    expect(container.querySelector('.navbar-divider')).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('.navbar-item').length
+    ).toBeGreaterThanOrEqual(5);
   });
 });

--- a/bulma-ui/src/components/__tests__/Pagination.test.tsx
+++ b/bulma-ui/src/components/__tests__/Pagination.test.tsx
@@ -1,5 +1,11 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import Pagination from '../Pagination';
+import Pagination, {
+  PaginationLink,
+  PaginationList,
+  PaginationEllipsis,
+  PaginationPrevious,
+  PaginationNext,
+} from '../Pagination';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Pagination', () => {
@@ -297,5 +303,35 @@ describe('Pagination.Next', () => {
     );
     fireEvent.click(screen.getByTestId('next'));
     expect(handleClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('Compound components', () => {
+  it('exposes the named exports as statics', () => {
+    expect(Pagination.Link).toBe(PaginationLink);
+    expect(Pagination.List).toBe(PaginationList);
+    expect(Pagination.Ellipsis).toBe(PaginationEllipsis);
+    expect(Pagination.Previous).toBe(PaginationPrevious);
+    expect(Pagination.Next).toBe(PaginationNext);
+  });
+
+  it('renders pagination through the dot path', () => {
+    const { container } = render(
+      <Pagination>
+        <Pagination.Previous>Previous</Pagination.Previous>
+        <Pagination.Next>Next page</Pagination.Next>
+        <Pagination.List>
+          <Pagination.Link active>1</Pagination.Link>
+          <Pagination.Ellipsis />
+          <Pagination.Link>10</Pagination.Link>
+        </Pagination.List>
+      </Pagination>
+    );
+    expect(container.querySelector('.pagination')).toBeInTheDocument();
+    expect(container.querySelector('.pagination-previous')).toBeInTheDocument();
+    expect(container.querySelector('.pagination-next')).toBeInTheDocument();
+    expect(container.querySelector('.pagination-list')).toBeInTheDocument();
+    expect(container.querySelectorAll('.pagination-link')).toHaveLength(2);
+    expect(container.querySelector('.pagination-ellipsis')).toBeInTheDocument();
   });
 });

--- a/bulma-ui/src/components/__tests__/Panel.test.tsx
+++ b/bulma-ui/src/components/__tests__/Panel.test.tsx
@@ -1,5 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import Panel from '../Panel';
+import Panel, {
+  PanelHeading,
+  PanelTabs,
+  PanelBlock,
+  PanelIcon,
+  PanelInputBlock,
+  PanelCheckboxBlock,
+  PanelButtonBlock,
+} from '../Panel';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Panel', () => {
@@ -288,5 +296,41 @@ describe('Panel.ButtonBlock', () => {
     );
     fireEvent.click(screen.getByTestId('button'));
     expect(handleClick).toHaveBeenCalled();
+  });
+});
+
+describe('Compound components', () => {
+  it('exposes the named exports as statics', () => {
+    expect(Panel.Heading).toBe(PanelHeading);
+    expect(Panel.Tabs).toBe(PanelTabs);
+    expect(Panel.Block).toBe(PanelBlock);
+    expect(Panel.Icon).toBe(PanelIcon);
+    expect(Panel.InputBlock).toBe(PanelInputBlock);
+    expect(Panel.CheckboxBlock).toBe(PanelCheckboxBlock);
+    expect(Panel.ButtonBlock).toBe(PanelButtonBlock);
+  });
+
+  it('renders a panel through the dot path', () => {
+    const { container } = render(
+      <Panel>
+        <Panel.Heading>Repositories</Panel.Heading>
+        <Panel.Tabs>
+          <a className="is-active">All</a>
+          <a>Public</a>
+        </Panel.Tabs>
+        <Panel.InputBlock placeholder="Search" />
+        <Panel.Block active>
+          <Panel.Icon name="book" variant="solid" />
+          bestax-bulma
+        </Panel.Block>
+        <Panel.CheckboxBlock>remember me</Panel.CheckboxBlock>
+        <Panel.ButtonBlock>Reset all filters</Panel.ButtonBlock>
+      </Panel>
+    );
+    expect(container.querySelector('.panel')).toBeInTheDocument();
+    expect(container.querySelector('.panel-heading')).toBeInTheDocument();
+    expect(container.querySelector('.panel-tabs')).toBeInTheDocument();
+    expect(container.querySelector('.panel-icon')).toBeInTheDocument();
+    expect(container.querySelectorAll('.panel-block')).toHaveLength(4);
   });
 });

--- a/bulma-ui/src/components/__tests__/Sidebar.test.tsx
+++ b/bulma-ui/src/components/__tests__/Sidebar.test.tsx
@@ -602,4 +602,45 @@ describe('Sidebar', () => {
       expect(footer).toHaveTextContent('Footer content');
     });
   });
+
+  describe('Compound components', () => {
+    it('exposes Sidebar.Header as a static', () => {
+      expect(Sidebar.Header).toBeDefined();
+    });
+
+    it('exposes Sidebar.Title as a static', () => {
+      expect(Sidebar.Title).toBeDefined();
+    });
+
+    it('exposes Sidebar.Close as a static', () => {
+      expect(Sidebar.Close).toBeDefined();
+    });
+
+    it('exposes Sidebar.Body as a static', () => {
+      expect(Sidebar.Body).toBeDefined();
+    });
+
+    it('exposes Sidebar.Footer as a static', () => {
+      expect(Sidebar.Footer).toBeDefined();
+    });
+
+    it('renders a sidebar through the dot path', () => {
+      const { container } = render(
+        <Sidebar inline isOpen onClose={() => {}}>
+          <Sidebar.Header>
+            <Sidebar.Title>Menu</Sidebar.Title>
+            <Sidebar.Close />
+          </Sidebar.Header>
+          <Sidebar.Body>Body content</Sidebar.Body>
+          <Sidebar.Footer>Footer content</Sidebar.Footer>
+        </Sidebar>
+      );
+      expect(container.querySelector('.sidebar')).toBeInTheDocument();
+      expect(container.querySelector('.sidebar-header')).toBeInTheDocument();
+      expect(container.querySelector('.sidebar-title')).toBeInTheDocument();
+      expect(container.querySelector('.sidebar-close')).toBeInTheDocument();
+      expect(container.querySelector('.sidebar-body')).toBeInTheDocument();
+      expect(container.querySelector('.sidebar-footer')).toBeInTheDocument();
+    });
+  });
 });

--- a/bulma-ui/src/components/__tests__/Steps.test.tsx
+++ b/bulma-ui/src/components/__tests__/Steps.test.tsx
@@ -794,3 +794,24 @@ describe('Step subcomponent', () => {
     expect(handleClick).toHaveBeenCalled();
   });
 });
+
+describe('Compound components', () => {
+  it('Steps.Step is the Step component', () => {
+    expect(Steps.Step).toBe(Step);
+  });
+
+  it('renders steps through the dot path', () => {
+    const { container } = render(
+      <Steps value={1}>
+        <Steps.Step label="Account" />
+        <Steps.Step label="Profile" />
+        <Steps.Step label="Complete" />
+      </Steps>
+    );
+    expect(container.querySelector('.steps')).toBeInTheDocument();
+    expect(container.querySelectorAll('.steps-segment')).toHaveLength(3);
+    expect(
+      container.querySelector('.steps-segment.is-active')
+    ).toHaveTextContent('Profile');
+  });
+});

--- a/bulma-ui/src/components/__tests__/Tabs.test.tsx
+++ b/bulma-ui/src/components/__tests__/Tabs.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import Tabs, { Tab, TabContentItem } from '../Tabs';
+import Tabs, {
+  Tab,
+  TabList,
+  TabItem,
+  TabsContent,
+  TabContentItem,
+} from '../Tabs';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Tabs', () => {
@@ -806,5 +812,37 @@ describe('Tabs', () => {
       expect(panel).toHaveAttribute('aria-hidden', 'true');
       expect(panel).not.toHaveClass('is-active');
     });
+  });
+});
+
+describe('Compound components', () => {
+  it('statics are the separately exported components', () => {
+    expect(Tabs.List).toBe(TabList);
+    expect(Tabs.Tab).toBe(Tab);
+    expect(Tabs.Item).toBe(TabItem);
+    expect(Tabs.Content).toBe(TabsContent);
+    expect(Tabs.Content.Item).toBe(TabContentItem);
+  });
+
+  it('renders tabs with content panels through the dot path', () => {
+    const { container } = render(
+      <Tabs>
+        <Tabs.List>
+          <Tabs.Tab index={0}>Overview</Tabs.Tab>
+          <Tabs.Tab index={1}>Settings</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Content>
+          <Tabs.Content.Item index={0}>Overview panel</Tabs.Content.Item>
+          <Tabs.Content.Item index={1}>Settings panel</Tabs.Content.Item>
+        </Tabs.Content>
+      </Tabs>
+    );
+    expect(container.querySelector('.tabs')).toBeInTheDocument();
+    expect(container.querySelectorAll('.tabs li')).toHaveLength(2);
+    expect(container.querySelector('.tabs-content')).toBeInTheDocument();
+    expect(container.querySelectorAll('.tabs-content-item')).toHaveLength(2);
+    expect(
+      container.querySelector('.tabs-content-item.is-active')
+    ).toHaveTextContent('Overview panel');
   });
 });

--- a/bulma-ui/src/elements/Figure.stories.tsx
+++ b/bulma-ui/src/elements/Figure.stories.tsx
@@ -148,3 +148,14 @@ export const CodeFigure: Story = {
     </Figure>
   ),
 };
+
+export const CompoundUsage: Story = {
+  render: () => (
+    <Figure textAlign="centered">
+      <img src="/img/logo.png" alt="Logo" />
+      <Figure.Caption mt="2">
+        Caption via the Figure.Caption static
+      </Figure.Caption>
+    </Figure>
+  ),
+};

--- a/bulma-ui/src/elements/__tests__/Figure.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Figure.test.tsx
@@ -182,3 +182,22 @@ describe('Figure Component', () => {
     });
   });
 });
+
+describe('Compound components', () => {
+  test('Figure.Caption is defined', () => {
+    expect(Figure.Caption).toBeDefined();
+  });
+
+  test('renders a caption through the dot path', () => {
+    const { container } = render(
+      <Figure>
+        <img src="test.jpg" alt="Test" />
+        <Figure.Caption>Caption text</Figure.Caption>
+      </Figure>
+    );
+    expect(container.querySelector('figure')).toBeInTheDocument();
+    expect(container.querySelector('figcaption')).toHaveTextContent(
+      'Caption text'
+    );
+  });
+});

--- a/bulma-ui/src/form/__tests__/Field.test.tsx
+++ b/bulma-ui/src/form/__tests__/Field.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import Field from '../Field';
+import Field, { FieldLabel, FieldBody } from '../Field';
 import { Control } from '../Control';
 import { ConfigProvider } from '../../helpers/Config';
 
@@ -324,6 +324,14 @@ describe('Field', () => {
 describe('Compound components', () => {
   test('Field.Control is the Control component', () => {
     expect(Field.Control).toBe(Control);
+  });
+
+  test('Field.Label is the FieldLabel component', () => {
+    expect(Field.Label).toBe(FieldLabel);
+  });
+
+  test('Field.Body is the FieldBody component', () => {
+    expect(Field.Body).toBe(FieldBody);
   });
 
   test('renders a horizontal field through Field.Label and Field.Body', () => {

--- a/bulma-ui/src/layout/Hero.stories.tsx
+++ b/bulma-ui/src/layout/Hero.stories.tsx
@@ -274,3 +274,26 @@ export const FullHeightWithHeadBodyFoot: StoryObj<typeof Hero> = {
     </Hero>
   ),
 };
+
+export const CompoundUsage: StoryObj<typeof Hero> = {
+  render: () => (
+    <Hero color="info">
+      <Hero.Head>
+        <Container textAlign="centered" pt="4">
+          <Title size="6">Hero head via dot notation</Title>
+        </Container>
+      </Hero.Head>
+      <Hero.Body>
+        <Container textAlign="centered">
+          <Title>Hero title</Title>
+          <SubTitle>Hero subtitle</SubTitle>
+        </Container>
+      </Hero.Body>
+      <Hero.Foot>
+        <Container textAlign="centered" pb="4">
+          <SubTitle size="6">Hero foot via dot notation</SubTitle>
+        </Container>
+      </Hero.Foot>
+    </Hero>
+  ),
+};

--- a/bulma-ui/src/layout/Level.stories.tsx
+++ b/bulma-ui/src/layout/Level.stories.tsx
@@ -143,3 +143,28 @@ export const MobileLevel: StoryObj<typeof Level> = {
     </Level>
   ),
 };
+
+// Compound (dot-notation) usage
+export const CompoundUsage: StoryObj<typeof Level> = {
+  render: () => (
+    <Level>
+      <Level.Left>
+        <Level.Item>
+          <Title as="p" size="5" className="subtitle">
+            <strong>All Posts</strong>
+          </Title>
+        </Level.Item>
+      </Level.Left>
+      <Level.Right>
+        <Level.Item as="p">
+          <a>Published</a>
+        </Level.Item>
+        <Level.Item as="p">
+          <Button color="success" as="a">
+            New
+          </Button>
+        </Level.Item>
+      </Level.Right>
+    </Level>
+  ),
+};

--- a/bulma-ui/src/layout/Media.stories.tsx
+++ b/bulma-ui/src/layout/Media.stories.tsx
@@ -220,3 +220,33 @@ export const WithButtonBelow: StoryObj<typeof Media> = {
     </Media>
   ),
 };
+
+// Compound (dot-notation) usage
+export const CompoundUsage: StoryObj<typeof Media> = {
+  render: () => (
+    <Media>
+      <Media.Left>
+        <Image
+          as="p"
+          size="64x64"
+          src="https://bulma.io/assets/images/placeholders/128x128.png"
+          alt=""
+        />
+      </Media.Left>
+      <Media.Content>
+        <Content>
+          <p>
+            <strong>John Smith</strong> <small>@johnsmith</small>
+            <br />
+            Composed entirely from the single Media import via dot notation.
+          </p>
+        </Content>
+      </Media.Content>
+      <Media.Right>
+        <Button as="a" size="small">
+          Reply
+        </Button>
+      </Media.Right>
+    </Media>
+  ),
+};

--- a/bulma-ui/src/layout/__tests__/Hero.test.tsx
+++ b/bulma-ui/src/layout/__tests__/Hero.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import Hero from '../Hero';
+import Hero, { HeroHead, HeroBody, HeroFoot } from '../Hero';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Hero', () => {
@@ -205,5 +205,33 @@ describe('Hero', () => {
       expect(getByTestId('foot')).toHaveClass('bulma-hero-foot');
       expect(getByTestId('foot')).toHaveClass('bulma-has-text-danger');
     });
+  });
+});
+
+describe('Compound components', () => {
+  it('statics are the separately exported components', () => {
+    expect(Hero.Head).toBe(HeroHead);
+    expect(Hero.Body).toBe(HeroBody);
+    expect(Hero.Foot).toBe(HeroFoot);
+  });
+
+  it('renders a hero through the dot path', () => {
+    const { container } = render(
+      <Hero>
+        <Hero.Head>Head content</Hero.Head>
+        <Hero.Body>Body content</Hero.Body>
+        <Hero.Foot>Foot content</Hero.Foot>
+      </Hero>
+    );
+    expect(container.querySelector('.hero')).toBeInTheDocument();
+    expect(container.querySelector('.hero-head')).toHaveTextContent(
+      'Head content'
+    );
+    expect(container.querySelector('.hero-body')).toHaveTextContent(
+      'Body content'
+    );
+    expect(container.querySelector('.hero-foot')).toHaveTextContent(
+      'Foot content'
+    );
   });
 });

--- a/bulma-ui/src/layout/__tests__/Level.test.tsx
+++ b/bulma-ui/src/layout/__tests__/Level.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import Level from '../Level';
+import Level, { LevelLeft, LevelRight, LevelItem } from '../Level';
 import { Title } from '../../elements/Title';
 import Button from '../../elements/Button';
 import Field from '../../form/Field';
@@ -332,5 +332,30 @@ describe('Level', () => {
       const item = screen.getByTestId('item');
       expect(item).toHaveClass('has-text-grey-light');
     });
+  });
+});
+
+describe('Compound components', () => {
+  it('statics are the separately exported components', () => {
+    expect(Level.Left).toBe(LevelLeft);
+    expect(Level.Right).toBe(LevelRight);
+    expect(Level.Item).toBe(LevelItem);
+  });
+
+  it('renders a level through the dot path', () => {
+    const { container } = render(
+      <Level>
+        <Level.Left>
+          <Level.Item>Posts</Level.Item>
+        </Level.Left>
+        <Level.Right>
+          <Level.Item>All</Level.Item>
+        </Level.Right>
+      </Level>
+    );
+    expect(container.querySelector('.level')).toBeInTheDocument();
+    expect(container.querySelector('.level-left')).toBeInTheDocument();
+    expect(container.querySelector('.level-right')).toBeInTheDocument();
+    expect(container.querySelectorAll('.level-item')).toHaveLength(2);
   });
 });

--- a/bulma-ui/src/layout/__tests__/Media.test.tsx
+++ b/bulma-ui/src/layout/__tests__/Media.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import Media from '../Media';
+import Media, { MediaLeft, MediaContent, MediaRight } from '../Media';
 import { ConfigProvider } from '../../helpers/Config';
 
 describe('Media', () => {
@@ -364,5 +364,31 @@ describe('Media', () => {
       const right = screen.getByTestId('right');
       expect(right).toHaveClass('has-text-grey-light');
     });
+  });
+});
+
+describe('Compound components', () => {
+  it('statics are the separately exported components', () => {
+    expect(Media.Left).toBe(MediaLeft);
+    expect(Media.Content).toBe(MediaContent);
+    expect(Media.Right).toBe(MediaRight);
+  });
+
+  it('renders a media object through the dot path', () => {
+    const { container } = render(
+      <Media>
+        <Media.Left>Avatar</Media.Left>
+        <Media.Content>Comment body</Media.Content>
+        <Media.Right>Dismiss</Media.Right>
+      </Media>
+    );
+    expect(container.querySelector('.media')).toBeInTheDocument();
+    expect(container.querySelector('.media-left')).toHaveTextContent('Avatar');
+    expect(container.querySelector('.media-content')).toHaveTextContent(
+      'Comment body'
+    );
+    expect(container.querySelector('.media-right')).toHaveTextContent(
+      'Dismiss'
+    );
   });
 });

--- a/docs/docs/api/components/dropdown.md
+++ b/docs/docs/api/components/dropdown.md
@@ -166,6 +166,21 @@ function example() {
 
 ---
 
+### Compound (dot-notation) usage
+
+`DropdownItem` and `DropdownDivider` are also available as `Dropdown.Item` and `Dropdown.Divider`, so the whole menu can be composed from the single `Dropdown` import.
+
+```tsx live
+<Dropdown label="Dropdown Menu" active>
+  <Dropdown.Item>First Item</Dropdown.Item>
+  <Dropdown.Item>Second Item</Dropdown.Item>
+  <Dropdown.Divider />
+  <Dropdown.Item>Third Item</Dropdown.Item>
+</Dropdown>
+```
+
+---
+
 ## Accessibility
 
 - The dropdown root is a `<div class="dropdown">` with ARIA roles/attributes for menu and trigger.

--- a/docs/docs/api/components/menu.md
+++ b/docs/docs/api/components/menu.md
@@ -167,6 +167,22 @@ Create multi-level navigation by nesting `Menu.List` components inside `Menu.Ite
 
 ---
 
+### Compound (dot-notation) usage
+
+`MenuLabel`, `MenuList`, and `MenuItem` are also available as `Menu.Label`, `Menu.List`, and `Menu.Item`, so the whole menu can be composed from the single `Menu` import.
+
+```tsx live
+<Menu>
+  <Menu.Label>General</Menu.Label>
+  <Menu.List>
+    <Menu.Item active>Dashboard</Menu.Item>
+    <Menu.Item>Customers</Menu.Item>
+  </Menu.List>
+</Menu>
+```
+
+---
+
 ## Accessibility
 
 - The root `Menu` renders as `<aside class="menu">`.

--- a/docs/docs/api/components/navbar.md
+++ b/docs/docs/api/components/navbar.md
@@ -406,6 +406,32 @@ function example() {
 
 ---
 
+### Compound (dot-notation) usage
+
+`NavbarBrand`, `NavbarMenu`, `NavbarItem`, and the other subcomponents are also available as `Navbar.Brand`, `Navbar.Menu`, `Navbar.Item`, and so on, so a complete navbar can be composed from the single `Navbar` import.
+
+```tsx live
+<Navbar>
+  <Navbar.Brand>
+    <Navbar.Item href="#">
+      <img src="/img/logo.svg" alt="Logo" width="28" height="28" />
+    </Navbar.Item>
+    <Navbar.Burger aria-label="menu" />
+  </Navbar.Brand>
+  <Navbar.Menu active>
+    <Navbar.Start>
+      <Navbar.Item href="#">Home</Navbar.Item>
+      <Navbar.Item href="#">Docs</Navbar.Item>
+    </Navbar.Start>
+    <Navbar.End>
+      <Navbar.Item href="#">Log in</Navbar.Item>
+    </Navbar.End>
+  </Navbar.Menu>
+</Navbar>
+```
+
+---
+
 ## Accessibility
 
 - The root `Navbar` renders as `<nav role="navigation" aria-label="main navigation">`.

--- a/docs/docs/api/components/pagination.md
+++ b/docs/docs/api/components/pagination.md
@@ -231,6 +231,25 @@ This example combines the `Pagination.Previous` and `Pagination.Next` subcompone
 
 ---
 
+### Compound (dot-notation) usage
+
+Every subcomponent is exported by name (`PaginationLink`, `PaginationList`, …) and attached to `Pagination` as a static, so a full pagination can be composed from the single `Pagination` import.
+
+```tsx live
+<Pagination>
+  <Pagination.Previous>Previous</Pagination.Previous>
+  <Pagination.Next>Next page</Pagination.Next>
+  <Pagination.List>
+    <Pagination.Link active>1</Pagination.Link>
+    <Pagination.Link>2</Pagination.Link>
+    <Pagination.Ellipsis />
+    <Pagination.Link>10</Pagination.Link>
+  </Pagination.List>
+</Pagination>
+```
+
+---
+
 ## Accessibility
 
 - The root `Pagination` renders as a semantic `<nav role="navigation" aria-label="pagination">`.

--- a/docs/docs/api/components/panel.md
+++ b/docs/docs/api/components/panel.md
@@ -147,6 +147,27 @@ This example demonstrates the `Panel` component's color variants. The `color` pr
 
 ---
 
+### Compound (dot-notation) usage
+
+Every subcomponent is exported by name (`PanelHeading`, `PanelBlock`, …) and attached to `Panel` as a static, so a whole panel can be composed from the single `Panel` import.
+
+```tsx live
+<Panel>
+  <Panel.Heading>Founding Documents</Panel.Heading>
+  <Panel.Block active>
+    <Panel.Icon name="file" variant="solid" />
+    Declaration of Independence
+  </Panel.Block>
+  <Panel.Block>
+    <Panel.Icon name="file" variant="solid" />
+    Articles of Confederation
+  </Panel.Block>
+  <Panel.ButtonBlock>Reset all filters</Panel.ButtonBlock>
+</Panel>
+```
+
+---
+
 ## Accessibility
 
 - The root panel renders as a semantic `<nav>` for navigation/landmark.

--- a/docs/docs/api/components/sidebar.md
+++ b/docs/docs/api/components/sidebar.md
@@ -344,6 +344,42 @@ function example() {
 
 ---
 
+### Compound (dot-notation) usage
+
+`Sidebar.Header`, `Sidebar.Title`, `Sidebar.Close`, `Sidebar.Body`, and `Sidebar.Footer` are all statics on `Sidebar`, so the whole panel can be composed from the single `Sidebar` import.
+
+```tsx live
+function example() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button color="primary" onClick={() => setIsOpen(true)}>
+        Open Sidebar
+      </Button>
+      <Sidebar inline isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <Sidebar.Header>
+          <Sidebar.Title>Dot Notation</Sidebar.Title>
+          <Sidebar.Close onClick={() => setIsOpen(false)} />
+        </Sidebar.Header>
+        <Sidebar.Body>
+          <Paragraph>
+            Header, Title, Close, Body, and Footer are all available from the
+            single Sidebar import.
+          </Paragraph>
+        </Sidebar.Body>
+        <Sidebar.Footer>
+          <Button color="primary" onClick={() => setIsOpen(false)}>
+            Done
+          </Button>
+        </Sidebar.Footer>
+      </Sidebar>
+    </>
+  );
+}
+```
+
+---
+
 ## Close Methods
 
 When `canCancel` is true, the sidebar can be closed by:

--- a/docs/docs/api/components/steps.md
+++ b/docs/docs/api/components/steps.md
@@ -267,6 +267,20 @@ function example() {
 
 ---
 
+### Compound (dot-notation) usage
+
+`Step` is also available as `Steps.Step`, so steps can be declared as children from the single `Steps` import — an alternative to the `items` prop.
+
+```tsx live
+<Steps value={1}>
+  <Steps.Step label="Account" />
+  <Steps.Step label="Profile" />
+  <Steps.Step label="Complete" />
+</Steps>
+```
+
+---
+
 ## Accessibility
 
 - Steps use `aria-current="step"` on the active step

--- a/docs/docs/api/components/tabs.md
+++ b/docs/docs/api/components/tabs.md
@@ -425,6 +425,25 @@ The final example showcases toggle tabs with fullwidth and large size, including
 
 ---
 
+### Compound (dot-notation) usage
+
+`TabList`, `Tab`, `TabsContent`, and `TabContentItem` are also available as `Tabs.List`, `Tabs.Tab`, `Tabs.Content`, and `Tabs.Content.Item`, so a complete tabbed interface can be composed from the single `Tabs` import.
+
+```tsx live
+<Tabs>
+  <Tabs.List>
+    <Tabs.Tab index={0}>Overview</Tabs.Tab>
+    <Tabs.Tab index={1}>Settings</Tabs.Tab>
+  </Tabs.List>
+  <Tabs.Content>
+    <Tabs.Content.Item index={0}>Overview panel</Tabs.Content.Item>
+    <Tabs.Content.Item index={1}>Settings panel</Tabs.Content.Item>
+  </Tabs.Content>
+</Tabs>
+```
+
+---
+
 ## Accessibility
 
 - The tab list renders as a semantic `<ul>` and each item as `<li>`.

--- a/docs/docs/api/elements/figure.md
+++ b/docs/docs/api/elements/figure.md
@@ -124,6 +124,17 @@ Use Figure to wrap code blocks with captions.
 </Figure>
 ```
 
+### Compound (dot-notation) usage
+
+The `Caption` subcomponent is only exposed as the `Figure.Caption` static, so a captioned figure needs just the single `Figure` import.
+
+```tsx live
+<Figure>
+  <Image src="/img/bestax-solar-system-3d.png" alt="Placeholder" />
+  <Figure.Caption>Caption via the Figure.Caption static</Figure.Caption>
+</Figure>
+```
+
 ---
 
 ## Accessibility

--- a/docs/docs/api/layout/hero.md
+++ b/docs/docs/api/layout/hero.md
@@ -274,6 +274,33 @@ This example shows a comprehensive usage of the `Hero` component with all its su
 
 ---
 
+### Compound (dot-notation) usage
+
+`HeroHead`, `HeroBody`, and `HeroFoot` are also available as `Hero.Head`, `Hero.Body`, and `Hero.Foot`, so the whole hero can be composed from the single `Hero` import.
+
+```tsx live
+<Hero color="info">
+  <Hero.Head>
+    <Container textAlign="centered" pt="4">
+      <Title size="6">Hero head via dot notation</Title>
+    </Container>
+  </Hero.Head>
+  <Hero.Body>
+    <Container textAlign="centered">
+      <Title>Hero title</Title>
+      <SubTitle>Hero subtitle</SubTitle>
+    </Container>
+  </Hero.Body>
+  <Hero.Foot>
+    <Container textAlign="centered" pb="4">
+      <SubTitle size="6">Hero foot via dot notation</SubTitle>
+    </Container>
+  </Hero.Foot>
+</Hero>
+```
+
+---
+
 ## Accessibility
 
 - The hero renders as a semantic `<section>` by default.

--- a/docs/docs/api/layout/level.md
+++ b/docs/docs/api/layout/level.md
@@ -188,6 +188,34 @@ This example demonstrates the `Level` component's mobile layout. When the `isMob
 
 ---
 
+### Compound (dot-notation) usage
+
+`LevelLeft`, `LevelRight`, and `LevelItem` are also available as `Level.Left`, `Level.Right`, and `Level.Item`, so the whole level can be composed from the single `Level` import.
+
+```tsx live
+<Level>
+  <Level.Left>
+    <Level.Item>
+      <Title as="p" size="5">
+        <strong>All Posts</strong>
+      </Title>
+    </Level.Item>
+  </Level.Left>
+  <Level.Right>
+    <Level.Item as="p">
+      <a>Published</a>
+    </Level.Item>
+    <Level.Item as="p">
+      <Button color="success" as="a">
+        New
+      </Button>
+    </Level.Item>
+  </Level.Right>
+</Level>
+```
+
+---
+
 ## Accessibility
 
 - The root `Level` renders as a semantic `<nav>` for grouping and navigation.

--- a/docs/docs/api/layout/media.md
+++ b/docs/docs/api/layout/media.md
@@ -254,6 +254,39 @@ In this variation, a button is placed below the input area within the `Media.Con
 
 ---
 
+### Compound (dot-notation) usage
+
+`MediaLeft`, `MediaContent`, and `MediaRight` are also available as `Media.Left`, `Media.Content`, and `Media.Right`, so the whole media object can be composed from the single `Media` import.
+
+```tsx live
+<Media>
+  <Media.Left>
+    <Image
+      as="p"
+      size="64x64"
+      src="https://bulma.io/assets/images/placeholders/128x128.png"
+      alt=""
+    />
+  </Media.Left>
+  <Media.Content>
+    <Content>
+      <p>
+        <strong>John Smith</strong> <small>@johnsmith</small>
+        <br />
+        Composed entirely from the single Media import via dot notation.
+      </p>
+    </Content>
+  </Media.Content>
+  <Media.Right>
+    <Button as="a" size="small">
+      Reply
+    </Button>
+  </Media.Right>
+</Media>
+```
+
+---
+
 ## Accessibility
 
 - The Media root renders as a semantic `<article>` by default. Use `as="div"` for a generic container.


### PR DESCRIPTION
Closes #330.

Brings the 17 pre-existing compound families up to the compound-artifact standard established for the newly-compound families in #331, and codifies that standard in the CLAUDE.md files.

## What's in here

**Tests + story + docs section added** (previously nothing):
- Panel, Pagination, Steps¹, Figure
- Navbar, Tabs (incl. nested `Tabs.Content.Item`), Media, Level, Hero
- Dropdown (plain-CSF story style, static open via `active`), Menu, Sidebar (`useState`/`isOpen` story pattern, `inline` docs examples, inserted before `## Close Methods`)

¹ Steps already had an equivalent `CompoundComponents` story — reused, not duplicated.

**Identity-test blocks only** (stories + docs already existed): Card (incl. nested `Card.Header.Title`/`Card.Header.Icon`), Modal (incl. `Modal.Card.Head/.Title/.Body/.Foot`), Message — all module-private subs, so `toBeDefined()` + dot-path renders asserting Bulma class output.

**Top-ups:** Field gains `expect(Field.Label).toBe(FieldLabel)` / `expect(Field.Body).toBe(FieldBody)`. Avatars verified already complete (identity test, `CompoundStatic` story, `### Compound Static` docs) — untouched.

**Standard codified:** new "Compound components" bullet in `bulma-ui/CLAUDE.md` Conventions (per the wording proposed in #330) and a tightened compound-pattern bullet in `bulma-ui/src/components/CLAUDE.md` referencing `withSubComponents` and the required artifacts.

## Verification

- `pnpm all` green locally: build, typecheck, jest with 99% coverage on all metrics, lint, format:check, bundle:stats, Storybook build
- `pnpm check:conformance`: all 7 checks pass (incl. the inline-style ratchet — no `style={{}}` in any new story/docs example)
- `pnpm gen:catalog:check`: catalog not stale
- Tests/stories/docs only — no runtime code changes; non-release commit type (`test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dot-notation compound component usage across menus, navigation, layouts, forms, and other UI components.
  * Subcomponents can now be composed from a single primary component import, such as `Dropdown.Item` and `Tabs.Content.Item`.
  * Added interactive Storybook examples showcasing compound component patterns.

* **Documentation**
  * Added usage guidance and live examples for compound components across the API documentation.

* **Tests**
  * Added coverage verifying compound subcomponents, identity mappings, and rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->