### PR TITLE
feat(create-bestax): scaffold .claude/launch.json with the AI skills opt-in

### DIFF
--- a/create-bestax/e2e/utils/scaffold.ts
+++ b/create-bestax/e2e/utils/scaffold.ts
@@ -64,6 +64,13 @@ export async function scaffoldApp(config: ScaffoldConfig): Promise<string> {
     stdio: 'inherit',
   });
 
+  // -y implies the AI-skills opt-in, so every real scaffold must contain the
+  // browser-preview manifest (#337) — fail loudly if the write path regresses.
+  const launchJsonPath = path.join(outputDir, '.claude', 'launch.json');
+  if (!(await fs.pathExists(launchJsonPath))) {
+    throw new Error(`Expected scaffold to contain ${launchJsonPath}`);
+  }
+
   // Install dependencies in the scaffolded app with a fresh pnpm resolve.
   // --ignore-workspace: the app may live inside the monorepo tree, so treat it
   // as a standalone project rather than a workspace member.

--- a/create-bestax/src/__tests__/constants.test.ts
+++ b/create-bestax/src/__tests__/constants.test.ts
@@ -24,6 +24,7 @@ const {
   PROJECT_NAME_REGEX,
   MESSAGES,
   PROMPTS,
+  LAUNCH_JSON,
 } = await import('../constants.js');
 
 describe('constants', () => {
@@ -203,6 +204,26 @@ describe('constants', () => {
         expect(typeof item.display).toBe('string');
         expect(typeof item.color).toBe('function');
       });
+    });
+  });
+
+  describe('LAUNCH_JSON', () => {
+    it('is valid JSON with a single dev configuration', () => {
+      const launch = JSON.parse(LAUNCH_JSON);
+      expect(launch.version).toBe('0.0.1');
+      expect(launch.configurations).toHaveLength(1);
+      expect(launch.configurations[0].name).toBe('dev');
+    });
+
+    it('uses package-manager-neutral npm and pins the Vite port with --strictPort', () => {
+      const config = JSON.parse(LAUNCH_JSON).configurations[0];
+      expect(config.runtimeExecutable).toBe('npm');
+      expect(config.runtimeArgs).toEqual(['run', 'dev', '--', '--strictPort']);
+      expect(config.port).toBe(5173);
+    });
+
+    it('is mentioned in the skills success message', () => {
+      expect(MESSAGES.SKILLS_ADDED).toContain('launch.json');
     });
   });
 

--- a/create-bestax/src/__tests__/project-creator.test.ts
+++ b/create-bestax/src/__tests__/project-creator.test.ts
@@ -276,6 +276,37 @@ describe('ProjectCreator', () => {
       expect(written).not.toContain('classPrefix');
     });
 
