### PR TITLE
docs: advertise supply-chain hardening in READMEs and correct SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax/blob/main/bulma-ui/jest.config.js)
 [![Bulma](https://img.shields.io/badge/Bulma-v1.0+-00d1b2.svg)](https://bulma.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/@allxsmith/bestax-bulma)](https://socket.dev/npm/package/@allxsmith/bestax-bulma/overview)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma#provenance)
+[![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
 
 TypeScript-first React component library for the **Bulma v1** CSS framework — 80+ fully typed components — plus a project scaffolder and AI agent tooling.
 
@@ -170,6 +174,25 @@ Building with an AI agent (Claude Code, Cursor, Copilot)? bestax-bulma ships LLM
 - **Lightweight** — see the live [bundlephobia badge](https://bundlephobia.com/package/@allxsmith/bestax-bulma); tree-shakeable ESM + CJS
 - **99% test coverage** — enforced in CI by the [jest config](bulma-ui/jest.config.js), not just claimed
 - **Active developer support** — issues, questions, and PRs get fast responses
+
+---
+
+## 🔒 Hardened by default
+
+Supply-chain security here is a standing constraint on how the project is built, not a checklist we filled in once:
+
+- **Signed provenance on every release** — each tarball carries a sigstore attestation linking it to the exact commit and CI run that produced it. Check it yourself with `npm audit signatures`, or on the package page's Provenance section.
+- **npm OIDC trusted publishing** — releases authenticate with short-lived, per-run tokens. There is no long-lived `NPM_TOKEN` in this repo to steal.
+- **Signed release commits** — release commits and tags are GPG-signed, and `main` rejects unsigned commits outright.
+- **Socket.dev scans every PR** — dependency changes are checked for malware, install scripts, obfuscated code, and privilege escalation before they can reach `main`.
+- **Every GitHub Action pinned to a full commit SHA** — no movable tags, so a compromised action release can't roll silently into the pipeline.
+- **Install scripts blocked by default** — dependency `install`/`postinstall` scripts don't run unless explicitly allow-listed one at a time, each with a written rationale ([`pnpm-workspace.yaml`](pnpm-workspace.yaml)).
+- **3-day dependency cooldown** — freshly published versions won't install. This is the main defense against account-takeover worms, which are usually yanked within hours.
+- **Frozen lockfile + audit gate** — CI installs exactly what the reviewed lockfile resolves and fails on high-severity advisories.
+- **CodeQL, Dependency Review, and Dependabot** — static analysis over both the source and the workflow files, PR-level advisory blocking, and weekly grouped dependency updates.
+- **Layered AI review before merge** — every PR gets a [CodeRabbit](https://coderabbit.ai) review plus an independent adversarial Claude review that deliberately runs a different model from the one writing AI-authored changes. On top of that, `main` requires green CI, one approving review, and a human merge. AI agents are structurally barred from editing the workflows, release config, or supply-chain settings that gate them.
+
+Full detail: [`SECURITY.md`](SECURITY.md) · [Security guide](https://bestax.io/docs/guides/security)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,9 +46,9 @@ Measures active in this repository and its release pipeline:
   full commit SHA, not a movable tag.
 - **Socket.dev** — the Socket GitHub App reviews every pull request for
   malware, install scripts, obfuscated code, and privilege escalation in
-  dependency changes, and posts two required checks. Its policy is managed in
-  the Socket dashboard rather than in this repository, so it has no config
-  file here.
+  dependency changes, and posts two checks on every pull request. Its policy
+  is managed in the Socket dashboard rather than in this repository, so it has
+  no config file here.
 - **CodeQL** — GitHub code scanning runs on JavaScript/TypeScript and the
   workflow files themselves. It uses GitHub's _default setup_, so there is no
   `codeql.yml` in `.github/workflows/`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,15 +3,16 @@
 ## Supported Versions
 
 Security fixes land on the **latest release line only** — currently
-`@allxsmith/bestax-bulma` 5.x and `create-bestax` 3.x. Both packages release
-automatically from `main` (semantic-release), so the latest published version
-is always the patched one. Older majors may still work but receive no security
-updates; please upgrade.
+`@allxsmith/bestax-bulma` 5.x, `create-bestax` 3.x, and `bestax-migrate` 1.x.
+All three packages release automatically from `main` (semantic-release), so the
+latest published version is always the patched one. Older majors may still work
+but receive no security updates; please upgrade.
 
 | Package                   | Supported    | Unsupported |
 | ------------------------- | ------------ | ----------- |
 | `@allxsmith/bestax-bulma` | 5.x (latest) | < 5.0       |
 | `create-bestax`           | 3.x (latest) | < 3.0       |
+| `bestax-migrate`          | 1.x (latest) | —           |
 
 ## Supply-Chain Security
 
@@ -22,8 +23,12 @@ Measures active in this repository and its release pipeline:
   (`allowBuilds` in `pnpm-workspace.yaml`).
 - **Dependency cooldown** — by default, versions published less than 3 days
   ago won't install (`minimumReleaseAge`), defending against just-published
-  malicious releases. One dev-only exception: `prettier` is excluded (and
-  pinned) so formatting stays deterministic; it is never shipped to users.
+  malicious releases. Exceptions are listed in `minimumReleaseAgeExclude` and
+  are the deliberate minority: `prettier` is excluded (and pinned) so
+  formatting stays deterministic and is never shipped to users, and an
+  individual package may be excluded temporarily to pull an urgent security
+  patch in ahead of the cooldown — each such entry carries an inline rationale
+  and a removal date.
 - **Isolated `node_modules`** — pnpm's isolated linker prevents phantom
   (undeclared) dependencies from being imported.
 - **Frozen lockfile in CI** — builds and releases install with
@@ -31,7 +36,7 @@ Measures active in this repository and its release pipeline:
   reviewed lockfile resolves. (The React 18/19 compatibility matrix is the
   one deliberate exception: it re-resolves to pin the requested React major
   for testing, and never publishes.)
-- **npm provenance** — both published packages set
+- **npm provenance** — all three published packages set
   `publishConfig.provenance`, so every release carries a signed attestation
   linking the tarball to the exact commit and CI run that built it.
 - **OIDC trusted publishing** — releases authenticate to npm with
@@ -39,11 +44,27 @@ Measures active in this repository and its release pipeline:
   to steal.
 - **SHA-pinned GitHub Actions** — every third-party action is pinned to a
   full commit SHA, not a movable tag.
+- **Socket.dev** — the Socket GitHub App reviews every pull request for
+  malware, install scripts, obfuscated code, and privilege escalation in
+  dependency changes, and posts two required checks. Its policy is managed in
+  the Socket dashboard rather than in this repository, so it has no config
+  file here.
 - **CodeQL** — GitHub code scanning runs on JavaScript/TypeScript and the
-  workflow files themselves.
+  workflow files themselves. It uses GitHub's _default setup_, so there is no
+  `codeql.yml` in `.github/workflows/`.
+- **OpenSSF Scorecard** — `.github/workflows/scorecard.yml` scores this
+  repository's supply-chain posture weekly and publishes the result publicly.
 - **Dependency review** — a workflow blocks PRs that introduce dependencies
   with known advisories.
 - **Dependabot** — weekly, grouped dependency update PRs.
+- **Protected `main`** — unsigned commits, force pushes, and branch deletion
+  are rejected. Merges require green CI (`Build and Test`, the React 18/19
+  compatibility matrix, and `Dependency Review`) plus an approving review.
+- **Layered automated review** — every PR is reviewed by CodeRabbit and by an
+  independent adversarial Claude review that deliberately runs a different
+  model from the one used to write AI-authored changes. AI agents working in
+  this repository are barred from modifying the workflows, release
+  configuration, or supply-chain settings that gate them.
 
 Consumers can verify provenance themselves: the npm package pages show the
 attestation ("Provenance" section), and — in projects installed with the npm

--- a/bestax-migrate/README.md
+++ b/bestax-migrate/README.md
@@ -1,5 +1,13 @@
 # bestax-migrate
 
+[![npm version](https://img.shields.io/npm/v/bestax-migrate.svg)](https://www.npmjs.com/package/bestax-migrate)
+[![npm downloads](https://img.shields.io/npm/dm/bestax-migrate.svg)](https://www.npmjs.com/package/bestax-migrate)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/bestax-migrate)](https://socket.dev/npm/package/bestax-migrate/overview)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/bestax-migrate#provenance)
+[![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
+
 Codemods that migrate existing React apps to [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) — the actively maintained React component library for **Bulma v1**.
 
 Currently supported source libraries:
@@ -53,6 +61,20 @@ npx skills add https://github.com/allxsmith/bestax --skill bestax-migrate
 3. Typecheck/build and review the rendered app
 
 Full walkthrough: [react-bulma-components migration guide](https://bestax.io/docs/guides/getting-started/migration/react-bulma-components).
+
+## Hardened by default
+
+A codemod rewrites your source in place, so how it is built and published matters:
+
+- **Signed provenance** — every release carries a sigstore attestation linking the tarball to the exact commit and CI run that built it. Check the **Provenance** section on the [npm page](https://www.npmjs.com/package/bestax-migrate#provenance), or run `npm audit signatures`.
+- **npm OIDC trusted publishing** — short-lived, per-run credentials; no long-lived `NPM_TOKEN` exists to be stolen. Release commits and tags are GPG-signed.
+- **Socket.dev scans every PR** for malware, install scripts, obfuscated code, and privilege escalation before it can reach `main`.
+- **The libraries this tool migrates away from are never installed here** — source fixtures are read as text only, so no unmaintained third-party package enters the dependency tree.
+- **Dependencies are a deliberate act** — install scripts are blocked unless individually allow-listed, freshly published versions are refused for 3 days, and CI installs only what the reviewed lockfile resolves.
+- **Every GitHub Action is pinned to a full commit SHA**, and CodeQL, Dependency Review, and Dependabot run continuously alongside a high-severity `pnpm audit` gate.
+- **Layered AI review before merge** — [CodeRabbit](https://coderabbit.ai) plus an independent adversarial Claude review (a different model from the one writing AI-authored changes), on top of required green CI, an approving review, and a human merge.
+
+Full detail: [`SECURITY.md`](https://github.com/allxsmith/bestax/blob/main/SECURITY.md) · [Security guide](https://bestax.io/docs/guides/security)
 
 ## License
 

--- a/bulma-ui/README.md
+++ b/bulma-ui/README.md
@@ -7,6 +7,10 @@
 [![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](https://github.com/allxsmith/bestax/blob/main/bulma-ui/jest.config.js)
 [![Bulma](https://img.shields.io/badge/Bulma-v1.0+-00d1b2.svg)](https://bulma.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/@allxsmith/bestax-bulma)](https://socket.dev/npm/package/@allxsmith/bestax-bulma/overview)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma#provenance)
+[![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
 
 TypeScript-first React component library for the **Bulma v1** CSS framework — 80+ fully typed, tree-shakeable components, including extras like Carousel, Dialog, Sidebar, Steps, and date/time pickers.
 
@@ -121,6 +125,22 @@ import { Theme } from '@allxsmith/bestax-bulma';
 
 View the package on npmjs:  
 👉 [https://www.npmjs.com/package/@allxsmith/bestax-bulma](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
+
+---
+
+## 🔒 Hardened by default
+
+This package is one runtime dependency deep (Bulma) and is published under a deliberately strict pipeline:
+
+- **Signed provenance** — every release carries a sigstore attestation linking the tarball to the exact commit and CI run that built it. Verify it in the **Provenance** section of the [npm page](https://www.npmjs.com/package/@allxsmith/bestax-bulma#provenance), or run `npm audit signatures` in your project.
+- **npm OIDC trusted publishing** — short-lived, per-run credentials; no long-lived `NPM_TOKEN` exists to be stolen. Release commits and tags are GPG-signed.
+- **Socket.dev scans every PR** for malware, install scripts, obfuscated code, and privilege escalation before it can reach `main`.
+- **Dependencies are a deliberate act** — install scripts are blocked unless individually allow-listed, freshly published versions are refused for 3 days, and CI installs only what the reviewed lockfile resolves.
+- **Every GitHub Action is pinned to a full commit SHA**, so a compromised action release can't roll silently into a build of this package.
+- **CodeQL, Dependency Review, and Dependabot** run continuously, alongside a high-severity `pnpm audit` gate.
+- **Layered AI review before merge** — [CodeRabbit](https://coderabbit.ai) plus an independent adversarial Claude review (a different model from the one writing AI-authored changes), on top of required green CI, an approving review, and a human merge.
+
+Full detail: [`SECURITY.md`](https://github.com/allxsmith/bestax/blob/main/SECURITY.md) · [Security guide](https://bestax.io/docs/guides/security)
 
 ---
 

--- a/create-bestax/README.md
+++ b/create-bestax/README.md
@@ -3,6 +3,10 @@
 [![npm version](https://img.shields.io/npm/v/create-bestax.svg)](https://www.npmjs.com/package/create-bestax)
 [![npm downloads](https://img.shields.io/npm/dm/create-bestax.svg)](https://www.npmjs.com/package/create-bestax)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/create-bestax)](https://socket.dev/npm/package/create-bestax/overview)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/create-bestax#provenance)
+[![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
 
 The scaffolder for [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) — spin up a Vite app pre-wired for the **Bulma v1** React component library in one command. Picks your framework (JS or TypeScript), CSS flavor, and icon library, and can drop in the bestax **AI skills** so an agent like Claude Code knows the library from the first prompt.
 
@@ -126,6 +130,20 @@ npm run typecheck # Type check CLI source code
 ```
 
 **Note on Templates:** Template files in `templates/` are excluded from linting. They should be manually validated by scaffolding a test project and running lint/build there before releasing.
+
+## Hardened by default
+
+A scaffolder runs with write access to your filesystem and picks your starting dependencies, so how it is built and published matters:
+
+- **Signed provenance** — every release carries a sigstore attestation linking the tarball to the exact commit and CI run that built it. Check the **Provenance** section on the [npm page](https://www.npmjs.com/package/create-bestax#provenance), or run `npm audit signatures`.
+- **npm OIDC trusted publishing** — short-lived, per-run credentials; no long-lived `NPM_TOKEN` exists to be stolen. Release commits and tags are GPG-signed.
+- **Socket.dev scans every PR** for malware, install scripts, obfuscated code, and privilege escalation before it can reach `main`.
+- **Dependencies are a deliberate act** — install scripts are blocked unless individually allow-listed, freshly published versions are refused for 3 days, and CI installs only what the reviewed lockfile resolves.
+- **Every GitHub Action is pinned to a full commit SHA**, so a compromised action release can't roll silently into a build of this CLI.
+- **CodeQL, Dependency Review, and Dependabot** run continuously, alongside a high-severity `pnpm audit` gate.
+- **Layered AI review before merge** — [CodeRabbit](https://coderabbit.ai) plus an independent adversarial Claude review (a different model from the one writing AI-authored changes), on top of required green CI, an approving review, and a human merge.
+
+Full detail: [`SECURITY.md`](https://github.com/allxsmith/bestax/blob/main/SECURITY.md) · [Security guide](https://bestax.io/docs/guides/security)
 
 ## Publishing
 


### PR DESCRIPTION
Closes #403. Also lands the badge half of #404 and the documentation half of #405.

## What

Badges + a **Hardened by default** section in all four READMEs, and four factual corrections to `SECURITY.md`.

| File | Badges added | Section |
| --- | --- | --- |
| `README.md` | Socket, Scorecard, provenance, security policy | `## 🔒 Hardened by default` |
| `bulma-ui/README.md` | same, scoped to `@allxsmith/bestax-bulma` | after `## 📦 NPM Package` |
| `create-bestax/README.md` | same, scoped to `create-bestax` | before `## Publishing` |
| `bestax-migrate/README.md` | **had none** — full block added | before `## License` |

## Why

`bulma-ui/README.md` and `create-bestax/README.md` *are* the npmjs.com package pages — the highest-leverage place to answer "is this dependency safe to add" — and they said nothing about provenance, scanning, or review. Socket.dev in particular was completely invisible: it's configured in the Socket dashboard, so no file in this repo mentioned it.

## SECURITY.md corrections found while auditing

These were wrong before this PR, independent of the new copy:

1. **Socket.dev and CodeQL were undocumented.** Both are dashboard-configured, so a file-only audit couldn't discover either. Added, each noting *why* there's no config file.
2. **Cooldown exceptions understated** — said "One dev-only exception: `prettier`". `pnpm-workspace.yaml:33-38` also excludes `fast-uri`. Reworded to describe the actual policy rather than enumerate a list that drifts.
3. **`bestax-migrate` missing** from the supported-versions table. It's published (1.0.0) and sets `publishConfig.provenance`.
4. **"both published packages"** → three.

## Wording note

The review layer is described as **AI bot reviews** — CodeRabbit plus an independent adversarial Claude review on a deliberately different model — followed by required green CI, an approving review, and a human merge. It does not claim multiple human reviewers.

## Verification

- [x] `prettier --check` passes on all five files
- [x] `pnpm check:conformance` — all 9 checks green
- [x] Package READMEs use **absolute** URLs for `SECURITY.md` and the docs guide, so links work when rendered on npmjs.com rather than resolving against a repo path
- [x] Every claim spot-checked against its source (`ci.yml`, `pnpm-workspace.yaml`, `.coderabbit.yaml`, `dependency-review.yml`, branch protection API)
- [ ] **Socket + Scorecard badge images actually render.** Could not verify from the dev sandbox — Cloudflare 403s automated requests to socket.dev, and npmjs.com blocks them too. The Socket URL format is verified against live public usage in `t3-oss/t3-env` and `ccusage/ccusage`. Please eyeball the rendered README here on GitHub, and the npm pages after the next release. **Fallback** if npm strips Socket-hosted images: swap to a shields.io badge linking to the Socket package page — shields.io is definitively rendered by npm, as the existing badges prove.

## Merge order

**Merge #406 first.** The Scorecard badge 404s until `scorecard.yml` has run on `main` at least once.

## Follow-up not done here

`pnpm-workspace.yaml` still excludes `fast-uri` from the cooldown, past its own stated removal date of 2026-07-22. Pruning it is a dependency-resolution change, not a docs change, so it's deliberately out of scope — worth a small separate PR (related: #391).