### PR TITLE
docs(bulma-ui): reconcile compound docs headings and story names with the codified standard

### DIFF
--- a/bulma-ui/src/components/Avatars.stories.tsx
+++ b/bulma-ui/src/components/Avatars.stories.tsx
@@ -118,8 +118,8 @@ export const UniformShape: Story = {
   },
 };
 
-export const CompoundStatic: Story = {
-  render: function CompoundStaticExample() {
+export const CompoundUsage: Story = {
+  render: function CompoundUsageExample() {
     // `Avatars.Avatar` is the same component as `Avatar`, handy when importing
     // only the container.
     return (

--- a/bulma-ui/src/components/Card.stories.tsx
+++ b/bulma-ui/src/components/Card.stories.tsx
@@ -183,7 +183,7 @@ export const Interactive: Story = {
   },
 };
 
-export const CompoundComponents: Story = {
+export const CompoundUsage: Story = {
   render: () => (
     <Card>
       <Card.Header>

--- a/bulma-ui/src/components/Message.stories.tsx
+++ b/bulma-ui/src/components/Message.stories.tsx
@@ -133,7 +133,7 @@ export const Large: StoryObj<MessageProps> = {
 };
 
 // ----- COMPOUND COMPONENT STORIES -----
-export const CompoundComponents: StoryObj = {
+export const CompoundUsage: StoryObj = {
   render: () => (
     <Message color="info">
       <Message.Header>

--- a/bulma-ui/src/components/Modal.stories.tsx
+++ b/bulma-ui/src/components/Modal.stories.tsx
@@ -127,7 +127,7 @@ const CompoundModalCardComponent = () => {
   );
 };
 
-export const CompoundModalCard: StoryObj<ModalProps> = {
+export const CompoundUsage: StoryObj<ModalProps> = {
   render: () => <CompoundModalCardComponent />,
 };
 

--- a/bulma-ui/src/components/Steps.stories.tsx
+++ b/bulma-ui/src/components/Steps.stories.tsx
@@ -903,7 +903,7 @@ export const HasNavigation: Story = {
 /**
  * Using `<Steps.Step>` compound component API with navigation.
  */
-export const CompoundComponents: Story = {
+export const CompoundUsage: Story = {
   render: function CompoundStory() {
     const [step, setStep] = useState(1);
     const labels = ['Account', 'Profile', 'Complete'];

--- a/docs/docs/api/components/avatars.md
+++ b/docs/docs/api/components/avatars.md
@@ -99,18 +99,6 @@ The surplus bubble always shows `+N`, but its accessible name defaults to Englis
 </Avatars>
 ```
 
-### Compound Static
-
-`Avatars.Avatar` is the same component as `Avatar`, handy when you import only the container.
-
-```tsx live
-<Avatars>
-  <Avatars.Avatar name="Ada Lovelace" />
-  <Avatars.Avatar name="Grace Hopper" />
-  <Avatars.Avatar name="Katherine Johnson" />
-</Avatars>
-```
-
 ### Spacing
 
 A `'sm' | 'md' | 'lg'` preset controls how far the avatars overlap; each group is stacked here
@@ -150,6 +138,18 @@ A `number` sets a pixel overlap directly:
   <Avatar name="Ada Lovelace" />
   <Avatar name="Grace Hopper" />
   <Avatar name="Katherine Johnson" />
+</Avatars>
+```
+
+### Compound (dot-notation) usage
+
+`Avatars.Avatar` is the same component as `Avatar`, handy when you import only the container.
+
+```tsx live
+<Avatars>
+  <Avatars.Avatar name="Ada Lovelace" />
+  <Avatars.Avatar name="Grace Hopper" />
+  <Avatars.Avatar name="Katherine Johnson" />
 </Avatars>
 ```
 

--- a/docs/docs/api/components/card.md
+++ b/docs/docs/api/components/card.md
@@ -39,6 +39,76 @@ import { Card } from '@allxsmith/bestax-bulma';
 | `textAlign`      | `'centered' \| 'justified' \| 'left' \| 'right'`                                                                                                                                                                                                                                         | Text alignment.                                                   |
 | ...              | All Bulma and standard HTML props                                                                                                                                                                                                                                                        | (See [Helper Props](../helpers/usebulmaclasses))                  |
 
+### Compound component props
+
+The `Card` component also supports a compound component API for maximum flexibility. This allows you to compose cards with fine-grained control over each section.
+
+#### Card.Header
+
+Renders the card header section with proper styling. When used without `Card.Header.Title`, it automatically wraps content in a `.card-header-title` div. When used with `Card.Header.Title`, it renders the title component directly without additional wrapping.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- `centered?`: Whether to center the header content (only applies when not using `Card.Header.Title`)
+- All standard HTML attributes for `<header>`
+
+#### Card.Header.Title
+
+Renders the card header title with proper styling. This provides more granular control over the header title when using compound components. When used inside `Card.Header`, it prevents automatic wrapping.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- `centered?`: Whether to center the header title
+- All standard HTML attributes for `<div>`
+
+#### Card.Header.Icon
+
+Renders the card header icon button with proper styling. This is typically placed after `Card.Header.Title` for actions like expand/collapse or accessing more options.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- `aria-label?`: Accessibility label (defaults to "more options")
+- All standard HTML attributes for `<button>`
+
+#### Card.Image
+
+Renders the card image section.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- All standard HTML attributes for `<div>`
+
+#### Card.Content
+
+Renders the main card content section.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- All standard HTML attributes for `<div>`
+
+#### Card.Footer
+
+Renders the card footer section.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- All standard HTML attributes for `<footer>`
+
+#### Card.FooterItem
+
+Renders individual footer items with proper styling.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- All standard HTML attributes for `<span>`
+
 ---
 
 ## Usage
@@ -189,77 +259,9 @@ Combine multiple props such as `header`, `textColor`, `bgColor`, `m`, `p`, `text
 
 ---
 
-## Compound Components
+### Compound (dot-notation) usage
 
-The `Card` component also supports a compound component API for maximum flexibility. This allows you to compose cards with fine-grained control over each section.
-
-### Card.Header
-
-Renders the card header section with proper styling. When used without `Card.Header.Title`, it automatically wraps content in a `.card-header-title` div. When used with `Card.Header.Title`, it renders the title component directly without additional wrapping.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- `centered?`: Whether to center the header content (only applies when not using `Card.Header.Title`)
-- All standard HTML attributes for `<header>`
-
-### Card.Header.Title
-
-Renders the card header title with proper styling. This provides more granular control over the header title when using compound components. When used inside `Card.Header`, it prevents automatic wrapping.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- `centered?`: Whether to center the header title
-- All standard HTML attributes for `<div>`
-
-### Card.Header.Icon
-
-Renders the card header icon button with proper styling. This is typically placed after `Card.Header.Title` for actions like expand/collapse or accessing more options.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- `aria-label?`: Accessibility label (defaults to "more options")
-- All standard HTML attributes for `<button>`
-
-### Card.Image
-
-Renders the card image section.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- All standard HTML attributes for `<div>`
-
-### Card.Content
-
-Renders the main card content section.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- All standard HTML attributes for `<div>`
-
-### Card.Footer
-
-Renders the card footer section.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- All standard HTML attributes for `<footer>`
-
-### Card.FooterItem
-
-Renders individual footer items with proper styling.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- All standard HTML attributes for `<span>`
-
-### Compound Component Examples
+Every card section is also available as a static — `Card.Header` (with `Card.Header.Title` and `Card.Header.Icon`), `Card.Image`, `Card.Content`, `Card.Footer`, and `Card.FooterItem` — so a whole card can be composed from the single `Card` import. Each static's props are listed under [Compound component props](#compound-component-props).
 
 #### Complete Card with Compound Components
 

--- a/docs/docs/api/components/message.md
+++ b/docs/docs/api/components/message.md
@@ -36,6 +36,28 @@ import { Message } from '@allxsmith/bestax-bulma';
 | `children`  | `React.ReactNode`                                                                                                                                                                                                                                                                        | —       | Body content for the message.                    |
 | ...         | All standard HTML and Bulma helper props (see [Helper Props](../helpers/usebulmaclasses))                                                                                                                                                                                                |         | Utility and accessibility props.                 |
 
+### Compound component props
+
+The `Message` component also supports a compound component API for maximum flexibility. This allows you to compose messages with fine-grained control over each section.
+
+#### Message.Header
+
+Renders the message header section with proper styling.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- All standard HTML attributes for `<div>`
+
+#### Message.Body
+
+Renders the message body section.
+
+**Props:**
+
+- `className?`: Additional CSS classes
+- All standard HTML attributes for `<div>`
+
 ---
 
 ## Usage
@@ -119,29 +141,9 @@ You can use Bulma size helpers or custom styles to adjust the size of the messag
 
 ---
 
-## Compound Components
+### Compound (dot-notation) usage
 
-The `Message` component also supports a compound component API for maximum flexibility. This allows you to compose messages with fine-grained control over each section.
-
-### Message.Header
-
-Renders the message header section with proper styling.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- All standard HTML attributes for `<div>`
-
-### Message.Body
-
-Renders the message body section.
-
-**Props:**
-
-- `className?`: Additional CSS classes
-- All standard HTML attributes for `<div>`
-
-### Compound Component Examples
+The message header and body are available as the `Message.Header` and `Message.Body` statics, so a whole message can be composed from the single `Message` import. Each static's props are listed under [Compound component props](#compound-component-props).
 
 #### Complete Message with Compound Components
 

--- a/docs/docs/api/components/modal.md
+++ b/docs/docs/api/components/modal.md
@@ -46,7 +46,7 @@ import { Modal } from '@allxsmith/bestax-bulma';
 | `children`       | `React.ReactNode`                                                                                                                                                                                                                                                                        | —       | Modal body/content.                                                                    |
 | ...              | All standard HTML and Bulma helper props                                                                                                                                                                                                                                                 |         | (See [Helper Props](../helpers/usebulmaclasses))                                       |
 
-### Compound Components
+### Compound component props
 
 | Component          | Description                                                                                                                                                  |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -222,7 +222,7 @@ function example() {
 
 ---
 
-### Compound Components API
+### Compound (dot-notation) usage
 
 #### Modal.Card with compound components
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -15,6 +15,8 @@
  *   docs-sections        API pages must have the house sections
  *   scss-conformance     SCSS partials follow the register-vars pattern
  *   story-per-component  every exported component module has a .stories.tsx
+ *   compound-family      withSubComponents families ship a CompoundUsage story
+ *                        and a "Compound (dot-notation) usage" docs subsection
  *   autodocs-tag         every story file opts into autodocs
  *   inline-style         no NEW inline style={{}} in stories/docs (ratcheted
  *                        against scripts/conformance-baseline.json; after
@@ -488,6 +490,89 @@ async function checkStoryPerComponent() {
   return violations;
 }
 
+// The compound-family standard (bulma-ui/CLAUDE.md): every component that
+// attaches statics via withSubComponents ships a story named exactly
+// `CompoundUsage` and a `### Compound (dot-notation) usage` example as the
+// LAST subsection of its API page's `## Usage` section. Detection is
+// source-driven (the withSubComponents call site), so a new compound family
+// is covered the moment it adopts the helper.
+async function checkCompoundFamily() {
+  const violations = [];
+  const modules = parseExportedModules(await readFile(INDEX_TS, 'utf8'));
+  const pages = new Map(); // frontmatter title -> relPath
+  for (const comps of (await apiComponents()).values()) {
+    for (const { title, relPath } of comps) pages.set(title, relPath);
+  }
+  const HEADING = '### Compound (dot-notation) usage';
+  const seen = new Set();
+  for (const { cat, mod } of modules) {
+    const key = `${cat}/${mod}`;
+    if (seen.has(key) || !/^[A-Z]/.test(mod) || mod.endsWith('Base')) continue;
+    seen.add(key);
+    let src;
+    try {
+      src = await readFile(
+        join(REPO, 'bulma-ui', 'src', cat, `${mod}.tsx`),
+        'utf8'
+      );
+    } catch {
+      continue; // .ts modules (helpers) have no component surface
+    }
+    if (!src.includes('withSubComponents(')) continue;
+
+    // 1. A story named exactly CompoundUsage. (A missing story file is
+    //    story-per-component's finding, not repeated here.)
+    const storyRel = `bulma-ui/src/${cat}/${mod}.stories.tsx`;
+    let storySrc = null;
+    try {
+      storySrc = await readFile(join(REPO, storyRel), 'utf8');
+    } catch {
+      /* reported by story-per-component */
+    }
+    if (storySrc !== null && !/^export const CompoundUsage\b/m.test(storySrc)) {
+      violations.push(
+        `${storyRel} has no \`export const CompoundUsage\` story. ${mod} is ` +
+          `a compound family (it calls withSubComponents), which ships a ` +
+          `CompoundUsage story — rename the primary dot-notation story or ` +
+          `add one (exemplar: bulma-ui/src/components/Menu.stories.tsx).`
+      );
+    }
+
+    // 2. The API page's `## Usage` section ends with the compound subsection.
+    const rel = pages.get(mod);
+    if (!rel) {
+      violations.push(
+        `${mod} (bulma-ui/src/${cat}/${mod}.tsx) is a compound family but no ` +
+          `API page under docs/docs/api has frontmatter \`title: ${mod}\`.`
+      );
+      continue;
+    }
+    const docSrc = await readFile(join(API_DIR, rel), 'utf8');
+    const lines = docSrc.split(/\r?\n/);
+    const start = lines.findIndex(l => /^## Usage[ \t]*$/.test(l));
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (/^## /.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    const subs = lines
+      .slice(start + 1, end)
+      .filter(l => /^### /.test(l))
+      .map(l => l.trim());
+    if (start === -1 || subs[subs.length - 1] !== HEADING) {
+      violations.push(
+        `docs/docs/api/${rel} must end its "## Usage" section with a ` +
+          `"${HEADING}" subsection (${mod} is a compound family). Mirror ` +
+          `docs/docs/api/components/dropdown.md: one sentence naming the ` +
+          `\`${mod}.*\` statics, then a \`\`\`tsx live example.`
+      );
+    }
+  }
+  return violations;
+}
+
 async function checkAutodocsTag() {
   const violations = [];
   const stories = await walk(join(REPO, 'bulma-ui', 'src'), '.stories.tsx');
@@ -563,6 +648,7 @@ const CHECKS = {
   'scss-conformance': checkScssConformance,
   'skills-sync': checkSkillsSync,
   'story-per-component': checkStoryPerComponent,
+  'compound-family': checkCompoundFamily,
   'autodocs-tag': checkAutodocsTag,
   'inline-style': null, // handled below (takes the flag)
 };


### PR DESCRIPTION
Closes #339

## What

Reconciles the five compound families that predate the standard codified in `bulma-ui/CLAUDE.md` (PR #336), taking the issue's preferred **Option 1 (reconcile)** — and mechanizes the standard so it can't drift again.

### Story renames (primary compound story → `CompoundUsage`)

| File | Renamed | Kept as-is (extras beyond the minimum) |
|---|---|---|
| `Card.stories.tsx` | `CompoundComponents` | `CompoundComponentsMinimal`, `MixedApproach` |
| `Message.stories.tsx` | `CompoundComponents` | `CompoundMinimal`, `CompoundHeaderOnly`, `MixedApproach` |
| `Modal.stories.tsx` | `CompoundModalCard` | `CompoundModalContent` |
| `Avatars.stories.tsx` | `CompoundStatic` | — |
| `Steps.stories.tsx` | `CompoundComponents` | — |

No test or docs page references these export names (identity tests key on `Parent.Sub`), so the renames are behavior-neutral. Stories aren't shipped in the package → non-release `docs` commit type.

### Docs restructuring (no content dropped — the standard is a minimum, not a ceiling)

- **card.md / message.md** — the standalone `## Compound Components` H2 is dissolved: per-static prop docs move under `## Props` as `### Compound component props` (demoted to H4), and the examples become `### Compound (dot-notation) usage` at the end of `## Usage`, keeping all richer examples as H4 sub-examples.
- **modal.md** — retitles only: the Props-side statics table becomes `### Compound component props`; `### Compound Components API` (already last in Usage) becomes `### Compound (dot-notation) usage`.
- **avatars.md** — `### Compound Static` renamed to the standard heading and moved to the end of `## Usage`.
- **steps.md** — already conformed; story rename only.

URLs/slugs are unchanged (headings only), so the published LLM index is unaffected beyond anchor text.

### New conformance sub-check: `compound-family`

`scripts/check-conformance.mjs` gains a source-driven check: every module calling `withSubComponents(` must ship an `export const CompoundUsage` story and a `### Compound (dot-notation) usage` subsection as the **last** H3 of its API page's `## Usage` section. All 27 compound families pass with **zero exemptions**; before the reconcile it correctly flagged exactly the 9 drifted artifacts. Run it alone with `node scripts/check-conformance.mjs --only=compound-family`.

## Verification

- `pnpm all` green (build, typecheck, tests + coverage, lint, format:check, storybook build).
- `pnpm check:conformance` green, including the new sub-check.
- Browser-verified: all four docs pages render the new sections with live examples executing (13 previews on card.md, 4 under the new compound section), and Storybook indexes `compound-usage` for all 27 families with the renamed stories rendering correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)