### PR TITLE
chore: force patched brace-expansion ahead of the cooldown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   serialize-javascript: '>=7.0.3'
   sharp@<0.35.0: '>=0.35.0'
   postcss@<8.5.18: '>=8.5.18 <9'
+  brace-expansion: '>=5.0.8'
 
 importers:
 
@@ -4546,9 +4547,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -4598,15 +4596,9 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4904,9 +4896,6 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -15495,8 +15484,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.40: {}
@@ -15561,16 +15548,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15877,8 +15855,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  concat-map@0.0.1: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -19093,15 +19069,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,11 @@ minimumReleaseAge: 4320
 # (which would cause recurring reformat churn). Not shipped to users.
 minimumReleaseAgeExclude:
   - prettier
+  # Urgent security patch (GHSA-mh99-v99m-4gvg, high): 5.0.8 is the only
+  # patched release on any major line and published 2026-07-23, so the audit
+  # gate cannot go green until the cooldown is bypassed. The cooldown elapses
+  # 2026-07-26 — remove from this list after that date.
+  - brace-expansion
 
 # Pin a single prettier version workspace-wide so eslint-plugin-prettier and
 # `prettier --check` never disagree (patch versions format union types
@@ -53,6 +58,14 @@ overrides:
   # auto-loading follows `../` out of the source directory and discloses
   # arbitrary .map files.
   'postcss@<8.5.18': '>=8.5.18 <9'
+  # Force patched brace-expansion (transitive via minimatch across the eslint
+  # and jest toolchains) — high advisory GHSA-mh99-v99m-4gvg: unbounded
+  # expansion length causes an out-of-memory crash. Unlike the earlier
+  # brace-expansion advisory this one has no per-major backport — 5.0.8 is the
+  # only patched release — so the 1.x and 2.x consumers are pulled across
+  # majors too. Safe here because 5.x keeps a `require` export condition and
+  # every consumer is dev-tooling only, never published output.
+  brace-expansion: '>=5.0.8'
 
 # Strict, symlinked node_modules prevents phantom dependencies (using packages
 # we never declared). Narrow public hoists only for tooling that needs a flat


### PR DESCRIPTION
# Pull Request

## Description

`main` went red immediately after #387 merged. A **new** high-severity advisory landed against
`brace-expansion` — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), unbounded
expansion length causing an out-of-memory crash — published in the ~100 minutes between the clean audit on
#387 and the post-merge CI run. It covers `<=5.0.7`, and **5.0.8 is the only patched release on any major
line**, so all three resolved copies (1.1.16, 2.1.2, 5.0.7) are affected at once.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: repo-root dependency policy (`pnpm-workspace.yaml`, `pnpm-lock.yaml`)

### This is not fallout from #387

The three selectors that PR removed — `<1.1.16`, `>=2.0.0 <2.1.2`, `>=3.0.0 <5.0.7` — match **none** of the
installed versions (1.1.16, 2.1.2, 5.0.7), which is exactly why removing them changed zero resolutions. They
were inert with or without this advisory, and 5.0.8 did not exist when they were written, so keeping them
would have left `main` failing identically.

### This one genuinely needs a cooldown bypass

`brace-expansion@5.0.8` published 2026-07-23 11:39Z — inside the 3-day `minimumReleaseAge` window. Unlike
the postcss case in #387, pnpm cannot reach the patch on its own, so the gate cannot go green without an
exclusion. Following the `fast-uri` precedent, the entry carries an explicit expiry: the cooldown elapses
**2026-07-26**, after which `brace-expansion` should be dropped from `minimumReleaseAgeExclude` (the
override stays).

### Cross-major bump — why it is safe here

With no 1.x/2.x backport available, a single `brace-expansion: '>=5.0.8'` override is the only way to clear
the advisory, which pulls the 1.x and 2.x consumers across majors. Checked before relying on it:

| Concern | Finding |
|---|---|
| CJS consumers (minimatch 3.x) | 5.x keeps a `require` export condition → `require('brace-expansion')` resolves |
| `engines` | 5.0.8 declares `node 20 \|\| >=22`; repo runs Node 22 local / 24 CI |
| Reaches published output? | No — `@allxsmith/bestax-bulma` ships one runtime dep (`bulma`); brace-expansion reaches only the private, unpublished docs site |

Verified empirically rather than by reasoning alone: the full gate exercises eslint, jest, the builds and
Storybook — every real consumer — and passes.

## Related Issue(s)

Refs #386

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling — dependency resolution policy and lockfile

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works — the CI audit step is
      itself the regression test for this class of change
- [x] I have added/updated documentation as needed — override and exclusion comments in `pnpm-workspace.yaml`
- [x] I have updated Storybook stories as needed (bulma-ui) — n/a, no source changes
- [x] My changes require a change to the documentation — n/a
- [x] All new and existing tests passed
- [x] Any relevant dependencies are updated
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are
      updated — n/a

## Verification

- `pnpm audit --audit-level=high` → exit 0 (red on `main`); three copies collapse to a single 5.0.8
- `pnpm install --frozen-lockfile` → no-op, lockfile in sync for CI parity
- `pnpm all` → green (build, typecheck, test + coverage, bundle:stats, lint, format:check, Storybook build)

## Additional Context

Follow-up note beyond this diff: this is the second high-severity advisory in under two hours on a repo whose
audit gate blocks every PR. A 3-day cooldown structurally guarantees a red gate whenever an advisory's only
patch is fresher than 72 hours. Worth deciding separately whether to shorten the cooldown or let the audit
step warn while a scheduled job tracks advisories — not changed here.

`chore:` commit — no semantic-release version bump for any package.

---
_Generated by [Claude Code](https://claude.ai/code/session_015wkR9URhcpY6VuU1chR6mV)_