### PR TITLE
ci: publish SBOMs per release and verify published provenance

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -19,13 +19,14 @@ permissions:
   contents: read
 
 jobs:
+  # Generation is read-only. It runs `pnpm install` and third-party actions, so
+  # it must never hold a write-scoped token — a compromised dependency or
+  # action would inherit it. The release upload is split into its own job below.
   sbom:
     name: SBOM
     runs-on: ubuntu-latest
     permissions:
-      # Only to attach the SBOM files to an existing release; nothing here
-      # creates or edits code.
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout code
@@ -74,10 +75,26 @@ jobs:
           output-file: bestax-sbom.cdx.json
           upload-release-assets: false
 
-      # Workflow artifacts expire; a release asset is the durable, linkable
-      # copy an auditor can actually cite.
-      - name: Attach SBOMs to the release
-        if: github.event_name == 'release'
+  # Workflow artifacts expire; a release asset is the durable, linkable copy an
+  # auditor can actually cite. Isolated from generation so the write-scoped
+  # token exists only on release runs, in a job that installs nothing and runs
+  # no third-party code beyond the artifact download.
+  attach-sbom:
+    name: Attach SBOMs to the release
+    runs-on: ubuntu-latest
+    needs: sbom
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: bestax-sbom.*
+          merge-multiple: true
+
+      - name: Upload to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
@@ -127,7 +144,13 @@ jobs:
         run: |
           fail=0
           for pkg in @allxsmith/bestax-bulma create-bestax; do
-            predicate=$(npm view "$pkg" dist.attestations.provenance.predicateType 2>/dev/null || true)
+            # --json + a type guard so only a real string counts as present.
+            # Bare `npm view` of a missing field is empty today, but null /
+            # undefined / a non-string would otherwise read as success. Any
+            # failure (network, 404, missing dist-tag) yields empty and fails
+            # closed, which is the right default for a security assertion.
+            predicate=$(npm view "$pkg" dist.attestations.provenance.predicateType --json 2>/dev/null \
+              | jq -r 'select(type=="string")' 2>/dev/null || true)
             if [ -z "$predicate" ]; then
               echo "::error::$pkg has NO provenance attestation on the registry"
               fail=1

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -58,6 +58,10 @@ jobs:
           format: spdx-json
           artifact-name: bestax-sbom.spdx.json
           output-file: bestax-sbom.spdx.json
+          # Defaults to true: the action would upload its own release asset on
+          # a release event, racing the explicit upload below and naming files
+          # by its own convention. Keep one deterministic uploader.
+          upload-release-assets: false
 
       # Both formats on purpose: SPDX is the ISO standard procurement asks for,
       # CycloneDX is what most scanning tools ingest natively.
@@ -68,6 +72,7 @@ jobs:
           format: cyclonedx-json
           artifact-name: bestax-sbom.cdx.json
           output-file: bestax-sbom.cdx.json
+          upload-release-assets: false
 
       # Workflow artifacts expire; a release asset is the durable, linkable
       # copy an auditor can actually cite.

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -144,13 +144,23 @@ jobs:
         run: |
           fail=0
           for pkg in @allxsmith/bestax-bulma create-bestax; do
