### PR TITLE
feat(create-bestax): set scaffolded index.html title to the project name

### DIFF
--- a/create-bestax/src/__tests__/constants.test.ts
+++ b/create-bestax/src/__tests__/constants.test.ts
@@ -25,6 +25,7 @@ const {
   MESSAGES,
   PROMPTS,
   LAUNCH_JSON,
+  CLAUDE_MD,
 } = await import('../constants.js');
 
 describe('constants', () => {
@@ -224,6 +225,18 @@ describe('constants', () => {
 
     it('is mentioned in the skills success message', () => {
       expect(MESSAGES.SKILLS_ADDED).toContain('launch.json');
+    });
+  });
+
+  describe('CLAUDE_MD', () => {
+    it('tells agents to customize the scaffolded title and README', () => {
+      const content = CLAUDE_MD('my-app', {
+        bulmaFlavor: 'complete',
+        iconLibrary: 'none',
+      });
+      expect(content).toContain('# my-app');
+      expect(content).toContain('`<title>`');
+      expect(content).toContain('README.md');
     });
   });
 

--- a/create-bestax/src/__tests__/constants.test.ts
+++ b/create-bestax/src/__tests__/constants.test.ts
@@ -237,6 +237,9 @@ describe('constants', () => {
       expect(content).toContain('# my-app');
       expect(content).toContain('`<title>`');
       expect(content).toContain('README.md');
+      expect(content).toContain('starts as the project name');
+      expect(content).toContain('meta tags');
+      expect(content).toContain('rewrite the README');
     });
   });
 

--- a/create-bestax/src/__tests__/project-creator.test.ts
+++ b/create-bestax/src/__tests__/project-creator.test.ts
@@ -553,6 +553,53 @@ describe('ProjectCreator', () => {
     });
   });
 
