### PR TITLE
feat(create-bestax): add controlled-Burger Navbar to the landing archetype

### DIFF
--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -139,6 +139,9 @@ ${setupLines.join('\n')}
   take a \`gap\` prop, so prefer that there).
 - Compose existing components before writing custom CSS; theme via \`Theme\` and \`--bulma-*\`
   variables, never hardcoded colors.
+- \`Navbar.Burger\`/\`Navbar.Menu\` are controlled — wire \`active\` via state on both, and pair
+  \`Navbar fixed="top"\` with the \`has-navbar-fixed-top\` class on \`<html>\` (never an inline
+  padding offset).
 - There is no test runner or Storybook in this app — don't assume one.
 
 ## AI skills

--- a/skills/bestax-layout-scaffold/SKILL.md
+++ b/skills/bestax-layout-scaffold/SKILL.md
@@ -45,10 +45,12 @@ Centered; a collection of items → Card grid. For mixed requests, pick the domi
   `height: 100%` on the card doesn't help — the column's height is auto).
 - Rely on Bulma's responsive defaults: `Columns` sit side by side on tablet and up and stack on
   mobile. Add responsive `size*` props only to tune the breakpoints.
-- `Navbar.Burger`/`Navbar.Menu` are **controlled** — wire `active` via state on both, or the
-  mobile menu can never open (no error, silent failure). For a `fixed="top"` `Navbar`, add the
-  `has-navbar-fixed-top` class to `<html>` so content is not hidden behind it — the library does
-  not do this automatically, and an inline padding offset is not a substitute.
+- `Navbar.Burger`/`Navbar.Menu` are **controlled** — wire the same `active` state to both:
+  `active` on `Navbar.Menu` shows/hides the mobile menu, while `active` + `onClick` on
+  `Navbar.Burger` make the burger toggle it and animate. Left unwired, clicking the burger
+  does nothing (no error, silent failure). For a `fixed="top"` `Navbar`, add the
+  `has-navbar-fixed-top` class to `<html>` so content is not hidden behind it — the library
+  does not do this automatically, and an inline padding offset is not a substitute.
 - **Style with helper props, not inline `style`.** Use `m`/`p` spacing (`mt="4"` = 1rem),
   `textAlign="centered"`, and `textColor`/`bgColor` instead of `style={{ marginTop, textAlign,
 color }}`. Set the app-wide icon library once with `<ConfigProvider iconLibrary="…">` at the root

--- a/skills/bestax-layout-scaffold/SKILL.md
+++ b/skills/bestax-layout-scaffold/SKILL.md
@@ -45,8 +45,10 @@ Centered; a collection of items → Card grid. For mixed requests, pick the domi
   `height: 100%` on the card doesn't help — the column's height is auto).
 - Rely on Bulma's responsive defaults: `Columns` sit side by side on tablet and up and stack on
   mobile. Add responsive `size*` props only to tune the breakpoints.
-- For a `fixed="top"` `Navbar`, add the `has-navbar-fixed-top` class to `<html>` so content is not
-  hidden behind it — the library does not do this automatically.
+- `Navbar.Burger`/`Navbar.Menu` are **controlled** — wire `active` via state on both, or the
+  mobile menu can never open (no error, silent failure). For a `fixed="top"` `Navbar`, add the
+  `has-navbar-fixed-top` class to `<html>` so content is not hidden behind it — the library does
+  not do this automatically, and an inline padding offset is not a substitute.
 - **Style with helper props, not inline `style`.** Use `m`/`p` spacing (`mt="4"` = 1rem),
   `textAlign="centered"`, and `textColor`/`bgColor` instead of `style={{ marginTop, textAlign,
 color }}`. Set the app-wide icon library once with `<ConfigProvider iconLibrary="…">` at the root
@@ -69,7 +71,7 @@ color }}`. Set the app-wide icon library once with `<ConfigProvider iconLibrary=
 ## Examples
 
 - `examples/app-shell.tsx` — fixed `Navbar` + sidebar `Menu` + content (dashboard).
-- `examples/landing.tsx` — `Hero` + `Section`s + `Footer`.
+- `examples/landing.tsx` — fixed `Navbar` (controlled burger) + `Hero` + `Section`s + `Footer`.
 - `examples/centered.tsx` — centered single column (auth/settings).
 - `examples/card-grid.tsx` — multiline `Columns` of `Card`s (catalog).
 - `examples/content-page.tsx` — hero + feature cards + CTA styled with helper props (no inline
@@ -82,6 +84,7 @@ color }}`. Set the app-wide icon library once with `<ConfigProvider iconLibrary=
 - [ ] Use `Grid`/`Cell` for uniform grids (equal heights per row, free); `Columns`/`Column`
       for proportional or per-breakpoint side-by-side layout — with the flex recipe when its
       cards must match height.
+- [ ] Wire `active` state to **both** `Navbar.Burger` and `Navbar.Menu` (they are controlled).
 - [ ] For a fixed navbar, add `has-navbar-fixed-top` to `<html>`.
 - [ ] Do not use `Tile` — it is not shipped.
 - [ ] Style with helper props (`mt`/`p`, `textAlign`, `textColor`), not inline `style`.

--- a/skills/bestax-layout-scaffold/examples/landing.tsx
+++ b/skills/bestax-layout-scaffold/examples/landing.tsx
@@ -2,9 +2,11 @@
 // Each Section stacks vertically; the feature Columns collapse to one per row on
 // mobile (Bulma columns stack below the tablet breakpoint).
 //
-// The Navbar's burger/menu is CONTROLLED: without `active` state wired to both
-// `Navbar.Burger` and `Navbar.Menu`, the mobile menu can never open — desktop
-// looks fine and nothing errors, so the failure is silent. A fixed-top navbar
+// The Navbar's burger/menu is CONTROLLED: `active` on Navbar.Menu shows/hides
+// the mobile menu, while `active` + `onClick` on Navbar.Burger make the burger
+// toggle it and animate. Wire the same state to both — left unwired, clicking
+// the burger does nothing; desktop looks fine and nothing errors, so the
+// failure is silent. A fixed-top navbar
 // also needs the `has-navbar-fixed-top` class on <html> so the page is padded
 // below it (never an inline padding offset) — Bulma requires this and the
 // library does NOT add it for you.

--- a/skills/bestax-layout-scaffold/examples/landing.tsx
+++ b/skills/bestax-layout-scaffold/examples/landing.tsx
@@ -1,8 +1,16 @@
-// Marketing / landing page — Hero + stacked Sections + Footer.
+// Marketing / landing page — fixed top Navbar + Hero + stacked Sections + Footer.
 // Each Section stacks vertically; the feature Columns collapse to one per row on
 // mobile (Bulma columns stack below the tablet breakpoint).
-import React from 'react';
+//
+// The Navbar's burger/menu is CONTROLLED: without `active` state wired to both
+// `Navbar.Burger` and `Navbar.Menu`, the mobile menu can never open — desktop
+// looks fine and nothing errors, so the failure is silent. A fixed-top navbar
+// also needs the `has-navbar-fixed-top` class on <html> so the page is padded
+// below it (never an inline padding offset) — Bulma requires this and the
+// library does NOT add it for you.
+import React, { useEffect, useState } from 'react';
 import {
+  Navbar,
   Hero,
   Section,
   Container,
@@ -24,8 +32,38 @@ const FEATURES = [
 ];
 
 export default function LandingPage() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.classList.add('has-navbar-fixed-top');
+    return () => {
+      document.documentElement.classList.remove('has-navbar-fixed-top');
+    };
+  }, []);
+
   return (
     <>
+      <Navbar fixed="top">
+        <Navbar.Brand>
+          <Navbar.Item href="#">Acme</Navbar.Item>
+          <Navbar.Burger
+            active={menuOpen}
+            onClick={() => setMenuOpen(open => !open)}
+            aria-label="menu"
+            aria-expanded={menuOpen}
+          />
+        </Navbar.Brand>
+        <Navbar.Menu active={menuOpen}>
+          <Navbar.Start>
+            <Navbar.Item href="#">Features</Navbar.Item>
+            <Navbar.Item href="#">Pricing</Navbar.Item>
+          </Navbar.Start>
+          <Navbar.End>
+            <Navbar.Item href="#">Sign in</Navbar.Item>
+          </Navbar.End>
+        </Navbar.Menu>
+      </Navbar>
+
       <Hero color="primary" size="medium">
         <Hero.Body>
           <Container textAlign="centered">

--- a/skills/bestax-layout-scaffold/references/archetypes.md
+++ b/skills/bestax-layout-scaffold/references/archetypes.md
@@ -75,6 +75,26 @@ pricing page. The default for "build me a site/page".
 
 ```tsx
 <>
