### PR TITLE
docs: add 4.x → 5.x migration guide and renumber migration guides 1–5

### DIFF
--- a/docs/docs/guides/getting-started/migration/bulma-0-9-to-1.md
+++ b/docs/docs/guides/getting-started/migration/bulma-0-9-to-1.md
@@ -1,7 +1,7 @@
 ---
 title: Bulma 0.9.4 → 1.x
 sidebar_label: Bulma 0.9.4 to 1.x
-sidebar_position: 2
+sidebar_position: 4
 ---
 
 # Migrating from Bulma v0.9.x → Bulma v1

--- a/docs/docs/guides/getting-started/migration/bulma-ui-2-to-3.md
+++ b/docs/docs/guides/getting-started/migration/bulma-ui-2-to-3.md
@@ -1,7 +1,7 @@
 ---
 title: bestax-bulma 2.x → 3.x
 sidebar_label: 2.x to 3.x
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Upgrading bestax-bulma 2.x → 3.x

--- a/docs/docs/guides/getting-started/migration/bulma-ui-3-to-4.md
+++ b/docs/docs/guides/getting-started/migration/bulma-ui-3-to-4.md
@@ -1,7 +1,7 @@
 ---
 title: bestax-bulma 3.x → 4.x
 sidebar_label: 3.x to 4.x
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Upgrading bestax-bulma 3.x → 4.x