+  describe('updateIndexHtmlTitle', () => {
+    it('replaces the stock <title> with the project name', async () => {
+      const targetPath = '/test/project';
+      const indexHtmlPath = '/test/project/index.html';
+
+      (
+        fs.default.existsSync as jest.MockedFunction<typeof fs.existsSync>
+      ).mockImplementation(path => path === indexHtmlPath);
+      (
+        fs.default.readFile as jest.MockedFunction<typeof fs.readFile>
+      ).mockResolvedValue(
+        '<head><title>Bestax + Vite + React</title></head>' as unknown
+      );
+
+      await projectCreator.updateIndexHtmlTitle(targetPath, 'my-app');
+
+      expect(fs.default.writeFile).toHaveBeenCalledWith(
+        indexHtmlPath,
+        '<head><title>my-app</title></head>'
+      );
+    });
+
+    it('does nothing when index.html is missing', async () => {
+      (
+        fs.default.existsSync as jest.MockedFunction<typeof fs.existsSync>
+      ).mockReturnValue(false);
+
+      await projectCreator.updateIndexHtmlTitle('/test/project', 'my-app');
+
+      expect(fs.default.readFile).not.toHaveBeenCalled();
+      expect(fs.default.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('leaves index.html untouched when it has no <title> tag', async () => {
+      (
+        fs.default.existsSync as jest.MockedFunction<typeof fs.existsSync>
+      ).mockReturnValue(true);
+      (
+        fs.default.readFile as jest.MockedFunction<typeof fs.readFile>
+      ).mockResolvedValue('<head></head>' as unknown);
+
+      await projectCreator.updateIndexHtmlTitle('/test/project', 'my-app');
+
+      expect(fs.default.writeFile).not.toHaveBeenCalled();
+    });
+  });
+
   describe('setupIconLibrary', () => {
     it('should skip setup for none', async () => {
       await projectCreator.setupIconLibrary('/test/project', 'none', 'vite');
@@ -962,6 +1009,37 @@ describe('ProjectCreator', () => {
 
       expect(fileSystem.copyDirectory).toHaveBeenCalled();
       expect(fileSystem.updatePackageJson).toHaveBeenCalled();
+    });
+
+    it('sets the index.html title to the project name', async () => {
+      (
+        fileSystem.checkDirectoryExists as jest.MockedFunction<
+          typeof fileSystem.checkDirectoryExists
+        >
+      ).mockResolvedValue(false);
+      (
+        fileSystem.isDirectoryEmpty as jest.MockedFunction<
+          typeof fileSystem.isDirectoryEmpty
+        >
+      ).mockResolvedValue(true);
+      (
+        fs.default.existsSync as jest.MockedFunction<typeof fs.existsSync>
+      ).mockImplementation(path => String(path).endsWith('index.html'));
+      (
+        fs.default.readFile as jest.MockedFunction<typeof fs.readFile>
+      ).mockResolvedValue(
+        '<head><title>Bestax + Vite + React</title></head>' as unknown
+      );
+
+      await projectCreator.create('test-project', { yes: true, skills: false });
+
+      expect(
+        (fs.default.writeFile as unknown as jest.Mock).mock.calls.some(
+          ([p, content]) =>
+            String(p).endsWith('index.html') &&
+            String(content).includes('<title>test-project</title>')
+        )
+      ).toBe(true);
     });
 
     it('writes launch.json when the skills opt-in is accepted', async () => {

--- a/create-bestax/src/constants.ts
+++ b/create-bestax/src/constants.ts
@@ -140,6 +140,9 @@ ${setupLines.join('\n')}
 - Compose existing components before writing custom CSS; theme via \`Theme\` and \`--bulma-*\`
   variables, never hardcoded colors.
 - There is no test runner or Storybook in this app — don't assume one.
+- \`index.html\`'s \`<title>\` starts as the project name and \`README.md\` is stock template
+  boilerplate — once this app has a real identity, set the title (and any meta tags) to match
+  it and rewrite the README to describe *this* app, not the template.
 
 ## AI skills
 

--- a/create-bestax/src/project-creator.ts
+++ b/create-bestax/src/project-creator.ts
@@ -104,6 +104,25 @@ export class ProjectCreator {
     await copyDirectory(templatePath, targetPath);
   }
 
+  async updateIndexHtmlTitle(
+    targetPath: string,
+    projectName: string
+  ): Promise<void> {
+    const indexHtmlPath = path.join(targetPath, 'index.html');
+    if (!fs.existsSync(indexHtmlPath)) return;
+
+    const htmlContent = await fs.readFile(indexHtmlPath, 'utf8');
+    // projectName is validated against PROJECT_NAME_REGEX (letters, digits,
+    // dots, dashes, underscores only), so it needs no HTML escaping.
+    const updated = htmlContent.replace(
+      /<title>[^<]*<\/title>/,
+      `<title>${projectName}</title>`
+    );
+    if (updated !== htmlContent) {
+      await fs.writeFile(indexHtmlPath, updated);
+    }
+  }
+
   async setupSkills(
     targetPath: string,
     projectName: string,
@@ -559,6 +578,7 @@ export class ProjectCreator {
     try {
       await this.copyTemplate(template, targetPath);
       await updatePackageJson(targetPath, projectName);
+      await this.updateIndexHtmlTitle(targetPath, projectName);
       await this.setupBulmaFlavor(targetPath, bulmaFlavor, template);
       await this.setupIconLibrary(targetPath, iconLibrary, template);
       await this.setupConfigProvider(


### PR DESCRIPTION
# Pull Request

## Description

Scaffolded apps shipped with the stock template `<title>Bestax + Vite + React</title>` and stock `README.md`, and nothing set them to the project's identity or prompted AI agents to update them (#349). This PR:

- Adds `ProjectCreator.updateIndexHtmlTitle`, which deterministically replaces the template `<title>` with the project name at scaffold time (called right after `updatePackageJson`, mirroring the existing icon `<link>` injection style). It no-ops safely when `index.html` or its `<title>` tag is missing. Project names are already validated against `PROJECT_NAME_REGEX`, so no HTML escaping is needed.
- Adds a bullet to the generated `CLAUDE.md` template (`constants.ts`) telling agents that the title starts as the project name and the README is stock boilerplate, and to set the title/meta and rewrite the README to describe the actual app once it has a real identity.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

## Related Issue(s)

Closes #349

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

Scaffolding `smoke-app` with the built CLI (`node dist/index.js smoke-app -t vite-ts -b complete -i none --no-skills -y`) now produces:

```html
<title>smoke-app</title>
```

and the generated `CLAUDE.md` (with skills) includes:

```
- `index.html`'s `<title>` starts as the project name and `README.md` is stock template
  boilerplate — once this app has a real identity, set the title (and any meta tags) to match
  it and rewrite the README to describe *this* app, not the template.
```

## Additional Context

Verified locally: create-bestax jest suite (202 tests) passes, coverage stays above thresholds (98.3% stmts / 88.7% branches), lint, typecheck, prettier, and `check:conformance` all green. The e2e specs assert the `<h1>` hero text, not the document title, so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lvpby5yW74N2RPACCqEjpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lvpby5yW74N2RPACCqEjpN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generated projects now automatically set the browser page title to the project name during creation.
  - The generated project guidance now recommends updating the page title, metadata, and README once the app has its own identity.

- **Bug Fixes**
  - Project creation now preserves valid output when the HTML file or title tag is unavailable, avoiding unnecessary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->