+  <Navbar fixed="top">
+    <Navbar.Brand>
+      <Navbar.Item href="#">Brand</Navbar.Item>
+      <Navbar.Burger
+        active={open}
+        onClick={() => setOpen(o => !o)}
+        aria-label="menu"
+      />
+    </Navbar.Brand>
+    <Navbar.Menu active={open}>
+      <Navbar.Start>
+        <Navbar.Item href="#">Features</Navbar.Item>
+        <Navbar.Item href="#">Pricing</Navbar.Item>
+      </Navbar.Start>
+      <Navbar.End>
+        <Navbar.Item href="#">Sign in</Navbar.Item>
+      </Navbar.End>
+    </Navbar.Menu>
+  </Navbar>
+
   <Hero color="primary" size="medium">
     <Hero.Body>
       <Container textAlign="centered">
@@ -113,7 +133,13 @@ pricing page. The default for "build me a site/page".
 </>
 ```
 
-**Responsive:** `Section`s already stack vertically. The feature `Columns` collapse to one feature
+**Required:** `Navbar.Burger`/`Navbar.Menu` are **controlled** — wire `active` via state on both
+(a bare `<Navbar.Burger />` renders a burger that can never open, with no error). And add
+`has-navbar-fixed-top` to `<html>` (see `examples/landing.tsx`) so content is not hidden behind
+the fixed navbar — never an inline padding offset.
+
+**Responsive:** the navbar collapses to a burger on mobile (`Navbar.Burger` + `Navbar.Menu active`).
+`Section`s already stack vertically. The feature `Columns` collapse to one feature
 per row on mobile. Use `Hero size="large"` / `"fullheight"` for a taller hero.
 
 **Hero CTAs:** on a colored hero use **filled** buttons only — `color="light"` for the primary

--- a/skills/bestax-layout-scaffold/references/archetypes.md
+++ b/skills/bestax-layout-scaffold/references/archetypes.md
@@ -19,6 +19,8 @@ app".
 **Skeleton:**
 
 ```tsx
