### PR TITLE
chore(docs): make the LLM flattener indentation-aware before the #402 rollout

### DIFF
--- a/docs/scripts/flatten-llms-corpus.test.mjs
+++ b/docs/scripts/flatten-llms-corpus.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * Run the flattener over the real docs corpus.
+ *
+ * The unit tests use hand-written fixtures, so they only ever cover shapes
+ * someone thought to write down. This walks every page we actually ship and
+ * asserts the invariants that matter for the published artifacts — which means a
+ * future page that nests a component somewhere awkward fails here rather than
+ * silently corrupting llms-full.txt.
+ *
+ * Source-only: no build required, so it runs in the same fast `pnpm test`.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { transform, verifyArtifact } from './flatten-llms-tabs.mjs';
+
+const DOCS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../docs'
+);
+
+async function* walk(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (/\.mdx?$/.test(entry.name)) yield full;
+  }
+}
+
+const pages = [];
+for await (const file of walk(DOCS_DIR)) pages.push(file);
+
+test('the corpus is non-empty (guards a bad DOCS_DIR)', () => {
+  assert.ok(pages.length > 100, `expected >100 pages, found ${pages.length}`);
+});
+
+test('every page survives the flattener cleanly', async () => {
+  const failures = [];
+
+  for (const file of pages) {
+    const src = await readFile(file, 'utf8');
+    const out = transform(src);
+    const rel = path.relative(DOCS_DIR, file);
+
+    for (const problem of verifyArtifact(out)) {
+      failures.push(`${rel}: ${problem}`);
+    }
+
+    // An empty emitted block means a command was swallowed. Anchored to line
+    // starts and to the indentation we emit — a loose regex false-positives on
+    // the inner fence of a ```` block (docs/tutorial-basics/markdown-features).
+    if (/^([ \t]*)```bash\n\1```$/m.test(out)) {
+      failures.push(`${rel}: emitted an empty bash fence`);
+    }
+
+    // Idempotency on real content, not just fixtures.
+    if (transform(out) !== out) {
+      failures.push(`${rel}: transform is not idempotent`);
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});
+
+test('pages with no tab JSX are passed through untouched', async () => {
+  const changed = [];
+
+  for (const file of pages) {
+    const src = await readFile(file, 'utf8');
+    if (/<Tabs|<TabItem|<PackageManagerTabs/.test(src)) continue;
+    if (transform(src) !== src) changed.push(path.relative(DOCS_DIR, file));
+  }
+
+  assert.deepEqual(changed, []);
+});

--- a/docs/scripts/flatten-llms-gate.test.mjs
+++ b/docs/scripts/flatten-llms-gate.test.mjs
@@ -81,6 +81,53 @@ test('the gate fails on a dedented fence body', async () => {
   assert.match(result.stderr, /dedented below its opening fence/);
 });
 
+test('the gate fails on a dedented fence body nested past 3 spaces', async () => {
+  // Two list levels deep, and with a following page whose fence pairs with the
+  // stray column-0 one — the shape that used to reach publication silently,
+  // because a fence opened at 4+ spaces was invisible to the check entirely.
+  const result = await runGate({
+    'llms-full.txt': [
+      '1. Outer step:',
+      '',
+      '   - Inner step:',
+      '',
+      '     ```bash',
+      'pnpm add foo',
+      '```',
+      '',
+      '# Next page',
+      '',
+      '```ts',
+      'const a = 1;',
+      '```',
+      '',
+      '<PackageManagerTabs command="install" />',
+    ].join('\n'),
+  });
+
+  assert.equal(result.ok, false, 'expected the build to fail');
+  assert.match(result.stderr, /dedented below its opening fence/);
+});
+
+test('the gate passes an indented code block that quotes a fence', async () => {
+  // The other side of that widening. At the top level this is indented code, not
+  // a nested fence, so neither its unclosed ``` nor its column-0 neighbours may
+  // be read as damage — otherwise closing the gap above would redden valid pages.
+  const result = await runGate({
+    'docs/guide.md': [
+      'An indented code block showing a fence:',
+      '',
+      '    ```bash',
+      '    pnpm add foo',
+      '',
+      '<PackageManagerTabs command="install" />',
+    ].join('\n'),
+  });
+
+  assert.ok(result.ok, `expected success, got: ${result.stderr}`);
+  assert.match(result.stdout, /rewrote 1 file/);
+});
+
 test('artifacts with no tab JSX are not even read for problems', async () => {
   // The NEEDS_FLATTENING prefilter still applies — an unrelated malformed page
   // must not start failing the docs build.

--- a/docs/scripts/flatten-llms-gate.test.mjs
+++ b/docs/scripts/flatten-llms-gate.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * The build gate, exercised through the CLI rather than through `verifyArtifact`.
+ *
+ * `verifyArtifact` had unit coverage already and still shipped a hole: `main()`
+ * skipped verification whenever `transform()` was a no-op, which silently exempted
+ * the one shape the gate exists to catch (a mid-line tag the line-anchored pattern
+ * deliberately ignores). Testing the pure function could not see that — the wiring
+ * is what was wrong. So these run the real script against a temp directory.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+const SCRIPT = fileURLToPath(
+  new URL('./flatten-llms-tabs.mjs', import.meta.url)
+);
+
+/** Write `files` into a fresh temp build dir and run the script over it. */
+async function runGate(files) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'flatten-gate-'));
+  for (const [name, body] of Object.entries(files)) {
+    const full = path.join(dir, name);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, body);
+  }
+
+  try {
+    const { stdout } = await run(process.execPath, [SCRIPT, dir]);
+    return { ok: true, stdout, dir };
+  } catch (error) {
+    return { ok: false, stderr: error.stderr ?? '', code: error.code, dir };
+  }
+}
+
+test('a clean artifact passes and is rewritten', async () => {
+  const result = await runGate({
+    'llms-full.txt': '# Docs\n\n<PackageManagerTabs command="add foo" />\n',
+  });
+
+  assert.ok(result.ok, `expected success, got: ${result.stderr}`);
+  assert.match(result.stdout, /rewrote 1 file/);
+
+  const out = await readFile(path.join(result.dir, 'llms-full.txt'), 'utf8');
+  assert.match(out, /```bash\npnpm add foo\n```/);
+});
+
+test('the gate fails on a mid-line tag even though the transform is a no-op', async () => {
+  // The regression. transform() leaves this untouched, so the old `after ===
+  // before` early-continue skipped verification entirely and the build passed.
+  const result = await runGate({
+    'llms-full.txt':
+      'Install it with <PackageManagerTabs command="add foo" /> today.\n',
+  });
+
+  assert.equal(result.ok, false, 'expected the build to fail');
+  assert.match(result.stderr, /failed verification/);
+  assert.match(result.stderr, /unflattened tab JSX/);
+  assert.match(result.stderr, /llms-full\.txt/);
+});
+
+test('the gate fails on a dedented fence body', async () => {
+  const result = await runGate({
+    'docs/guide.md': [
+      '1. **Step:**',
+      '',
+      '   ```bash',
+      'pnpm add foo',
+      '```',
+      '',
+      '<PackageManagerTabs command="install" />',
+    ].join('\n'),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.stderr, /dedented below its opening fence/);
+});
+
+test('artifacts with no tab JSX are not even read for problems', async () => {
+  // The NEEDS_FLATTENING prefilter still applies — an unrelated malformed page
+  // must not start failing the docs build.
+  const result = await runGate({
+    'docs/unrelated.md': '# Title\n\n```bash\nnever closed\n',
+  });
+
+  assert.ok(result.ok, `expected success, got: ${result.stderr}`);
+  assert.match(result.stdout, /rewrote 0 file/);
+});
+
+test('non-artifact files are ignored', async () => {
+  const result = await runGate({
+    'robots.txt': '<PackageManagerTabs command="add foo" /> mid line\n',
+    'assets/app.js': 'const x = "<Tabs>";\n',
+  });
+
+  assert.ok(result.ok, `expected success, got: ${result.stderr}`);
+  assert.match(result.stdout, /rewrote 0 file/);
+});

--- a/docs/scripts/flatten-llms-tabs.indent.test.mjs
+++ b/docs/scripts/flatten-llms-tabs.indent.test.mjs
@@ -247,6 +247,88 @@ test('a blank line inside an indented fence is not a dedent', () => {
   assert.deepEqual(verifyArtifact(fine), []);
 });
 
+// --- the gate past the 3-space break -----------------------------------------
+
+test('verifyArtifact catches the corruption shape nested past 3 spaces', () => {
+  // The same damage as above, one list level deeper, and inside a *concatenated*
+  // artifact — which is the case that used to escape entirely. CommonMark reads
+  // an opening fence at 4+ spaces as indented code, so the dedent check could not
+  // see this fence at all; the stray column-0 ``` then paired with the next
+  // page's fence instead, masking the whole region as code. Nothing was reported.
+  const corrupted = [
+    '1. Outer step:',
+    '',
+    '   - Inner step:',
+    '',
+    '     ```bash',
+    'pnpm add foo',
+    '```',
+    '',
+    '# Next page',
+    '',
+    '```ts',
+    'const a = 1;',
+    '```',
+  ].join('\n');
+
+  assert.deepEqual(verifyArtifact(corrupted), [
+    'fenced block dedented below its opening fence',
+  ]);
+});
+
+test('a correctly indented fence past 3 spaces is not flagged', () => {
+  // Also pins the closing fence rule: a closer at 6 spaces has to pair with an
+  // opener at 6 spaces, or this would report an unterminated fence instead.
+  const fine = [
+    '1. Outer step:',
+    '',
+    '   - Inner step:',
+    '',
+    '      ```bash',
+    '      pnpm add foo',
+    '      ```',
+    '',
+    '2. Done.',
+  ].join('\n');
+
+  assert.deepEqual(verifyArtifact(fine), []);
+});
+
+test('an unclosed fence past 3 spaces is not reported as unterminated', () => {
+  // Deliberate: at the top level this is an indented code block that happens to
+  // contain a ``` line, which is valid and harms nothing. The wide view is
+  // trusted with the dedent signal only, so it cannot redden a build over this.
+  const indentedCodeBlock = [
+    'An indented code block showing a fence:',
+    '',
+    '    ```bash',
+    '    pnpm add foo',
+    '',
+    '<PackageManagerTabs command="install" />',
+  ].join('\n');
+
+  assert.deepEqual(verifyArtifact(transform(indentedCodeBlock)), []);
+});
+
+test('a tab-indented fence line is indented code, not a fence', () => {
+  // A tab advances to the next multiple of four, so this sits at column 4 — the
+  // same indented-code reading as four spaces. Measuring it as one column would
+  // open a fence here and report the document as unterminated.
+  assert.deepEqual(verifyArtifact('\t```bash\n\tpnpm add foo\n'), []);
+});
+
+test('the JSX scan keeps the transform view of code, not the wide one', () => {
+  // A tag inside a fence opened at 4 spaces *is* rewritten by transform (that
+  // fence is indented code in the top-level reading), so the residual-JSX scan
+  // has to read the document the same way. Scanning it through the wide view
+  // would mask this region and call a genuine miss clean.
+  const src = ['    ```mdx', '    <Tabs>', '    </Tabs>', '    ```'].join('\n');
+
+  assert.match(transform(src), /^\s*```mdx$/m);
+  assert.doesNotMatch(transform(src), /<Tabs>/);
+  assert.deepEqual(verifyArtifact(transform(src)), []);
+});
+
 // --- generic <Tabs> in a list item -------------------------------------------
 
 test('an indented generic Tabs block keeps its indentation', () => {

--- a/docs/scripts/flatten-llms-tabs.indent.test.mjs
+++ b/docs/scripts/flatten-llms-tabs.indent.test.mjs
@@ -1,0 +1,267 @@
+/**
+ * Indentation and multi-segment coverage for the flattener.
+ *
+ * Split from flatten-llms-tabs.test.mjs because these cover a distinct class of
+ * defect: the flattener replaces JSX *in place*, so every line it emits has to
+ * carry the indentation of the tag it replaced. A component nested in a list
+ * item that emits its fence body at column 0 terminates the list item, turns the
+ * command into prose, and leaves a stray ``` that opens a new block — and since
+ * llms-full.txt is one concatenated document, the damage runs into the next page.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { transform, verifyArtifact } from './flatten-llms-tabs.mjs';
+
+/** Every line of a fenced block the flattener emitted, in order. */
+function fenceLines(out) {
+  return out.split('\n').filter(line => line.trim() !== '');
+}
+
+const indents = [
+  { label: '2 spaces (bulleted list)', indent: '  ' },
+  { label: '3 spaces (numbered list)', indent: '   ' },
+  { label: '6 spaces (nested list)', indent: '      ' },
+];
+
+for (const { label, indent } of indents) {
+  test(`indentation is carried onto every emitted line — ${label}`, () => {
+    const out = transform(`${indent}<PackageManagerTabs command="add foo" />`);
+    const lines = fenceLines(out);
+
+    assert.equal(lines.length, 3, 'fence open, body, fence close');
+    for (const line of lines) {
+      assert.ok(
+        line.startsWith(indent),
+        `expected line to start with ${indent.length} spaces, got ${JSON.stringify(line)}`
+      );
+      assert.ok(
+        !line.startsWith(indent + ' '),
+        `expected exactly ${indent.length} spaces, got ${JSON.stringify(line)}`
+      );
+    }
+    assert.equal(lines[0].trim(), '```bash');
+    assert.equal(lines[1].trim(), 'pnpm add foo');
+    assert.equal(lines[2].trim(), '```');
+  });
+}
+
+test('an indented component keeps the surrounding list intact', () => {
+  const src = [
+    '1. **Create it:**',
+    '',
+    '   <PackageManagerTabs command="add foo" />',
+    '',
+    '2. **Then install:**',
+    '',
+    '   <PackageManagerTabs command="install" />',
+    '',
+  ].join('\n');
+
+  const out = transform(src);
+
+  // Both list markers survive at column 0 and neither command leaks out of its item.
+  assert.match(out, /^1\. \*\*Create it:\*\*$/m);
+  assert.match(out, /^2\. \*\*Then install:\*\*$/m);
+  assert.match(out, /^ {3}```bash\n {3}pnpm add foo\n {3}```$/m);
+  assert.match(out, /^ {3}```bash\n {3}pnpm install\n {3}```$/m);
+  // No fence line may sit at column 0 — that is what ejects the block.
+  assert.doesNotMatch(out, /^```/m);
+});
+
+test('an unindented component is unaffected by indentation handling', () => {
+  const out = transform('<PackageManagerTabs command="add foo" />');
+  assert.equal(out.trim(), '```bash\npnpm add foo\n```');
+});
+
+test('a component mid-line is left alone rather than mangled', () => {
+  // Only a tag that starts its own line can be indented correctly. Anything else
+  // should fail loudly as untouched JSX rather than emit a broken fence inline.
+  const src = 'See <PackageManagerTabs command="add foo" /> above.';
+  assert.equal(transform(src), src);
+});
+
+// --- multi-segment `command` -------------------------------------------------
+
+test('semicolons split a command into one line per segment', () => {
+  const out = transform(
+    '<PackageManagerTabs command="create bestax@latest my-app; cd my-app; install" />'
+  );
+
+  assert.equal(
+    out.trim(),
+    [
+      '```bash',
+      'pnpm create bestax@latest my-app',
+      'cd my-app',
+      'pnpm install',
+      '```',
+    ].join('\n')
+  );
+});
+
+test('segments that are not package-manager verbs pass through verbatim', () => {
+  const out = transform(
+    '<PackageManagerTabs command="# Remove the old dependency; remove node-sass; add sass" />'
+  );
+
+  const lines = fenceLines(out);
+  assert.equal(lines[1], '# Remove the old dependency');
+  assert.equal(lines[2], 'pnpm remove node-sass');
+  assert.equal(lines[3], 'pnpm add sass');
+});
+
+test('a trailing comment survives on a translated segment', () => {
+  const out = transform(
+    '<PackageManagerTabs command="dlx bestax-migrate src/ --dry # preview" />'
+  );
+  assert.match(out, /^pnpm dlx bestax-migrate src\/ --dry # preview$/m);
+});
+
+test('irregular spacing and a trailing semicolon produce no blank lines', () => {
+  const out = transform(
+    '<PackageManagerTabs command="add foo ;   cd app ;  install ; " />'
+  );
+
+  assert.equal(
+    out.trim(),
+    ['```bash', 'pnpm add foo', 'cd app', 'pnpm install', '```'].join('\n')
+  );
+});
+
+test('indentation and multi-segment combine', () => {
+  const src = [
+    '1. **Scaffold:**',
+    '',
+    '   <PackageManagerTabs command="create vite@latest my-app -- --template react; cd my-app; install" />',
+  ].join('\n');
+
+  const out = transform(src);
+
+  assert.match(
+    out,
+    /^ {3}```bash\n {3}pnpm create vite@latest my-app -- --template react\n {3}cd my-app\n {3}pnpm install\n {3}```$/m
+  );
+  assert.doesNotMatch(out, /^```/m);
+});
+
+test('transform stays idempotent when indented and multi-segment', () => {
+  const src = [
+    '1. **Scaffold:**',
+    '',
+    '   <PackageManagerTabs command="create foo my-app; cd my-app; install" />',
+    '',
+    '2. Done.',
+  ].join('\n');
+
+  const once = transform(src);
+  assert.equal(transform(once), once);
+});
+
+test('an indented component flattens with no import line present', () => {
+  // Global MDXComponents registration means pages carry no import at all.
+  const src = [
+    '- Note:',
+    '',
+    '  <PackageManagerTabs command="add foo" />',
+  ].join('\n');
+  const out = transform(src);
+
+  assert.doesNotMatch(out, /<PackageManagerTabs/);
+  assert.match(out, /^ {2}```bash\n {2}pnpm add foo\n {2}```$/m);
+});
+
+// --- the build gate ----------------------------------------------------------
+
+test('verifyArtifact passes clean output', () => {
+  const out = transform('   <PackageManagerTabs command="add foo" />');
+  assert.deepEqual(verifyArtifact(out), []);
+});
+
+test('verifyArtifact catches tab JSX that reached the artifact', () => {
+  // The shape that slips past the line-anchored regex.
+  const problems = verifyArtifact(
+    'See <PackageManagerTabs command="add foo" /> above.'
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /unflattened tab JSX/);
+});
+
+test('verifyArtifact ignores tab JSX inside code, as the flattener does', () => {
+  const src = [
+    '```mdx',
+    '<PackageManagerTabs command="add foo" />',
+    '```',
+  ].join('\n');
+  assert.deepEqual(verifyArtifact(src), []);
+  assert.deepEqual(verifyArtifact('Prose about `<Tabs>` and `<TabItem>`.'), []);
+});
+
+test('verifyArtifact catches an unterminated fence', () => {
+  // What a wrongly-indented emission looks like downstream.
+  const problems = verifyArtifact('```bash\npnpm add foo\n');
+  assert.deepEqual(problems, ['unterminated code fence']);
+});
+
+test('verifyArtifact catches the pre-fix corruption shape', () => {
+  // Exactly what the old flattener produced for an indented component: opening
+  // fence at 3 spaces, body and closer at column 0. Note the fences still *pair*
+  // — CommonMark lets a closer sit at 0-3 spaces regardless of the opening indent
+  // — so parity alone sees nothing wrong. The dedent check is what catches it.
+  const corrupted = [
+    '1. **Create it:**',
+    '',
+    '   ```bash',
+    'pnpm add foo',
+    '```',
+    '',
+    '2. **Then install:**',
+  ].join('\n');
+
+  assert.deepEqual(verifyArtifact(corrupted), [
+    'fenced block dedented below its opening fence',
+  ]);
+});
+
+test('a correctly indented fence is not flagged as dedented', () => {
+  const fine = [
+    '1. **Create it:**',
+    '',
+    '   ```bash',
+    '   pnpm add foo',
+    '   ```',
+    '',
+    '2. **Then install:**',
+  ].join('\n');
+
+  assert.deepEqual(verifyArtifact(fine), []);
+});
+
+test('a blank line inside an indented fence is not a dedent', () => {
+  const fine = [
+    '  ```ts',
+    '  const a = 1;',
+    '',
+    '  const b = 2;',
+    '  ```',
+  ].join('\n');
+  assert.deepEqual(verifyArtifact(fine), []);
+});
+
+// --- generic <Tabs> in a list item -------------------------------------------
+
+test('an indented generic Tabs block keeps its indentation', () => {
+  const src = [
+    '1. Pick one:',
+    '',
+    '   <Tabs>',
+    '   <TabItem label="A">body a</TabItem>',
+    '   <TabItem label="B">body b</TabItem>',
+    '   </Tabs>',
+  ].join('\n');
+
+  const out = transform(src);
+
+  assert.match(out, /^ {3}#### A$/m);
+  assert.match(out, /^ {3}#### B$/m);
+  assert.doesNotMatch(out, /^#### /m);
+});

--- a/docs/scripts/flatten-llms-tabs.mjs
+++ b/docs/scripts/flatten-llms-tabs.mjs
@@ -329,11 +329,16 @@ async function main(buildDir) {
     const before = await readFile(file, 'utf8');
     if (!NEEDS_FLATTENING.test(before)) continue;
     const after = transform(before);
-    if (after === before) continue;
 
+    // Verify whether or not anything changed. A no-op transform is exactly the
+    // case worth checking: a mid-line tag that the line-anchored pattern
+    // deliberately skips leaves the artifact untouched, so gating verification on
+    // `after !== before` would silently exempt the very shape this catches.
     for (const problem of verifyArtifact(after)) {
       failures.push(`${path.relative(buildDir, file)}: ${problem}`);
     }
+
+    if (after === before) continue;
     await writeFile(file, after);
     changed += 1;
   }
@@ -342,8 +347,8 @@ async function main(buildDir) {
     `flatten-llms-tabs: rewrote ${changed} file(s) under ${buildDir}`
   );
 
-  // Fail the build. These artifacts are what agents consume, and both failure
-  // modes are invisible in the rendered site.
+  // Fail the build. These artifacts are what agents consume, and every failure
+  // mode here is invisible in the rendered site.
   if (failures.length) {
     throw new Error(
       `${failures.length} artifact(s) failed verification:\n  ${failures.join('\n  ')}`

--- a/docs/scripts/flatten-llms-tabs.mjs
+++ b/docs/scripts/flatten-llms-tabs.mjs
@@ -18,7 +18,9 @@
  *   1. `<PackageManagerTabs command="add foo" />` — four *equivalent* commands.
  *      Collapse to a single fenced pnpm block. What an agent copies out of
  *      llms.txt has to match what a reader sees on the default tab, and pnpm is
- *      the default tab.
+ *      the default tab — so the pnpm rendering is imported from the component's
+ *      own `translate.mjs` rather than reimplemented here. A `command` may hold
+ *      several `;`-separated lines.
  *
  *   2. `<Tabs>` / `<TabItem label="X">` — *complementary* content (the skills
  *      pages tab between ProfileCard.tsx, _profilecard.scss and Usage). Keep
@@ -31,6 +33,7 @@
 import { readFile, writeFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { renderCommand } from '../src/components/PackageManagerTabs/translate.mjs';
 
 /** Heading level that a flattened `<TabItem label>` is promoted to. */
 const TAB_HEADING = '####';
@@ -39,23 +42,58 @@ const TAB_HEADING = '####';
 const NUL = String.fromCharCode(0);
 
 /**
- * `command` is authored in pnpm's verb vocabulary (`add`, `create`, `dlx`), so
- * this is a passthrough. The npm/yarn/bun translations live in the React
- * component; duplicating them here would be a second source of truth.
+ * Emit a fenced block, indented to match the JSX tag it replaces.
+ *
+ * Every line needs the prefix, not just the opening fence. A component nested in
+ * a list item whose body lands at column 0 terminates the list item: the command
+ * becomes prose and the closing ``` opens a new block instead — and because
+ * llms-full.txt is one concatenated document, that runs on into the next page.
  */
-const toPnpm = command => `pnpm ${command}`.replace(/\s+/g, ' ').trim();
+function fenced(indent, body) {
+  const lines = body.split('\n').map(line => indent + line);
+  return [`${indent}\`\`\`bash`, ...lines, `${indent}\`\`\``].join('\n');
+}
 
 /**
  * Quoted `command` only. A braced template — command={`add foo`} — is not
  * supported on purpose: its backticks are indistinguishable from an inline code
  * span, and code masking has to run first (see `outsideCode`), so the attribute
  * would be masked before this ever saw it. Author the prop as a plain string.
+ *
+ * Anchored to the start of a line so the tag's own indentation can be captured.
+ * A tag sitting mid-sentence therefore doesn't match and survives as raw JSX —
+ * loud and visible, rather than an inline fence that corrupts the document.
+ *
+ * The pnpm rendering comes from the component's own module, so llms.txt and the
+ * default tab cannot drift apart.
  */
 function flattenPackageManagerTabs(src) {
   return src.replace(
-    /<PackageManagerTabs\b[^>]*?\bcommand=(?:"([^"]*)"|'([^']*)')[^>]*?\/>/g,
-    (_match, dq, sq) => '```bash\n' + toPnpm((dq ?? sq).trim()) + '\n```'
+    /(^|\n)([ \t]*)<PackageManagerTabs\b[^>]*?\bcommand=(?:"([^"]*)"|'([^']*)')[^>]*?\/>/g,
+    (_match, lead, indent, dq, sq) =>
+      lead + fenced(indent, renderCommand((dq ?? sq).trim(), 'pnpm'))
   );
+}
+
+/**
+ * Re-anchor a block of text to `indent`: strip the indentation its lines share,
+ * then apply the target. Dedent-then-indent rather than prefixing, so a tab body
+ * that already carries the source indentation doesn't end up doubly indented
+ * (which at 4+ spaces would silently become a markdown code block). Identity
+ * when there is nothing to strip and nothing to add.
+ */
+function reindentBlock(text, indent) {
+  const lines = text.split('\n');
+  const widths = lines
+    .filter(line => line.trim() !== '')
+    .map(line => line.match(/^[ \t]*/)[0].length);
+  const shared = widths.length ? Math.min(...widths) : 0;
+
+  if (shared === 0 && indent === '') return text;
+
+  return lines
+    .map(line => (line.trim() === '' ? '' : indent + line.slice(shared)))
+    .join('\n');
 }
 
 function attrLabel(attrs) {
@@ -69,32 +107,32 @@ function attrLabel(attrs) {
 function flattenGenericTabs(src) {
   // `<Tabs(?=[\s>])`, never `<Tabs\b` — \b matches inside `<Tabs.List>`, which
   // is bestax-bulma's own Tabs component as documented in docs/api/components.
-  return src.replace(/<Tabs(?=[\s>])[^>]*>([\s\S]*?)<\/Tabs>/g, (_m, inner) => {
-    const items = [
-      ...inner.matchAll(/<TabItem\b([^>]*)>([\s\S]*?)<\/TabItem>/g),
-    ];
-    if (items.length === 0) return inner.trim();
-    return items
-      .map(([, attrs, body]) => {
-        const label = attrLabel(attrs);
-        const text = body.trim();
-        return label ? `${TAB_HEADING} ${label}\n\n${text}` : text;
-      })
-      .join('\n\n');
-  });
+  // Indentation is captured for the same reason as flattenPackageManagerTabs:
+  // a `####` heading emitted at column 0 breaks out of an enclosing list item.
+  return src.replace(
+    /(^|\n)([ \t]*)<Tabs(?=[\s>])[^>]*>([\s\S]*?)<\/Tabs>/g,
+    (_m, lead, indent, inner) => {
+      const items = [
+        ...inner.matchAll(/<TabItem\b([^>]*)>([\s\S]*?)<\/TabItem>/g),
+      ];
+      const reindent = text => reindentBlock(text, indent);
+
+      if (items.length === 0) return lead + reindent(inner.trim());
+
+      return (
+        lead +
+        items
+          .map(([, attrs, body]) => {
+            const label = attrLabel(attrs);
+            const text = reindent(body.trim());
+            return label ? `${indent}${TAB_HEADING} ${label}\n\n${text}` : text;
+          })
+          .join('\n\n')
+      );
+    }
+  );
 }
 
-/**
- * Apply `fn` only outside code — fenced blocks *and* inline spans.
- *
- * Both exclusions are load-bearing: `docs/api/components/tabs.md` documents
- * bestax-bulma's own `<Tabs.List>` / `<Tabs.Item>` inside tsx fences, and the
- * migration guides mention the Tabs component inline in prose. Neither is a
- * Docusaurus theme tab and neither may be rewritten.
- *
- * Mask rather than split: a `<Tabs>` block *wraps* fenced code, so the document
- * has to stay contiguous for `<Tabs>…</Tabs>` to match across it.
- */
 /**
  * Mask fenced code blocks, per CommonMark rather than by regex.
  *
@@ -103,7 +141,7 @@ function flattenGenericTabs(src) {
  * `docs/api/helpers/theme.md` and `docs/tutorial-basics/markdown-features.mdx`
  * both wrap ``` examples in ```` fences, so mis-pairing is not hypothetical.
  */
-function maskFences(src, hold) {
+function maskFences(src, hold, report) {
   const out = [];
   let open = null;
   let buf = [];
@@ -116,7 +154,11 @@ function maskFences(src, hold) {
       const validOpen =
         fence && !(fence[1][0] === '`' && fence[2].includes('`'));
       if (validOpen) {
-        open = { char: fence[1][0], len: fence[1].length };
+        open = {
+          char: fence[1][0],
+          len: fence[1].length,
+          indent: line.match(/^[ \t]*/)[0].length,
+        };
         buf = [line];
       } else {
         out.push(line);
@@ -127,6 +169,22 @@ function maskFences(src, hold) {
     buf.push(line);
     const close = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
     if (close && close[1][0] === open.char && close[1].length >= open.len) {
+      // A fence opened inside a list item whose body or closer is *less*
+      // indented than the opening fence. CommonMark still pairs the two (a
+      // closer may sit at 0-3 spaces regardless), so parity looks fine — but the
+      // under-indented lines have terminated the list item, ejecting the command
+      // into prose and swallowing whatever followed. This is the exact signature
+      // of a rewrite that forgot to carry the tag's indentation.
+      if (report && open.indent > 0) {
+        const dedented = buf
+          .slice(1)
+          .some(
+            body =>
+              body.trim() !== '' &&
+              body.match(/^[ \t]*/)[0].length < open.indent
+          );
+        if (dedented) report.dedentedFenceBody = true;
+      }
       out.push(hold(buf.join('\n')));
       open = null;
       buf = [];
@@ -134,8 +192,13 @@ function maskFences(src, hold) {
   }
 
   // An unterminated fence runs to end of document (CommonMark). Mask it: never
-  // mutate content we can't confidently parse.
-  if (open) out.push(hold(buf.join('\n')));
+  // mutate content we can't confidently parse. Callers that are verifying rather
+  // than transforming want to know, because in a generated artifact it means an
+  // earlier rewrite emitted a fence line at the wrong indentation.
+  if (open) {
+    if (report) report.unterminatedFence = true;
+    out.push(hold(buf.join('\n')));
+  }
 
   return out.join('\n');
 }
@@ -155,14 +218,14 @@ function maskFences(src, hold) {
  * an unpaired backtick in prose would then swallow the rest of the document —
  * the failure mode of guessing wrong here is much worse than the miss.
  */
-function outsideCode(src, fn) {
+function outsideCode(src, fn, report) {
   const held = [];
   const hold = chunk => {
     held.push(chunk);
     return NUL + (held.length - 1) + NUL;
   };
 
-  const masked = maskFences(src, hold).replace(
+  const masked = maskFences(src, hold, report).replace(
     /(`+)(?:(?!\1)[^\n])*?\1/g,
     hold
   );
@@ -194,6 +257,54 @@ export function transform(src) {
 export const NEEDS_FLATTENING =
   /<Tabs|<TabItem|<PackageManagerTabs|^[ \t]*import\s+(?:Tabs|TabItem|PackageManagerTabs)\b/m;
 
+/**
+ * Problems that mean a rewritten artifact is not fit to publish.
+ *
+ * Both failure modes here are silent by nature — the HTML site builds fine and
+ * only the machine-readable artifacts are wrong — so `main` turns them into a
+ * build failure rather than trusting review to spot them.
+ *
+ * - Surviving tab JSX outside code means a tag shape this script doesn't handle
+ *   (a mid-line component, an unquoted prop) reached the artifact verbatim.
+ * - A fence whose body is dedented below its opening fence is the signature of a
+ *   rewrite that dropped the tag's indentation: CommonMark still pairs the
+ *   fences, so nothing looks wrong, but the under-indented lines have terminated
+ *   the enclosing list item and swallowed what followed.
+ * - An unterminated fence corrupts everything after it in a concatenated
+ *   artifact.
+ */
+export function verifyArtifact(src) {
+  const problems = [];
+  const report = {};
+  const residual = new Set();
+
+  outsideCode(
+    src,
+    chunk => {
+      for (const [tag] of chunk.matchAll(
+        /<PackageManagerTabs\b|<Tabs(?=[\s>])|<TabItem\b/g
+      )) {
+        residual.add(tag);
+      }
+      return chunk;
+    },
+    report
+  );
+
+  if (residual.size) {
+    problems.push(
+      `unflattened tab JSX outside code: ${[...residual].join(', ')}`
+    );
+  }
+  if (report.dedentedFenceBody) {
+    problems.push('fenced block dedented below its opening fence');
+  }
+  if (report.unterminatedFence) {
+    problems.push('unterminated code fence');
+  }
+  return problems;
+}
+
 /** True when a file is one of the artifacts this script owns. */
 export function isLlmArtifact(file) {
   const base = path.basename(file);
@@ -211,18 +322,33 @@ async function* walk(dir) {
 
 async function main(buildDir) {
   let changed = 0;
+  const failures = [];
+
   for await (const file of walk(buildDir)) {
     if (!isLlmArtifact(file)) continue;
     const before = await readFile(file, 'utf8');
     if (!NEEDS_FLATTENING.test(before)) continue;
     const after = transform(before);
     if (after === before) continue;
+
+    for (const problem of verifyArtifact(after)) {
+      failures.push(`${path.relative(buildDir, file)}: ${problem}`);
+    }
     await writeFile(file, after);
     changed += 1;
   }
+
   console.log(
     `flatten-llms-tabs: rewrote ${changed} file(s) under ${buildDir}`
   );
+
+  // Fail the build. These artifacts are what agents consume, and both failure
+  // modes are invisible in the rendered site.
+  if (failures.length) {
+    throw new Error(
+      `${failures.length} artifact(s) failed verification:\n  ${failures.join('\n  ')}`
+    );
+  }
 }
 
 const invokedDirectly =

--- a/docs/scripts/flatten-llms-tabs.mjs
+++ b/docs/scripts/flatten-llms-tabs.mjs
@@ -133,6 +133,55 @@ function flattenGenericTabs(src) {
   );
 }
 
+/** A fence line at any indentation; how far in it may sit is decided per mode. */
+const FENCE = /^[ \t]*(`{3,}|~{3,})(.*)$/;
+
+/**
+ * Column width of a prefix, with a tab advancing to the next multiple of four as
+ * CommonMark expands it. Counting a tab as one character would read a
+ * tab-indented fence as sitting at column 1 — a fence — when it is four columns
+ * in and therefore indented code.
+ */
+function widthOf(prefix) {
+  let columns = 0;
+  for (const char of prefix) columns += char === '\t' ? 4 - (columns % 4) : 1;
+  return columns;
+}
+
+/** Indentation of a line, in columns. */
+const indentOf = line => widthOf(line.match(/^[ \t]*/)[0]);
+
+/**
+ * Track the content column of the innermost open list item; 0 at the top level.
+ *
+ * CommonMark's "an opening fence may be indented 0-3 spaces" is relative to the
+ * *enclosing container*, not to the document, so a fence nested two list levels
+ * deep legitimately opens at 4+ spaces. Without the container column there is no
+ * way to tell that fence from a top-level indented code block that happens to
+ * contain a ``` line — and the two want opposite treatment.
+ *
+ * Deliberately a small approximation of block parsing, not an implementation of
+ * it: enough for that one distinction, which is all the caller asks of it. Lazy
+ * continuation lines and non-list containers (blockquotes) are not modelled, and
+ * only `verifyArtifact`'s structural pass consults it.
+ */
+function listColumnTracker() {
+  const columns = [];
+
+  return line => {
+    // A blank line does not end a list item — indented content may follow it.
+    if (line.trim() === '') return columns.at(-1) ?? 0;
+
+    const indent = indentOf(line);
+    while (columns.length && indent < columns.at(-1)) columns.pop();
+
+    const marker = line.match(/^[ \t]*(?:[-*+]|\d{1,9}[.)])[ \t]+(?=\S)/);
+    if (marker) columns.push(widthOf(marker[0]));
+
+    return columns.at(-1) ?? 0;
+  };
+}
+
 /**
  * Mask fenced code blocks, per CommonMark rather than by regex.
  *
@@ -140,24 +189,37 @@ function flattenGenericTabs(src) {
  * and the closing fence only has to be *at least* as long as the opening one.
  * `docs/api/helpers/theme.md` and `docs/tutorial-basics/markdown-features.mdx`
  * both wrap ``` examples in ```` fences, so mis-pairing is not hypothetical.
+ *
+ * `listAware` widens which lines can open a fence, from "0-3 spaces" to "0-3
+ * spaces past the enclosing list item's content column". Off (the default) is
+ * the reading that decides what `transform` may rewrite, and is exactly the
+ * top-level CommonMark rule; on, it lets the dedent signal below see a fence
+ * nested past the 3-space break at all. See `verifyArtifact`.
  */
-function maskFences(src, hold, report) {
+function maskFences(src, hold, report, { listAware = false } = {}) {
   const out = [];
+  const listColumn = listColumnTracker();
   let open = null;
   let buf = [];
 
   for (const line of src.split('\n')) {
-    const fence = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
-
     if (!open) {
+      // Container column of *this* line, so the fence is judged in its own
+      // context. Fed only outside fences: a `1.` inside a code sample is not a
+      // list item, and letting one in would move the column under the fence.
+      const column = listAware ? listColumn(line) : 0;
+      const fence = line.match(FENCE);
       // A backtick fence's info string may not itself contain a backtick.
       const validOpen =
-        fence && !(fence[1][0] === '`' && fence[2].includes('`'));
+        fence &&
+        indentOf(line) <= column + 3 &&
+        !(fence[1][0] === '`' && fence[2].includes('`'));
       if (validOpen) {
         open = {
           char: fence[1][0],
           len: fence[1].length,
-          indent: line.match(/^[ \t]*/)[0].length,
+          indent: indentOf(line),
+          column,
         };
         buf = [line];
       } else {
@@ -167,22 +229,27 @@ function maskFences(src, hold, report) {
     }
 
     buf.push(line);
-    const close = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
-    if (close && close[1][0] === open.char && close[1].length >= open.len) {
+    // A closing fence may be indented up to three spaces past its container —
+    // the same allowance the opener got, which is why it is measured against
+    // `open.column` and not against `open.indent`. So a closer may legally sit
+    // *below* the opening fence, and does in the corruption shape below.
+    const close = line.match(/^[ \t]*(`{3,}|~{3,})[ \t]*$/);
+    if (
+      close &&
+      close[1][0] === open.char &&
+      close[1].length >= open.len &&
+      indentOf(line) <= open.column + 3
+    ) {
       // A fence opened inside a list item whose body or closer is *less*
-      // indented than the opening fence. CommonMark still pairs the two (a
-      // closer may sit at 0-3 spaces regardless), so parity looks fine — but the
+      // indented than the opening fence. CommonMark still pairs the two (the
+      // closer gets its own allowance, as above), so parity looks fine — but the
       // under-indented lines have terminated the list item, ejecting the command
       // into prose and swallowing whatever followed. This is the exact signature
       // of a rewrite that forgot to carry the tag's indentation.
       if (report && open.indent > 0) {
         const dedented = buf
           .slice(1)
-          .some(
-            body =>
-              body.trim() !== '' &&
-              body.match(/^[ \t]*/)[0].length < open.indent
-          );
+          .some(body => body.trim() !== '' && indentOf(body) < open.indent);
         if (dedented) report.dedentedFenceBody = true;
       }
       out.push(hold(buf.join('\n')));
@@ -272,10 +339,29 @@ export const NEEDS_FLATTENING =
  *   the enclosing list item and swallowed what followed.
  * - An unterminated fence corrupts everything after it in a concatenated
  *   artifact.
+ *
+ * Two passes, because the two questions want different views of what code is:
+ *
+ *   1. *Did the flattener miss a tag?* Scanned through the same view `transform`
+ *      uses. A wider one here would mask a region the flattener does rewrite,
+ *      and so would call a genuine miss clean.
+ *   2. *Is a fence structurally broken?* Scanned again with `listAware`, because
+ *      the plain top-level reading cannot see a fence opened past the 3-space
+ *      break: `open.indent` was only ever 1-3, so a corrupted emission nested
+ *      deeper than one list level fell through to the unterminated-fence signal
+ *      — and in `llms-full.txt` not even reliably, since a later page's fence can
+ *      pair with the stray one and mask the whole region as code.
+ *
+ * Only the dedent signal is taken from the second pass; the first stays the
+ * authority on unterminated fences. `listAware` reaches past where a top-level
+ * reading would stop, so an *unclosed* deep fence there is often just an indented
+ * code block quoting a fence — valid, and not something to redden a build over.
+ * The dedent signal carries no such risk: it only fires once a pair was found.
  */
 export function verifyArtifact(src) {
   const problems = [];
   const report = {};
+  const deep = {};
   const residual = new Set();
 
   outsideCode(
@@ -291,12 +377,14 @@ export function verifyArtifact(src) {
     report
   );
 
+  maskFences(src, chunk => chunk, deep, { listAware: true });
+
   if (residual.size) {
     problems.push(
       `unflattened tab JSX outside code: ${[...residual].join(', ')}`
     );
   }
-  if (report.dedentedFenceBody) {
+  if (report.dedentedFenceBody || deep.dedentedFenceBody) {
     problems.push('fenced block dedented below its opening fence');
   }
   if (report.unterminatedFence) {

--- a/docs/scripts/package-manager-translate.test.mjs
+++ b/docs/scripts/package-manager-translate.test.mjs
@@ -101,6 +101,20 @@ test('an unknown first token passes through identically for all managers', () =>
   }
 });
 
+test('passthrough segments are normalized, not byte-preserved', () => {
+  // The guarantee is "the same on every tab", not "identical to the source" —
+  // splitSegments collapses whitespace so authors can pad around the separators.
+  const authored = '#   Remove    the  old  dep; remove node-sass';
+  const rendered = PACKAGE_MANAGERS.map(pm => renderCommand(authored, pm));
+
+  for (const out of rendered) {
+    assert.match(out, /^# Remove the old dep$/m);
+  }
+  // Same passthrough line on all four tabs.
+  const firstLines = rendered.map(out => out.split('\n')[0]);
+  assert.equal(new Set(firstLines).size, 1);
+});
+
 test('a trailing comment rides along untouched', () => {
   assert.equal(
     translateSegment('dlx bestax-migrate src/ --dry # preview', 'npm'),

--- a/docs/scripts/package-manager-translate.test.mjs
+++ b/docs/scripts/package-manager-translate.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * The pnpm → npm/yarn/bun translation table.
+ *
+ * Lives in docs/scripts/ rather than beside the module because `docs` has no
+ * jest config — `node --test "scripts/*.test.mjs"` is the only place a unit test
+ * in this package actually runs in CI.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PACKAGE_MANAGERS,
+  splitSegments,
+  translateSegment,
+  renderCommand,
+  lintCommand,
+} from '../src/components/PackageManagerTabs/translate.mjs';
+import { transform } from './flatten-llms-tabs.mjs';
+
+test('pnpm is first, so it is the default tab', () => {
+  assert.deepEqual(PACKAGE_MANAGERS, ['pnpm', 'npm', 'yarn', 'bun']);
+});
+
+// [authored, pnpm, npm, yarn, bun]
+const TABLE = [
+  [
+    'add @allxsmith/bestax-bulma',
+    'pnpm add @allxsmith/bestax-bulma',
+    'npm install @allxsmith/bestax-bulma',
+    'yarn add @allxsmith/bestax-bulma',
+    'bun add @allxsmith/bestax-bulma',
+  ],
+  [
+    'add -D typescript @types/react',
+    'pnpm add -D typescript @types/react',
+    'npm install -D typescript @types/react',
+    'yarn add -D typescript @types/react',
+    'bun add -d typescript @types/react',
+  ],
+  ['install', 'pnpm install', 'npm install', 'yarn', 'bun install'],
+  [
+    'install --frozen-lockfile',
+    'pnpm install --frozen-lockfile',
+    'npm install --frozen-lockfile',
+    'yarn install --frozen-lockfile',
+    'bun install --frozen-lockfile',
+  ],
+  [
+    'remove node-sass',
+    'pnpm remove node-sass',
+    'npm uninstall node-sass',
+    'yarn remove node-sass',
+    'bun remove node-sass',
+  ],
+  [
+    'create bestax@latest my-app',
+    'pnpm create bestax@latest my-app',
+    'npm create bestax@latest my-app',
+    'yarn create bestax@latest my-app',
+    'bun create bestax@latest my-app',
+  ],
+  [
+    // The `--` quirk: npm needs it to pass flags through, yarn and bun would
+    // forward it to the scaffolder.
+    'create vite@latest my-app -- --template react',
+    'pnpm create vite@latest my-app -- --template react',
+    'npm create vite@latest my-app -- --template react',
+    'yarn create vite@latest my-app --template react',
+    'bun create vite@latest my-app --template react',
+  ],
+  ['run dev', 'pnpm run dev', 'npm run dev', 'yarn dev', 'bun run dev'],
+  [
+    'dlx bestax-migrate src/',
+    'pnpm dlx bestax-migrate src/',
+    'npx bestax-migrate src/',
+    'yarn dlx bestax-migrate src/',
+    'bunx bestax-migrate src/',
+  ],
+];
+
+for (const [authored, ...expected] of TABLE) {
+  test(`translates "${authored}"`, () => {
+    PACKAGE_MANAGERS.forEach((manager, i) => {
+      assert.equal(
+        translateSegment(authored, manager),
+        expected[i],
+        `${manager} rendering of "${authored}"`
+      );
+    });
+  });
+}
+
+test('an unknown first token passes through identically for all managers', () => {
+  for (const segment of [
+    'cd my-app',
+    '# Install the peer dep',
+    'corepack enable',
+  ]) {
+    for (const manager of PACKAGE_MANAGERS) {
+      assert.equal(translateSegment(segment, manager), segment);
+    }
+  }
+});
+
+test('a trailing comment rides along untouched', () => {
+  assert.equal(
+    translateSegment('dlx bestax-migrate src/ --dry # preview', 'npm'),
+    'npx bestax-migrate src/ --dry # preview'
+  );
+});
+
+test('splitSegments trims, collapses whitespace and drops empties', () => {
+  assert.deepEqual(splitSegments('add  foo ;  cd app ; ; install ; '), [
+    'add foo',
+    'cd app',
+    'install',
+  ]);
+});
+
+test('renderCommand joins segments one per line', () => {
+  assert.equal(
+    renderCommand('create bestax@latest my-app; cd my-app; install', 'yarn'),
+    ['yarn create bestax@latest my-app', 'cd my-app', 'yarn'].join('\n')
+  );
+});
+
+test('the pnpm rendering is always a pure prefix', () => {
+  // This identity is why commands are authored in pnpm vocabulary.
+  for (const [authored] of TABLE) {
+    assert.equal(renderCommand(authored, 'pnpm'), `pnpm ${authored}`);
+  }
+});
+
+test('the flattener emits exactly the pnpm tab', () => {
+  // The single assertion that mechanically keeps llms.txt and the default tab in
+  // sync. If these ever diverge, agents copy a command no reader is shown.
+  for (const [authored] of TABLE) {
+    const out = transform(`<PackageManagerTabs command="${authored}" />`);
+    const body = out.trim().split('\n').slice(1, -1).join('\n');
+    assert.equal(body, renderCommand(authored, 'pnpm'));
+  }
+});
+
+test('the flattener emits the pnpm tab for multi-segment commands too', () => {
+  const authored =
+    'create vite@latest my-app -- --template react; cd my-app; install';
+  const out = transform(`<PackageManagerTabs command="${authored}" />`);
+  const body = out.trim().split('\n').slice(1, -1).join('\n');
+  assert.equal(body, renderCommand(authored, 'pnpm'));
+});
+
+test('lintCommand flags a command that already names a package manager', () => {
+  assert.deepEqual(lintCommand('add foo'), []);
+  assert.equal(lintCommand('pnpm add foo').length, 1);
+  assert.equal(lintCommand('npx skills add x').length, 1);
+  assert.equal(lintCommand('add foo; yarn add bar').length, 1);
+});
+
+test('an unknown manager is a programming error, not silent output', () => {
+  assert.throws(
+    () => translateSegment('add foo', 'cnpm'),
+    /Unknown package manager/
+  );
+});

--- a/docs/src/components/PackageManagerTabs/translate.mjs
+++ b/docs/src/components/PackageManagerTabs/translate.mjs
@@ -1,0 +1,129 @@
+/**
+ * The package-manager vocabulary, in one place.
+ *
+ * Docs commands are authored in **pnpm's** verb vocabulary — `add`, `add -D`,
+ * `install`, `remove`, `create`, `dlx`, `run` — and this module derives the npm,
+ * yarn and bun equivalents. Authoring in pnpm terms (rather than npm's) is what
+ * lets the pnpm rendering be a pure prefix: `renderCommand(cmd, 'pnpm')` is
+ * always `pnpm ${cmd}`.
+ *
+ * That identity is load-bearing. `docs/scripts/flatten-llms-tabs.mjs` collapses
+ * `<PackageManagerTabs>` to a single pnpm block in the published LLM artifacts,
+ * and it imports this module rather than reimplementing the rule — so what an
+ * agent copies out of llms.txt is byte-identical to what a reader sees on the
+ * default tab.
+ *
+ * `.mjs`, not `.js`: `docs/package.json` has no `"type": "module"`, so node
+ * would load a `.js` file as CommonJS and `node --test` could not import it.
+ * Webpack resolves the explicit extension natively.
+ *
+ * A `command` may hold several lines separated by `;`. A segment whose first
+ * token is a known verb gets translated; anything else (`cd my-app`, a `#`
+ * comment) is emitted byte-identically in all four tabs.
+ */
+
+/** Tab order. pnpm is first, and therefore the default. */
+export const PACKAGE_MANAGERS = ['pnpm', 'npm', 'yarn', 'bun'];
+
+/** Verbs we know how to translate. Anything else is a passthrough line. */
+const VERBS = new Set(['add', 'install', 'remove', 'create', 'dlx', 'run']);
+
+/**
+ * Split a `command` into one segment per rendered line. Blank segments are
+ * dropped so a trailing `;` or padded separators can't emit an empty line.
+ */
+export function splitSegments(command) {
+  return String(command)
+    .split(';')
+    .map(segment => segment.trim().replace(/\s+/g, ' '))
+    .filter(Boolean);
+}
+
+/**
+ * Translate one segment for one package manager.
+ *
+ * Three rules go beyond swapping the prefix:
+ * - `dlx` is a whole-prefix replacement (`npx`, `bunx`), not a verb swap.
+ * - bun spells the dev-dependency flag `-d`, not `-D`.
+ * - npm needs `--` to pass flags through a `create` scaffolder; yarn and bun
+ *   forward arguments directly and would hand the `--` to the scaffolder.
+ */
+export function translateSegment(segment, manager) {
+  const tokens = segment.split(' ');
+  const [verb, ...rest] = tokens;
+
+  if (!VERBS.has(verb)) return segment;
+  if (manager === 'pnpm') return `pnpm ${segment}`;
+
+  const join = parts => parts.filter(Boolean).join(' ');
+  const withoutDoubleDash = () => rest.filter(token => token !== '--');
+  const bunFlags = () => rest.map(token => (token === '-D' ? '-d' : token));
+
+  switch (manager) {
+    case 'npm':
+      switch (verb) {
+        case 'add':
+          return join(['npm', 'install', ...rest]);
+        case 'remove':
+          return join(['npm', 'uninstall', ...rest]);
+        case 'dlx':
+          return join(['npx', ...rest]);
+        default:
+          // install / create / run keep npm's own verb, and `create` keeps `--`.
+          return join(['npm', verb, ...rest]);
+      }
+    case 'yarn':
+      switch (verb) {
+        case 'install':
+          // Bare `yarn` is the idiomatic install; with flags it needs the verb.
+          return rest.length ? join(['yarn', 'install', ...rest]) : 'yarn';
+        case 'create':
+          return join(['yarn', 'create', ...withoutDoubleDash()]);
+        case 'run':
+          // `yarn dev`, not `yarn run dev`.
+          return join(['yarn', ...rest]);
+        case 'dlx':
+          // Yarn Berry. Yarn Classic has no `dlx`.
+          return join(['yarn', 'dlx', ...rest]);
+        default:
+          return join(['yarn', verb, ...rest]);
+      }
+    case 'bun':
+      switch (verb) {
+        case 'add':
+          return join(['bun', 'add', ...bunFlags()]);
+        case 'create':
+          return join(['bun', 'create', ...withoutDoubleDash()]);
+        case 'dlx':
+          return join(['bunx', ...rest]);
+        default:
+          return join(['bun', verb, ...rest]);
+      }
+    default:
+      throw new Error(`Unknown package manager: ${manager}`);
+  }
+}
+
+/** Render a whole `command` — every segment, one per line — for one manager. */
+export function renderCommand(command, manager) {
+  return splitSegments(command)
+    .map(segment => translateSegment(segment, manager))
+    .join('\n');
+}
+
+/**
+ * Authoring mistakes that render identically on all four tabs, and so would
+ * otherwise ship unnoticed. Surfaced as a dev-only warning by the component.
+ */
+export function lintCommand(command) {
+  const warnings = [];
+  for (const segment of splitSegments(command)) {
+    const verb = segment.split(' ')[0];
+    if (PACKAGE_MANAGERS.includes(verb) || verb === 'npx' || verb === 'bunx') {
+      warnings.push(
+        `"${segment}" already names a package manager — author the pnpm verb alone, e.g. "add foo" not "pnpm add foo".`
+      );
+    }
+  }
+  return warnings;
+}

--- a/docs/src/components/PackageManagerTabs/translate.mjs
+++ b/docs/src/components/PackageManagerTabs/translate.mjs
@@ -19,7 +19,12 @@
  *
  * A `command` may hold several lines separated by `;`. A segment whose first
  * token is a known verb gets translated; anything else (`cd my-app`, a `#`
- * comment) is emitted byte-identically in all four tabs.
+ * comment) is a passthrough — emitted identically across all four tabs.
+ *
+ * Every segment is whitespace-normalized first (trimmed, runs of spaces
+ * collapsed), so authoring can pad around the `;` separators freely. Passthrough
+ * means "the same on every tab", not "byte-identical to the source" — don't rely
+ * on internal alignment surviving.
  */
 
 /** Tab order. pnpm is first, and therefore the default. */


### PR DESCRIPTION
First PR of #402. No docs pages change here — this fixes a latent defect in the flattener that #408 shipped, which would have corrupted the LLM artifacts the moment a `<PackageManagerTabs>` landed inside a numbered step.

## The bug

The flattener replaces JSX in place, but only the *opening* fence inherited the tag's indentation. Running the merged `transform()` on a nested component:

```
1. **Create it:**

   <PackageManagerTabs command="add foo" />
```

produced:

```
1. **Create it:**

   ```bash
pnpm add foo
```
```

Opening fence at 3 spaces, body and closer at column 0. Per CommonMark the under-indented lines terminate the list item: the command becomes prose, and the following step gets swallowed into the block that the stray ``` opens. `transform()` reports the corrupted output as idempotent, so nothing self-heals, and re-running masks the damage as code.

**20 of #402's target sites are nested** — 18 in `react-setups.md` at 3 spaces, `migration/bulma-ui-3-to-4.md:40` at 2 — and because `llms-full.txt` is one concatenated document, `bulma-ui-3-to-4.md` (the only fence on its page) would have bled into the next page. Nothing in CI would have caught it: the HTML site builds perfectly and only the machine-readable artifacts are wrong.

## The fix

Both `flattenPackageManagerTabs` and `flattenGenericTabs` now capture the tag's indentation and carry it onto every emitted line. Two consequences worth reviewing:

- The pattern is **anchored to the start of a line**, since only a tag that starts its own line has an indentation to inherit. A component mid-sentence therefore no longer matches and survives as visible JSX — a loud failure instead of an inline fence that corrupts the document. The build gate below catches it.
- `flattenGenericTabs` **dedents then re-indents** the tab body rather than prefixing it, so a body that already carries the source indentation doesn't end up doubly indented — at 4+ spaces that would silently become a markdown code block.

## Shared translation module

Adds `docs/src/components/PackageManagerTabs/translate.mjs` — the pnpm → npm/yarn/bun vocabulary, which the component in the next PR will consume. The flattener now imports `renderCommand` from it instead of its own `toPnpm`, so the "duplicating them here would be a second source of truth" claim in its header comment is mechanically true rather than aspirational. A test asserts the flattened body equals `renderCommand(cmd, 'pnpm')` for every row of the table — the single assertion keeping llms.txt and the default tab from drifting.

`.mjs` because `docs/package.json` has no `"type": "module"`, so node would load a `.js` as CommonJS and `node --test` couldn't import it.

A `command` may now hold several `;`-separated lines. Segments whose first token is a known verb get translated; anything else (`cd my-app`, a `#` comment) passes through byte-identically. That's what the Quick Start scaffold sequences need.

## Build gate

`main()` now throws if a rewritten artifact still contains tab JSX outside code, has an unterminated fence, or has **a fenced block dedented below its opening fence**.

That third check is the one that catches the bug above, and it's worth explaining why the obvious check doesn't: I first wrote this as a fence-parity assertion and the test failed. CommonMark lets a closing fence sit at 0–3 spaces *regardless* of the opening indent, so the corrupted output pairs its fences happily and parity sees nothing wrong. The damage is structural, not lexical. Comparing body indentation against the opening fence is what actually detects it.

## Verification

- **The LLM artifacts are byte-identical to a pre-change baseline build.** `diff -r` over `*.md` twins and `llms*.txt` is empty, so this closes the latent defect without moving any published output.
- Coverage 21 → **64 tests**. The new ones were written failing first against the merged code: 11 failed before the fix.
- Includes a **corpus test** that runs every shipped page through `transform()` and asserts no surviving tab JSX, no dedented or unterminated fence, no empty emitted block, and idempotency — so a future nested usage fails in `pnpm test` rather than silently in `llms-full.txt`.
- Gates: `check:conformance` 7/7, `gen:catalog:check` clean, prettier clean, full docs build green with the new verifier active.

One incidental cleanup: removed a duplicated `outsideCode` doc comment that #408 left sitting above `maskFences`.

## Not in scope

The component, the global `MDXComponents` registration, the homepage, and any docs page conversion — those follow in the next PRs of #402.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation now renders package-manager commands consistently for pnpm, npm, Yarn, and Bun.
  * Multi-step commands are displayed clearly across separate lines.
  * Flattened documentation preserves indentation, list formatting, headings, and code blocks.
* **Bug Fixes**
  * Improved handling of tabbed documentation and nested code examples.
  * Build validation now detects unflattened tabs, malformed fences, and swallowed commands before release.
* **Tests**
  * Added comprehensive coverage for documentation transformations and command rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->