### PR TITLE
ci: tolerate narration before triage sentinels — require them last, not alone

### DIFF
--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -72,9 +72,10 @@ name: AI Triage
 # ended turn kills the headless session and orphans the agents). The prompt
 # therefore forbids backgrounded sub-agents AND requires a final
 # `TRIAGE-RESULT:` sentinel line per command; the watchdog fails the job
-# unless the result text is nothing but such lines, exactly one per
-# expected command (one for issues, two for PRs — so finishing the first
-# PR command and bailing during the second still fails).
+# unless the result text ENDS with exactly one such line per expected
+# command (one for issues, two for PRs — so finishing the first PR
+# command and bailing during the second still fails; leading narration
+# is tolerated).
 #
 # KILL SWITCHES: AI_TRIAGE_MODE=off (this workflow only) or
 # AI_LOOP_ENABLED=false (all Claude spend, repo-wide).
@@ -386,8 +387,8 @@ jobs:
       #          running ("I'll wait for them to finish…"), so nothing was
       #          ever posted. Session status alone cannot catch this, which
       #          is why the prompt demands the TRIAGE-RESULT sentinel: a
-      #          session that actually finished its commands ends with only
-      #          sentinel lines; any other final text fails here.
+      #          session that actually finished its commands ends with the
+      #          sentinel lines; a bailout never emits them, so it fails.
       # Fail loudly on both. An empty/missing execution file (e.g. the
       # action's workflow-validation skip) is tolerated: there was no
       # session to judge.
@@ -404,12 +405,18 @@ jobs:
           fi
           # Fail closed: accept a JSON array or NDJSON, and require a final
           # result record whose is_error is exactly false AND whose result
-          # text is nothing but TRIAGE-RESULT sentinel lines — exactly one
-          # per expected command (issues run one command, PRs run two), so
-          # a session that finishes the first PR command but bails during
-          # the second cannot pass on the strength of one sentinel.
-          # Malformed JSON, a missing result record, a mid-task bailout
-          # message, or any other shape fails the job.
+          # text ENDS with the TRIAGE-RESULT sentinel lines — exactly one
+          # per expected command (issues run one command, PRs run two), as
+          # the LAST non-empty lines, and none anywhere else. The exact
+          # count means a session that finishes the first PR command but
+          # bails during the second cannot pass on one sentinel; requiring
+          # them last means a bailout message can't follow them. Leading
+          # narration is tolerated (the first live run, 29794090279,
+          # false-failed an otherwise-correct skip because the session
+          # prefixed one explanatory line — the review's predicted
+          # chatter false-positive). Malformed JSON, a missing result
+          # record, or a mid-task bailout (which never emits sentinels)
+          # still fails the job.
           if [ "$IS_PR" = "true" ]; then EXPECTED=2; else EXPECTED=1; fi
           if jq -es --argjson n "$EXPECTED" \
                     '[.[] | if type == "array" then .[] else . end]
@@ -418,8 +425,9 @@ jobs:
                      | (.is_error == false)
                        and ((.result // "") | split("\n")
                             | map(select(length > 0))
-                            | (length == $n)
-                              and all(startswith("TRIAGE-RESULT:")))' \
+                            | (length >= $n)
+                              and ([.[] | select(startswith("TRIAGE-RESULT:"))] | length == $n)
+                              and (.[- $n:] | all(startswith("TRIAGE-RESULT:"))))' \
               "$EXEC_FILE" >/dev/null 2>&1; then
             echo "session ended cleanly with $EXPECTED TRIAGE-RESULT sentinel(s) — triage completed"
           else


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #340, fixing a false positive its first live run exposed. After merging, I applied `ai-triage` to issue #330 as the post-merge verification: the session behaved correctly (found the issue closed, stopped per pre-check 1, emitted `TRIAGE-RESULT: triage-dedupe skipped (issue not open)`, label auto-removed) — but [run 29794090279](https://github.com/allxsmith/bestax/actions/runs/29794090279) failed because the session prefixed one explanatory line before the sentinel, and the watchdog required the final message to be *nothing but* sentinel lines. This is exactly the chatter false-positive the deep adversarial review predicted (finding 5 in [its review](https://github.com/allxsmith/bestax/pull/340#issuecomment-5029026353)), with the loosening already scoped in [the response](https://github.com/allxsmith/bestax/pull/340#issuecomment-5029169389).

The watchdog jq now requires the `TRIAGE-RESULT:` lines to be the **last** non-empty lines of the final message — exactly one per expected command (one for issues, two for PRs) and none elsewhere — instead of the only lines. Every protective property holds: a bailout emits no sentinels and fails; a bailout *after* a sentinel fails (sentinels no longer last); over- and under-counts fail. Leading narration no longer causes a false failure.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): CI workflow (`.github/workflows/ai-triage.yml`)

## Related Issue(s)

Refs #338

Related to #340

## Type of Change

- [x] Bug fix
- [x] Build tooling

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works — no jest surface; the jq was verified against 13 execution-file fixtures, including the literal false-positive text from run 29794090279 (now passes) and all bailout/miscount shapes (still fail)
- [x] I have added/updated documentation as needed (workflow header + step comments)
- [ ] I have updated Storybook stories as needed (bulma-ui) — n/a
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed (`prettier --check`, YAML parse)
- [ ] Any relevant dependencies are updated — n/a
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated — n/a

## Screenshots / Demos

n/a

## Additional Context

- The prompt keeps instructing "nothing else" — instruct strictly, validate tolerantly.
- After merge, the live test should be re-run against an **open** issue (the #330 attempt doubled as a skip-path test since the issue had been closed by #336's merge).
- No release: `ci:` type, no package scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1LrTrVRbtdh8paN7f67CB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1LrTrVRbtdh8paN7f67CB)_