+const [open, setOpen] = useState(false); // controls the burger + mobile menu
+
 <>
   <Navbar fixed="top" color="dark">
     <Navbar.Brand>
@@ -54,7 +56,7 @@ app".
       </Column>
     </Columns>
   </Container>
-</>
+</>;
 ```
 
 **Required:** add `has-navbar-fixed-top` to `<html>` (see `examples/app-shell.tsx`) so content is
@@ -74,6 +76,8 @@ pricing page. The default for "build me a site/page".
 **Skeleton:**
 
 ```tsx
+const [open, setOpen] = useState(false); // controls the burger + mobile menu
+
 <>
   <Navbar fixed="top">
     <Navbar.Brand>
@@ -130,11 +134,13 @@ pricing page. The default for "build me a site/page".
       <Content textAlign="centered">{/* footer */}</Content>
     </Container>
   </Footer>
-</>
+</>;
 ```
 
-**Required:** `Navbar.Burger`/`Navbar.Menu` are **controlled** — wire `active` via state on both
-(a bare `<Navbar.Burger />` renders a burger that can never open, with no error). And add
+**Required:** `Navbar.Burger`/`Navbar.Menu` are **controlled** — wire the same `active` state to
+both: `active` on `Navbar.Menu` shows/hides the mobile menu, and `active` + `onClick` on
+`Navbar.Burger` make the burger toggle it and animate (a bare `<Navbar.Burger />` does nothing
+when clicked, with no error). And add
 `has-navbar-fixed-top` to `<html>` (see `examples/landing.tsx`) so content is not hidden behind
 the fixed navbar — never an inline padding offset.
 


### PR DESCRIPTION
# Pull Request

## Description

Closes the landing-archetype coverage gap from the Skynet A/B prompt experiment: a model scaffolding a marketing page via `bestax-layout-scaffold` never saw the controlled-Burger Navbar pattern (it was only taught in the app-shell archetype), so it shipped a `Navbar fixed="top"` whose mobile menu could never open — a bare `<Navbar.Burger />` with no `active` state fails silently — and offset the fixed navbar with inline padding instead of `has-navbar-fixed-top`.

Changes (skill source lives in repo-root `skills/`, synced into the package at build time):

- `skills/bestax-layout-scaffold/examples/landing.tsx` — the landing example now opens with a fixed-top `Navbar` whose `Navbar.Burger`/`Navbar.Menu` are wired to `useState` via `active` on **both**, plus the `has-navbar-fixed-top` add/remove effect on `<html>`, mirroring `app-shell.tsx`. A leading comment explains the silent-failure mode and why an inline padding offset is wrong.
- `skills/bestax-layout-scaffold/references/archetypes.md` §2 (Marketing / landing) — same Navbar pattern added to the skeleton, plus a **Required** note (controlled burger wiring, `has-navbar-fixed-top`, never an inline padding offset) and burger-collapse responsive behavior, matching §1's structure.
- `skills/bestax-layout-scaffold/SKILL.md` — the Approach bullet on fixed navbars now leads with the controlled Burger/Menu rule; a matching Checklist item was added; the landing example's description mentions the Navbar.
- `create-bestax/src/constants.ts` (`CLAUDE_MD` template) — one always-in-context House style line: `Navbar.Burger`/`Navbar.Menu` are controlled — wire `active` via state on both, and pair `Navbar fixed="top"` with `has-navbar-fixed-top` (never an inline padding offset).

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): `skills/` (bundled into create-bestax via `sync-skills.mjs`)

## Related Issue(s)

Closes #348

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works (skill/template content change; no behavioral code paths added — existing 197 create-bestax tests pass)
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui) — no skill-example story renders the landing example
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated (none needed)
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated (no repo-level convention changed; the *generated* app CLAUDE.md template gained the Navbar line)

## Screenshots / Demos

The new landing example's Navbar wiring:

```tsx
const [menuOpen, setMenuOpen] = useState(false);