--- a/docs/docs/guides/getting-started/migration/bulma-ui-4-to-5.md
+++ b/docs/docs/guides/getting-started/migration/bulma-ui-4-to-5.md
@@ -1,0 +1,108 @@
+---
+title: bestax-bulma 4.x → 5.x
+sidebar_label: 4.x to 5.x
+sidebar_position: 1
+---
+
+# Upgrading bestax-bulma 4.x → 5.x
+
+This guide explains what changes when you upgrade `@allxsmith/bestax-bulma` from 4.x to 5.x. There is **one** consumer-facing change: the `versions/bestax-bulma-prefixed.css` stylesheet (the variant that prefixed every class with `bulma-`) is removed. Everything else in the 5.x line is additive — new components and props, no removals or renames.
+
+## TL;DR
+
+:::tip One thing to check
+5.x removes the **`versions/bestax-bulma-prefixed.css`** stylesheet. If you never imported that file, upgrade freely — nothing in your code needs to change. If you did, switch the import to `versions/bestax-prefixed.css` and change `classPrefix="bulma-"` to `classPrefix="bestax-"`.
+:::
+
+| Area               | What changed                                                            | Action                                                                |
+| ------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| CSS variations     | `versions/bestax-bulma-prefixed.css` export removed                     | Import `versions/bestax-prefixed.css` and set `classPrefix="bestax-"` |
+| Class prefix       | One prefixed scheme (`bestax-`) instead of two (`bestax-` and `bulma-`) | Update custom CSS that targets `.bulma-*` classes to `.bestax-*`      |
+| Component behavior | No changes                                                              | None                                                                  |
+| Props / exports    | No removals or renames                                                  | None                                                                  |
+| React peer range   | Unchanged (`^18.0.0 \|\| ^19.0.0`)                                      | None                                                                  |
+
+## The one breaking change: `bestax-bulma-prefixed.css` is removed
+
+4.x shipped **two** prefixed CSS bundles: `versions/bestax-prefixed.css` (classes prefixed `bestax-`, e.g. `bestax-button`) and `versions/bestax-bulma-prefixed.css` (classes prefixed `bulma-`, e.g. `bulma-button`). 5.x standardizes on a single `bestax-` prefix scheme and drops the `bulma-`-prefixed bundle, including its `package.json` export.
+
+**Who is affected:**
+
+- ✅ Importing `bestax.css`, `versions/bestax-prefixed.css`, one of the `no-helpers` / `no-dark-mode` variants, `extras.css`, or building your own Sass — upgrade with no code changes. Those stylesheets are unchanged.
+- ⚠️ Importing `versions/bestax-bulma-prefixed.css` — the import no longer resolves (`ERR_PACKAGE_PATH_NOT_EXPORTED`), so your build fails loudly rather than silently losing styles. Migrate as follows.
+
+### Migrate in two steps
+
+Swap the stylesheet import and the [`ConfigProvider`](/docs/api/helpers/config) prefix together:
+
+```tsx title="Before (4.x)"
+import { ConfigProvider, Button } from '@allxsmith/bestax-bulma';
+import '@allxsmith/bestax-bulma/versions/bestax-bulma-prefixed.css';
+
+function App() {
+  return (
+    <ConfigProvider classPrefix="bulma-">
+      <Button color="primary">Save</Button>
+    </ConfigProvider>
+  );
+}
+```
+
+```tsx title="After (5.x)"
+import { ConfigProvider, Button } from '@allxsmith/bestax-bulma';
+import '@allxsmith/bestax-bulma/versions/bestax-prefixed.css';
+
+function App() {
+  return (
+    <ConfigProvider classPrefix="bestax-">
+      <Button color="primary">Save</Button>
+    </ConfigProvider>
+  );
+}
+```
+
+### Update anything that referenced `bulma-*` class names
+
+The rendered class names change from `bulma-*` to `bestax-*`:
+
+```html title="Rendered HTML, before → after"
+<!-- 4.x with bestax-bulma-prefixed.css -->
+<button class="bulma-button bulma-is-primary">Save</button>
+
+<!-- 5.x with bestax-prefixed.css -->
+<button class="bestax-button bestax-is-primary">Save</button>
+```
+
+So alongside the two-step swap, update anything in your project that referenced the old names: custom CSS overrides (`.bulma-button { … }` → `.bestax-button { … }`), and any tests or E2E selectors that queried `.bulma-*` classes.
+
+### If you need to keep the `bulma-` prefix
+
+The pre-built bundle is gone, but the prefix itself isn't reserved — you can rebuild the same stylesheet from Sass, exactly like the [Custom Brand variation](../variations.md#custom-brand-scss-only):
+
+```scss title="src/styles/bulma-prefixed.scss"
+@use 'bulma/sass' with (
+  $class-prefix: 'bulma-'
+);
+
+// Include bestax extras (Toast, Dialog, Carousel, Slider, Switch, etc.)
+@use '@allxsmith/bestax-bulma/scss';
+```
+
+Import that file instead of the removed CSS (you'll need `bulma` and `sass` installed — `pnpm add bulma sass`), keep `classPrefix="bulma-"`, and nothing else changes.
+
+**Why this changed:** maintaining two parallel prefixed bundles doubled the prefixed build and test surface without adding capability — anything the `bulma-` bundle could do, the `bestax-` bundle (or a custom Sass build) does equally well. 5.x standardizes on the single `bestax-` scheme.
+
+## No other breaking changes
+
+No components, props, or exports were removed or renamed crossing the 5.0 boundary, and the React peer range is unchanged from 4.x (React 18 or 19). The rest of the 5.x line is additive — highlights since 4.x:
+
+- New components: [Avatar](/docs/api/components/avatar), [Avatars](/docs/api/components/avatars), [Badge](/docs/api/components/badge), and [Reveal](/docs/api/components/reveal) (scroll-triggered animations).
+- Compound (dot-notation) sub-components for all parent/child families — `Card.Header`, `Navbar.Item`, `Modal.Card`, and the rest.
+- [`Theme`](/docs/api/helpers/theme) gained a `colorMode` prop for forcing light/dark mode.
+- `Button` and `Link` accept a polymorphic `as` prop; `Columns` gained a `gap` prop.
+
+The full list is in the [changelog](https://github.com/allxsmith/bestax/blob/main/bulma-ui/CHANGELOG.md).
+
+:::note Coming from 3.x?
+If you're upgrading across majors, read the [3.x → 4.x guide](./bulma-ui-3-to-4.md) first — that release raised the React floor to 18. And if you're coming all the way from 2.x, the [2.x → 3.x guide](./bulma-ui-2-to-3.md) is where the real migration work (if any) lives.
+:::

--- a/docs/docs/guides/getting-started/migration/bulma-ui-4-to-5.md
+++ b/docs/docs/guides/getting-started/migration/bulma-ui-4-to-5.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Upgrading bestax-bulma 4.x → 5.x
 
-This guide explains what changes when you upgrade `@allxsmith/bestax-bulma` from 4.x to 5.x. There is **one** consumer-facing change: the `versions/bestax-bulma-prefixed.css` stylesheet (the variant that prefixed every class with `bulma-`) is removed. Everything else in the 5.x line is additive — new components and props, no removals or renames.
+This guide explains what changes when you upgrade `@allxsmith/bestax-bulma` from 4.x to 5.x. There is **one** consumer-facing change: the `versions/bestax-bulma-prefixed.css` stylesheet and its package export (the variant that prefixed every class with `bulma-`) are removed. Everything else in the 5.x line is additive — new components and props; no component props or JavaScript exports are removed or renamed.
 
 ## TL;DR
 
@@ -14,13 +14,13 @@ This guide explains what changes when you upgrade `@allxsmith/bestax-bulma` from
 5.x removes the **`versions/bestax-bulma-prefixed.css`** stylesheet. If you never imported that file, upgrade freely — nothing in your code needs to change. If you did, switch the import to `versions/bestax-prefixed.css` and change `classPrefix="bulma-"` to `classPrefix="bestax-"`.
 :::
 
-| Area               | What changed                                                            | Action                                                                |
-| ------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| CSS variations     | `versions/bestax-bulma-prefixed.css` export removed                     | Import `versions/bestax-prefixed.css` and set `classPrefix="bestax-"` |
-| Class prefix       | One prefixed scheme (`bestax-`) instead of two (`bestax-` and `bulma-`) | Update custom CSS that targets `.bulma-*` classes to `.bestax-*`      |
-| Component behavior | No changes                                                              | None                                                                  |
-| Props / exports    | No removals or renames                                                  | None                                                                  |
-| React peer range   | Unchanged (`^18.0.0 \|\| ^19.0.0`)                                      | None                                                                  |
+| Area                         | What changed                                                            | Action                                                                |
+| ---------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| CSS variations               | `versions/bestax-bulma-prefixed.css` export removed                     | Import `versions/bestax-prefixed.css` and set `classPrefix="bestax-"` |
+| Class prefix                 | One prefixed scheme (`bestax-`) instead of two (`bestax-` and `bulma-`) | Update custom CSS that targets `.bulma-*` classes to `.bestax-*`      |
+| Component behavior           | No changes                                                              | None                                                                  |
+| Component props / JS exports | No removals or renames                                                  | None                                                                  |
+| React peer range             | Unchanged (`^18.0.0 \|\| ^19.0.0`)                                      | None                                                                  |
 
 ## The one breaking change: `bestax-bulma-prefixed.css` is removed
 
@@ -94,7 +94,7 @@ Import that file instead of the removed CSS (you'll need `bulma` and `sass` inst
 
 ## No other breaking changes
 
-No components, props, or exports were removed or renamed crossing the 5.0 boundary, and the React peer range is unchanged from 4.x (React 18 or 19). The rest of the 5.x line is additive — highlights since 4.x:
+No components, component props, or JavaScript exports were removed or renamed crossing the 5.0 boundary — the stylesheet export above is the only removal — and the React peer range is unchanged from 4.x (React 18 or 19). The rest of the 5.x line is additive — highlights since 4.x:
 
 - New components: [Avatar](/docs/api/components/avatar), [Avatars](/docs/api/components/avatars), [Badge](/docs/api/components/badge), and [Reveal](/docs/api/components/reveal) (scroll-triggered animations).
 - Compound (dot-notation) sub-components for all parent/child families — `Card.Header`, `Navbar.Item`, `Modal.Card`, and the rest.

--- a/docs/docs/guides/getting-started/migration/index.md
+++ b/docs/docs/guides/getting-started/migration/index.md
@@ -7,7 +7,7 @@ slug: /guides/getting-started/migration
 # Migration
 
 :::note Independent migration paths
-The pages below cover unrelated upgrades. Most readers only need one. The 4.x → 5.x and 3.x → 4.x bumps are one-line changes for most apps; the real work (if any) is in 2.x → 3.x.
+The pages below cover unrelated upgrades. Most readers only need one. For apps already on React 18 or 19, the 4.x → 5.x and 3.x → 4.x bumps are one-line changes at most; apps still on React 16 or 17 need a React upgrade first to cross 4.x. The real work (if any) is in 2.x → 3.x.
 :::
 
 Pick whichever applies to your situation:

--- a/docs/docs/guides/getting-started/migration/index.md
+++ b/docs/docs/guides/getting-started/migration/index.md
@@ -7,10 +7,16 @@ slug: /guides/getting-started/migration
 # Migration
 
 :::note Independent migration paths
-The pages below cover unrelated upgrades. Most readers only need one. The 3.x → 4.x bump is a one-line change for most apps; the real work (if any) is in 2.x → 3.x.
+The pages below cover unrelated upgrades. Most readers only need one. The 4.x → 5.x and 3.x → 4.x bumps are one-line changes for most apps; the real work (if any) is in 2.x → 3.x.
 :::
 
 Pick whichever applies to your situation:
+
+## [Upgrading bestax-bulma 4.x → 5.x](./bulma-ui-4-to-5.md)
+
+The 5.x release has a single consumer-facing change: the **`versions/bestax-bulma-prefixed.css` stylesheet is removed** (the variant that prefixed every class with `bulma-`). If you never imported that file, upgrade with no code changes. If you did, switch to `versions/bestax-prefixed.css` with `classPrefix="bestax-"` and update any custom CSS targeting `.bulma-*` classes. The rest of the 5.x line is additive — Avatar, Badge, Reveal, compound (dot-notation) sub-components, and more.
+
+[Read the full 4.x to 5.x guide →](./bulma-ui-4-to-5.md)
 
 ## [Upgrading bestax-bulma 3.x → 4.x](./bulma-ui-3-to-4.md)
 
@@ -29,12 +35,6 @@ Also notable but not breaking: new optional context-driven APIs in `<Tabs>`, `<C
 
 [Read the full 2.x to 3.x guide →](./bulma-ui-2-to-3.md)
 
-## [Migrating from react-bulma-components](./react-bulma-components.md)
-
-Coming from the (unmaintained) `react-bulma-components` library? The **`bestax-migrate`** codemod converts imports, component names, props, and responsive objects to bestax-bulma automatically, and flags everything it can't convert with `TODO(bestax-migrate)` comments plus a report. An [Agent Skill](/docs/skills/migrate) packages the whole workflow for coding agents.
-
-[Read the react-bulma-components guide →](./react-bulma-components.md)
-
 ## [Migrating from Bulma v0.9.x → v1](./bulma-0-9-to-1.md)
 
 bestax-bulma itself has always required Bulma v1 — there's no "bestax on Bulma 0.9" path. This guide is for two adjacent scenarios: (1) you're migrating off **another** React + Bulma library (`react-bulma-components`, Buefy, etc.) that was pinned to Bulma 0.9.x, or (2) you have **plain Bulma 0.9.x** in your own project that you want to upgrade alongside (or before) adopting bestax.
@@ -42,3 +42,9 @@ bestax-bulma itself has always required Bulma v1 — there's no "bestax on Bulma
 The HTML stays identical between Bulma 0.9 and 1, but Bulma v1 swaps Node Sass for Dart Sass, introduces CSS custom properties for runtime theming, ships a real CSS Grid system, and deprecates Tiles.
 
 [Read the full Bulma 0.9.4 → 1.x guide →](./bulma-0-9-to-1.md)
+
+## [Migrating from react-bulma-components](./react-bulma-components.md)
+
+Coming from the (unmaintained) `react-bulma-components` library? The **`bestax-migrate`** codemod converts imports, component names, props, and responsive objects to bestax-bulma automatically, and flags everything it can't convert with `TODO(bestax-migrate)` comments plus a report. An [Agent Skill](/docs/skills/migrate) packages the whole workflow for coding agents.
+
+[Read the react-bulma-components guide →](./react-bulma-components.md)

--- a/docs/docs/guides/getting-started/migration/react-bulma-components.md
+++ b/docs/docs/guides/getting-started/migration/react-bulma-components.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating from react-bulma-components
 sidebar_label: From react-bulma-components
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 # Migrating from react-bulma-components


### PR DESCRIPTION
# Pull Request

## Description

Adds the missing **bestax-bulma 4.x → 5.x migration guide** and gives the migration guides a clean, sequential sidebar order.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)
- [ ] Other (please specify):

**What changed:**

- New `guides/getting-started/migration/bulma-ui-4-to-5.md` covering the single 5.0.0 breaking change: `versions/bestax-bulma-prefixed.css` (the `bulma-`-prefix bundle) was removed. The guide follows the 3.x → 4.x guide's format (TL;DR admonition + area/what-changed/action table), shows the two-step migration (swap the import to `versions/bestax-prefixed.css`, change `classPrefix="bulma-"` → `"bestax-"`), calls out the rendered-class-name consequence for custom CSS/test selectors, documents the custom-Sass escape hatch for keeping the `bulma-` prefix, and summarizes the additive 5.x highlights (Avatar/Avatars/Badge, Reveal, compound sub-components, Theme `colorMode`, polymorphic `as`, Columns `gap`).
- All five migration guides now have unique sequential `sidebar_position` values (previously two guides shared position 2, interleaving the Bulma 0.9 guide between the bestax version guides):
  1. `bulma-ui-4-to-5.md` (new)
  2. `bulma-ui-3-to-4.md`
  3. `bulma-ui-2-to-3.md`
  4. `bulma-0-9-to-1.md`
  5. `react-bulma-components.md`
- The migration landing page (`index.md`) gains a 4.x → 5.x section, its intro note now mentions both one-line bumps, and its section order matches the sidebar order.

## Related Issue(s)

Closes #364

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] Build tooling
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [ ] All new and existing tests passed
- [ ] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Screenshots / Demos

N/A — docs-only. The resulting sidebar order is the numbered list above.

## Additional Context

- Docs-only change (six markdown files, no code). Verified with `pnpm exec prettier --write` (no diffs), `pnpm check:conformance` (passes), and a full docs production build (`turbo run build --filter=@allxsmith/bestax-docs`), which succeeds with `onBrokenLinks: 'throw'` — so the new page's relative links, anchors (`../variations.md#custom-brand-scss-only`), and API links all resolve. The unchecked "tests passed" box reflects that the jest suites weren't run locally; nothing in them is affected by markdown changes and CI will run them.
- The guide's facts were verified against the source: commit 94baa34 (the 5.0.0 break) only removed the `bulma-`-prefix bundle, and at the `@allxsmith/bestax-bulma@4.0.0` tag `bestax-prefixed.scss` already used the `bestax-` prefix — so `bestax-bulma-prefixed.css` importers are the only affected consumers, which is exactly how the guide scopes it.
- No page URLs changed (renumbering only affects sidebar order), so the published LLM index only gains the new page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSayBXndVkFsxGFNFX9sRJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a migration guide for upgrading from version 4.x to 5.x, including stylesheet, class-prefix, and custom CSS updates.
  * Clarified migration paths and upgrade effort across supported versions.
  * Reordered migration topics and improved documentation sidebar organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->