-            # --json + a type guard so only a real string counts as present.
-            # Bare `npm view` of a missing field is empty today, but null /
-            # undefined / a non-string would otherwise read as success. Any
-            # failure (network, 404, missing dist-tag) yields empty and fails
-            # closed, which is the right default for a security assertion.
-            predicate=$(npm view "$pkg" dist.attestations.provenance.predicateType --json 2>/dev/null \
-              | jq -r 'select(type=="string")' 2>/dev/null || true)
+            # --json + a type guard so only a real string counts as present:
+            # null, undefined, [] and non-strings all collapse to empty. The
+            # array branch covers npm aggregating a bare spec into one element.
+            # Any failure (network, 404, missing dist-tag) also yields empty and
+            # fails closed — the right default for a security assertion.
+            #
+            # Retried because this runs weekly and failing closed means a
+            # registry blip would otherwise report the same red as a genuinely
+            # dropped attestation. A gate that cries wolf gets ignored, so
+            # spend three attempts before believing provenance is really gone.
+            predicate=""
+            for attempt in 1 2 3; do
+              predicate=$(npm view "$pkg" dist.attestations.provenance.predicateType --json 2>/dev/null \
+                | jq -r 'if type=="array" then .[0] else . end | select(type=="string")' 2>/dev/null || true)
+              [ -n "$predicate" ] && break
+              [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
+            done
             if [ -z "$predicate" ]; then
               echo "::error::$pkg has NO provenance attestation on the registry"
               fail=1

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -42,8 +42,12 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
-      # The SBOM must describe the same tree CI builds and publishes from,
-      # so resolve it the same way the release does.
+      # NOTE ON SCOPE: this produces a *repository* SBOM — the full monorepo
+      # dev toolchain (storybook, playwright, docusaurus, jest, turbo…) as
+      # resolved by the lockfile CI builds from. It is deliberately NOT the
+      # published-package dependency closure, which for bestax-bulma is just
+      # Bulma. Useful for auditing what builds our releases; do not read it as
+      # "what a consumer installs". Per-package SBOMs are tracked separately.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -108,3 +112,22 @@ jobs:
         run: |
           cd "$RUNNER_TEMP/verify"
           npm audit signatures
+
+      # `npm audit signatures` only fails on signatures/attestations that are
+      # *invalid*; it stays green when provenance is simply absent. On its own
+      # it would therefore never catch a release that silently lost
+      # `publishConfig.provenance` or had OIDC misconfigured. Assert presence
+      # explicitly so a dropped attestation is a hard failure.
+      - name: Assert our packages actually carry provenance
+        run: |
+          fail=0
+          for pkg in @allxsmith/bestax-bulma create-bestax; do
+            predicate=$(npm view "$pkg" dist.attestations.provenance.predicateType 2>/dev/null || true)
+            if [ -z "$predicate" ]; then
+              echo "::error::$pkg has NO provenance attestation on the registry"
+              fail=1
+            else
+              echo "ok: $pkg -> $predicate"
+            fi
+          done
+          exit "$fail"

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,110 @@
+name: Supply Chain Evidence
+
+# Produces the artifacts enterprise consumers ask for and that the rest of our
+# posture only *claims*: a machine-readable SBOM per release, and an
+# independent check that what we actually published to npm carries valid
+# registry signatures and provenance attestations.
+#
+# Deliberately NOT wired into ci.yml's publish job: nothing here may be able to
+# fail a release. It runs after the release exists, on a schedule, or on demand.
+on:
+  release:
+    types: [published]
+  schedule:
+    # Mondays 08:17 UTC, offset from the Scorecard run.
+    - cron: '17 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      # Only to attach the SBOM files to an existing release; nothing here
+      # creates or edits code.
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      # The SBOM must describe the same tree CI builds and publishes from,
+      # so resolve it the same way the release does.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: bestax-sbom.spdx.json
+          output-file: bestax-sbom.spdx.json
+
+      # Both formats on purpose: SPDX is the ISO standard procurement asks for,
+      # CycloneDX is what most scanning tools ingest natively.
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          artifact-name: bestax-sbom.cdx.json
+          output-file: bestax-sbom.cdx.json
+
+      # Workflow artifacts expire; a release asset is the durable, linkable
+      # copy an auditor can actually cite.
+      - name: Attach SBOMs to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release upload "$TAG" \
+            bestax-sbom.spdx.json \
+            bestax-sbom.cdx.json \
+            --clobber --repo "$GITHUB_REPOSITORY"
+
+  verify-provenance:
+    name: Verify published provenance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+
+      # SECURITY.md tells consumers to run `npm audit signatures`; this closes
+      # the loop by running it ourselves against the real published tarballs
+      # rather than the local workspace. npm (not pnpm) on purpose: the
+      # signature audit needs an npm-resolved tree and lockfile.
+      # bestax-migrate is deliberately absent: its published manifest still
+      # carries an unresolved `workspace:^` specifier, so `npm install` of it
+      # fails outright and would mask real signature failures here. Add it back
+      # once that is fixed.
+      - name: Install published packages into a scratch tree
+        run: |
+          mkdir -p "$RUNNER_TEMP/verify"
+          cd "$RUNNER_TEMP/verify"
+          npm init -y > /dev/null
+          npm install --ignore-scripts \
+            @allxsmith/bestax-bulma create-bestax
+
+      - name: Audit registry signatures and provenance attestations
+        run: |
+          cd "$RUNNER_TEMP/verify"
+          npm audit signatures


### PR DESCRIPTION
Adds `.github/workflows/supply-chain.yml` — two evidence artifacts our posture previously only *claimed*.

## What

**`sbom` job** — Syft generates SPDX **and** CycloneDX SBOMs (SPDX is the ISO standard procurement asks for; CycloneDX is what most scanners ingest natively). Uploaded as workflow artifacts, and on a `release: published` event attached to the GitHub release as durable, citable assets. Workflow artifacts expire; release assets are what an auditor can link to.

**`verify-provenance` job** — installs the real published tarballs from npm into a scratch tree and runs `npm audit signatures`. `SECURITY.md` tells consumers to run this; until now we never ran it ourselves.

## Why it's decoupled from the release

Triggers are `release: published`, weekly schedule, and `workflow_dispatch` — **never** `ci.yml`'s publish job. Nothing in this workflow can fail a release.

## Verified locally, not just written

```
$ npm install --ignore-scripts @allxsmith/bestax-bulma create-bestax
$ npm audit signatures
audited 17 packages in 2s
17 packages have verified registry signatures
4 packages have verified attestations
```

- [x] `prettier --check` passes
- [x] YAML parses; both jobs' permissions confirmed (`contents: write` on `sbom` only, for the release upload; `verify-provenance` inherits read)
- [x] All three actions SHA-pinned with version comments (`anchore/sbom-action` v0.24.0 dereferenced from its annotated tag)
- [ ] SBOM attachment can only be exercised by a real `release: published` event — verify on the next release

## ⚠️ Found while testing this: `bestax-migrate` is broken on npm

`verify-provenance` originally installed all three published packages. It failed — and not because of this workflow:

```
$ npm install bestax-migrate
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

`bestax-migrate@1.0.0`'s published manifest contains `"@allxsmith/bestax-bulma": "workspace:^"` — an unresolved pnpm workspace specifier. **`npm install bestax-migrate` fails for every consumer, on every package manager.** Filed separately; this PR excludes that package from the audit (with a comment) so the check measures signatures rather than that bug. Add it back once fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generates SPDX and CycloneDX SBOMs for published releases and attaches them to the corresponding release assets.
* **Improvements**
  * Strengthened provenance verification by improving how provenance is detected and adding retries with backoff before failing.
  * Ensures the verification run fails if any targeted package lacks required provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->