useEffect(() => {
  document.documentElement.classList.add('has-navbar-fixed-top');
  return () => {
    document.documentElement.classList.remove('has-navbar-fixed-top');
  };
}, []);

<Navbar fixed="top">
  <Navbar.Brand>
    <Navbar.Item href="#">Acme</Navbar.Item>
    <Navbar.Burger
      active={menuOpen}
      onClick={() => setMenuOpen(open => !open)}
      aria-label="menu"
      aria-expanded={menuOpen}
    />
  </Navbar.Brand>
  <Navbar.Menu active={menuOpen}>…</Navbar.Menu>
</Navbar>
```

## Additional Context

- Verified: `landing.tsx` typechecks strict against the library's source types; `prettier --check`, `check-conformance` (incl. `skills-sync`), and `turbo run test typecheck lint --filter=create-bestax` (197 tests) all pass.
- The alternative from the issue (making `Navbar.Burger` auto-toggling/uncontrolled in bulma-ui) is intentionally not done here — that's a component API change for a separate bulma-ui proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDRUvpEgaMAV2UBPokA7hR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDRUvpEgaMAV2UBPokA7hR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for controlling mobile navbar menus with shared state.
  * Documented the required `has-navbar-fixed-top` class for fixed-top navigation.
  * Updated landing-page examples, checklists, and archetype guidance with the corrected navbar pattern.
* **Bug Fixes**
  * Fixed the mobile navbar menu so it opens and closes correctly.
  * Prevented content from being hidden beneath fixed-top navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->