+    it('writes .claude/launch.json for the browser preview alongside the skills', async () => {
+      (
+        fileSystem.checkDirectoryExists as jest.MockedFunction<
+          typeof fileSystem.checkDirectoryExists
+        >
+      ).mockResolvedValue(true);
+
+      await projectCreator.setupSkills('/target/path', 'my-app', {
+        bulmaFlavor: 'complete',
+        iconLibrary: 'none',
+      });
+
+      const written = (
+        fs.default.writeFile as unknown as jest.Mock
+      ).mock.calls.find(([p]) => String(p).includes('launch.json'))?.[1];
+      expect(written).toBeDefined();
+      const launch = JSON.parse(String(written));
+      expect(launch.configurations).toHaveLength(1);
+      expect(launch.configurations[0]).toEqual({
+        name: 'dev',
+        runtimeExecutable: 'npm',
+        runtimeArgs: ['run', 'dev', '--', '--strictPort'],
+        port: 5173,
+      });
+      // the scaffolded CLAUDE.md points agents at the launch config
+      const claudeMd = (
+        fs.default.writeFile as unknown as jest.Mock
+      ).mock.calls.find(([p]) => String(p).includes('CLAUDE.md'))?.[1];
+      expect(claudeMd).toContain('.claude/launch.json');
+    });
+
     it('documents the prefix caveat and icon library for a prefixed scaffold', async () => {
       (
         fileSystem.checkDirectoryExists as jest.MockedFunction<
@@ -931,6 +962,55 @@ describe('ProjectCreator', () => {
 
       expect(fileSystem.copyDirectory).toHaveBeenCalled();
       expect(fileSystem.updatePackageJson).toHaveBeenCalled();
+    });
+
+    it('writes launch.json when the skills opt-in is accepted', async () => {
+      // target dir does not exist; the bundled skills dir does
+      (
+        fileSystem.checkDirectoryExists as jest.MockedFunction<
+          typeof fileSystem.checkDirectoryExists
+        >
+      ).mockImplementation(async p => String(p).includes('skills'));
+      (
+        fileSystem.isDirectoryEmpty as jest.MockedFunction<
+          typeof fileSystem.isDirectoryEmpty
+        >
+      ).mockResolvedValue(true);
+      (
+        fs.default.existsSync as jest.MockedFunction<typeof fs.existsSync>
+      ).mockReturnValue(false);
+
+      await projectCreator.create('test-project', { yes: true, skills: true });
+
+      expect(
+        (fs.default.writeFile as unknown as jest.Mock).mock.calls.some(([p]) =>
+          String(p).includes('launch.json')
+        )
+      ).toBe(true);
+    });
+
+    it('does not write launch.json when the skills opt-in is declined', async () => {
+      (
+        fileSystem.checkDirectoryExists as jest.MockedFunction<
+          typeof fileSystem.checkDirectoryExists
+        >
+      ).mockImplementation(async p => String(p).includes('skills'));
+      (
+        fileSystem.isDirectoryEmpty as jest.MockedFunction<
+          typeof fileSystem.isDirectoryEmpty
+        >
+      ).mockResolvedValue(true);
+      (
+        fs.default.existsSync as jest.MockedFunction<typeof fs.existsSync>
+      ).mockReturnValue(false);
+
+      await projectCreator.create('test-project', { yes: true, skills: false });
+
+      expect(
+        (fs.default.writeFile as unknown as jest.Mock).mock.calls.some(([p]) =>
+          String(p).includes('launch.json')
+        )
+      ).toBe(false);
     });
 
     it('should prompt for missing template option', async () => {

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -38,8 +38,32 @@ export const MESSAGES = {
   NEXT_STEPS: 'Next steps:',
   HAPPY_CODING: 'Happy coding! 🎉',
   SKILLS_ADDED:
-    '✔ Installed bestax AI skills into .claude/skills/ (+ CLAUDE.md)',
+    '✔ Installed bestax AI skills into .claude/skills/ (+ CLAUDE.md, .claude/launch.json)',
 } as const;
+
+// Dev-server manifest written into .claude/ with the skills opt-in so Claude
+// Code's browser preview (`preview_start`) can boot the app by name instead of
+// rediscovering the dev command from package.json. `npm` is deliberately
+// package-manager-neutral (`npm run dev` works whichever PM installed the
+// project), and `--strictPort` stops Vite from silently auto-incrementing to
+// 5174 when 5173 is busy — a mismatch with the declared `port` must fail
+// loudly, not point the preview at nothing.
+export const LAUNCH_JSON =
+  JSON.stringify(
+    {
+      version: '0.0.1',
+      configurations: [
+        {
+          name: 'dev',
+          runtimeExecutable: 'npm',
+          runtimeArgs: ['run', 'dev', '--', '--strictPort'],
+          port: 5173,
+        },
+      ],
+    },
+    null,
+    2
+  ) + '\n';
 
 export const PROMPTS = {
   PROJECT_NAME: 'Project name:',
@@ -130,6 +154,10 @@ automatically when the task matches:
 - **bestax-optimize** — shrink the built CSS: measure raw+gzip, then flavor switch or a modular Sass build.
 
 Prefer the library's components and these skills over hand-written Bulma markup or custom CSS.
+
+\`.claude/launch.json\` declares this app's dev server for Claude Code's browser preview
+(\`npm run dev\` on port 5173, \`--strictPort\`) — start it from there rather than rediscovering
+the command.
 
 ## Docs
 

--- a/create-bestax/src/project-creator.ts
+++ b/create-bestax/src/project-creator.ts
@@ -30,6 +30,7 @@ import {
   ICON_LIBRARIES,
   BULMA_FLAVORS,
   CLAUDE_MD,
+  LAUNCH_JSON,
   CONFIG_PROVIDER_ICON_VALUES,
   type ClaudeMdOptions,
 } from './constants.js';
@@ -117,6 +118,10 @@ export class ProjectCreator {
     }
 
     await fs.copy(skillsSrc, path.join(targetPath, '.claude', 'skills'));
+    await fs.writeFile(
+      path.join(targetPath, '.claude', 'launch.json'),
+      LAUNCH_JSON
+    );
     await fs.writeFile(
       path.join(targetPath, 'CLAUDE.md'),
       CLAUDE_MD(projectName, options)

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -103,3 +103,11 @@ machine.
   reading it.
 - **Kill switches**: removing the `ai-loop` label stops one PR; a repository variable turns
   the whole system off.
+
+## AI-ready scaffolds
+
+New apps can start AI-ready too: accepting the AI-skills prompt in `npm create bestax@latest`
+installs the bestax Agent Skills and a `CLAUDE.md`, plus a `.claude/launch.json` that tells
+Claude Code's browser preview how to start the app's dev server (`npm run dev` on port 5173,
+with `--strictPort` so a busy port fails loudly instead of silently drifting to another port).
+See the [LLMs guide](/docs/guides/llms) for the full AI tooling story.

--- a/docs/docs/guides/llms/index.md
+++ b/docs/docs/guides/llms/index.md
@@ -35,9 +35,10 @@ npx skills add https://github.com/allxsmith/bestax --skill bestax-layout-scaffol
 ```
 
 Starting a new app? `pnpm create bestax@latest` offers to **preinstall these skills**
-into the generated app's `.claude/skills/` (alongside a `CLAUDE.md`), so a Claude Code
-session picks them up automatically. See the [Skills overview](/docs/skills/intro) for
-what each one does.
+into the generated app's `.claude/skills/` (alongside a `CLAUDE.md` and a
+`.claude/launch.json` that lets Claude Code's browser preview start the dev server by
+name), so a Claude Code session picks them up automatically. See the
+[Skills overview](/docs/skills/intro) for what each one does.
 
 ## MCP server (coming soon)
 


### PR DESCRIPTION
# Pull Request

## Description

When the user accepts the "Install the bestax AI skills?" prompt, `create-bestax` now also writes a `.claude/launch.json` into the scaffolded project (both `vite` and `vite-ts` templates), so Claude Code's browser preview can `preview_start` the app's dev server by name instead of rediscovering the command from `package.json`.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

Details, per the issue's design decisions:

- **Gated behind the skills opt-in** — written in `setupSkills` alongside the `.claude/skills` copy; users who declined AI files get nothing new (and the degenerate missing-bundle build still writes nothing).
- **Package-manager-neutral** — `runtimeExecutable: "npm"` with `npm run dev`, which works regardless of which PM installed the project.
- **Port pinned loudly** — `runtimeArgs` pass `-- --strictPort` so Vite fails when 5173 is busy instead of silently drifting to 5174 and desyncing from the declared `port`.

Also touched:

- `MESSAGES.SKILLS_ADDED` now mentions `.claude/launch.json`.
- The scaffolded `CLAUDE.md` template tells agents the file exists and to start the dev server from it.
- Docs: a new "AI-ready scaffolds" section in the AI-Assisted Development guide, and the LLMs guide's "Starting a new app?" paragraph now enumerates the file.

## Related Issue(s)

Fixes #337

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [x] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

Tests: new unit coverage for the `LAUNCH_JSON` constant (valid JSON, npm + `--strictPort`, port 5173), the `setupSkills` write path, and `create()`-level gating (skills accepted → file written; declined → not). create-bestax suite: 197 passed; coverage above the 95% bar; typecheck/lint/format green.

## Screenshots / Demos

Scaffolded with the opt-in accepted:

```json
{
  "version": "0.0.1",
  "configurations": [
    {
      "name": "dev",
      "runtimeExecutable": "npm",
      "runtimeArgs": ["run", "dev", "--", "--strictPort"],
      "port": 5173
    }
  ]
}
```

Smoke-tested by scaffolding real apps from `dist/`: with `-y` (skills default on) the file lands in `.claude/` next to `skills/` and the success line reads `✔ Installed bestax AI skills into .claude/skills/ (+ CLAUDE.md, .claude/launch.json)`; with `--no-skills` no `.claude/` directory is created.

## Additional Context

Commit type is `feat(create-bestax)` → minor release of create-bestax only. The bundled `templates/skills` copy was not edited (build re-syncs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fh5j4Th9cdaEpZnVirseot

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fh5j4Th9cdaEpZnVirseot)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New projects with AI skills enabled now include a `.claude/launch.json` configuration for browser previews.
  * The configuration starts the development server on port 5173 with strict port handling.
  * Generated project guidance now documents the browser preview setup.

* **Documentation**
  * Updated AI development and LLM guides to explain AI-ready scaffolds and launch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->