### PR TITLE
ci: add OpenSSF Scorecard workflow with published results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,60 @@
+name: OpenSSF Scorecard
+
+# Third-party, independently verifiable rating of this repo's supply-chain
+# posture (pinned actions, token permissions, signed releases, SAST, branch
+# protection...). Publishing the results is what makes the README badge and the
+# public scorecard.dev viewer work — see issue #404.
+#
+# No pull_request trigger: that trigger is experimental upstream and is not
+# supported on forks. The weekly schedule is the point — it keeps scoring us
+# after merge, so a change that regresses the posture surfaces without anyone
+# remembering to look.
+on:
+  branch_protection_rule:
+  schedule:
+    # Mondays 07:41 UTC — off the hour to avoid GitHub's scheduling backlog.
+    - cron: '41 7 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the SARIF so findings land in the Security tab next to CodeQL.
+      security-events: write
+      # Required by publish_results: mints the OIDC token that proves to the
+      # OpenSSF API that this result really came from this repo's CI.
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Required for the badge and the public viewer to have any data.
+          publish_results: true
+
+      # Retained separately from code scanning: the Security tab prunes old
+      # alerts, and a raw SARIF is easier to diff when investigating a score drop.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Closes part of #404 (the workflow half — the badge lands in the #403 README PR).

## What

Adds `.github/workflows/scorecard.yml`. Runs the [OpenSSF Scorecard](https://scorecard.dev) analysis weekly, on pushes to `main`, and on `branch_protection_rule` changes; publishes results so the public viewer and the README badge have data; uploads SARIF to the Security tab alongside CodeQL.

## Why

Scorecard is a third-party, independently verifiable rating of exactly the posture this repo already invests in. It turns "we say we're hardened" into a number anyone can check — which is the whole premise of #403.

## Notes on the choices

- **No `pull_request` trigger.** Experimental upstream and unsupported on forks.
- **`publish_results: true`** with `id-token: write` — without both, the badge has no data at all.
- **`permissions: read-all`** at workflow level, with the three write scopes re-declared on the job only. Same least-privilege shape as `ci.yml:13-14` (which uses `contents: read`); `read-all` is the value upstream recommends for Scorecard, which needs broad read access to score the repo.
- **All four actions SHA-pinned** with `# vN` comments, per house convention. `actions/checkout` reuses the exact pin already in `ci.yml`; `ossf/scorecard-action` v2.4.4 and `github/codeql-action/upload-sarif` v4 tags were dereferenced to their commit SHAs.
- **Weekly schedule is deliberate** — it keeps scoring after merge, so a regression surfaces without anyone remembering to look.

## Expected score

Roughly **7–8 / 10** initially. High on `Pinned-Dependencies`, `Token-Permissions`, `Signed-Releases`, `SAST`, `Dependency-Update-Tool`, `Security-Policy`. Dragged down by `Fuzzing` (not applicable to a component library — expect 0, ignore it) and `Code-Review` (Scorecard counts GitHub review approvals; our reviews are AI bots that don't leave approvals).

`Branch-Protection` should now score better — required status checks and 1 required approval were applied to `main` under #405.

## Verification

- [x] `prettier --check` passes
- [x] YAML parses; triggers, job permissions, and all four SHA pins confirmed
- [ ] Workflow runs green **after merge to `main`** (the `push` trigger can't fire from a PR branch)
- [ ] Results appear at https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax
- [ ] SARIF appears in the Security tab

**Merge this before the #403 README PR** — the Scorecard badge 404s until this has run on `main` at least once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated OpenSSF Scorecard security analysis on a weekly schedule and whenever changes are pushed to the main branch.
  * Security analysis results are now published to code scanning for visibility and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->