### PR TITLE
fix(bestax-migrate): give the kitchen-sink e2e a per-process scratch dir

### DIFF
--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -40,9 +40,13 @@ each source library registers in `src/sources/registry.ts`; the first is
 - Fixture pairs: `__testfixtures__/<case>.input.tsx` → `.output.tsx`, exact-match. To
   update outputs after changing the transform, regenerate them by running the built
   transform over the inputs and reviewing the diff — do not hand-edit drift in.
-- Kitchen sink e2e (`e2e/kitchen-sink.test.ts`): copies `fixtures/kitchen-sink` to
-  `.e2e-tmp/`, migrates it, and runs `tsc --noEmit` on the output against the built
-  bulma-ui (`turbo` orders the build; see `bestax-migrate#test` in root turbo.json).
+- Kitchen sink e2e (`e2e/kitchen-sink.test.ts`): copies `fixtures/kitchen-sink` to a
+  `mkdtemp`'d dir under `.e2e-tmp/`, migrates it, and runs `tsc --noEmit` on the output
+  against the built bulma-ui (`turbo` orders the build; see `bestax-migrate#test` in root
+  turbo.json). The scratch dir is **per process, never a fixed path**: `pnpm all` runs
+  `test` and `test:coverage` in one turbo invocation, so two jest processes run this file
+  concurrently and a shared path lets them clobber each other's rmSync/cpSync — the suite
+  then fails as though the codemod had not run. `BESTAX_E2E_KEEP=1` leaves the dir behind.
   `src/leftovers.tsx` holds every intentionally-unsupported pattern — excluded from the
   typecheck, asserted via TODO rules instead. New unsupported patterns go there; new
   supported ones go in the other fixture files, which must stay TODO-free.

--- a/bestax-migrate/e2e/kitchen-sink.test.ts
+++ b/bestax-migrate/e2e/kitchen-sink.test.ts
@@ -23,7 +23,17 @@ const packageRoot = path.join(
   '..'
 );
 const fixtureDir = path.join(packageRoot, 'fixtures', 'kitchen-sink');
-const tmpDir = path.join(packageRoot, '.e2e-tmp', 'kitchen-sink');
+
+// One scratch directory PER PROCESS, not one shared path. `pnpm all` runs
+// `test` and `test:coverage` inside a single turbo invocation, so two jest
+// processes execute this file at the same time; against a fixed
+// `.e2e-tmp/kitchen-sink` they interleave each other's rmSync/cpSync and the
+// suite fails claiming the codemod did nothing ("Expected substring: not
+// 'react-bulma-components'") on files that migrate correctly in isolation.
+// Set BESTAX_E2E_KEEP=1 to leave the directory behind for inspection.
+const tmpRoot = path.join(packageRoot, '.e2e-tmp');
+fs.mkdirSync(tmpRoot, { recursive: true });
+const tmpDir = fs.mkdtempSync(path.join(tmpRoot, 'kitchen-sink-'));
 
 interface MigratedApp {
   todosByFile: Map<string, TodoEntry[]>;
@@ -86,6 +96,12 @@ describe('kitchen-sink e2e', () => {
 
   beforeAll(() => {
     app = migrateKitchenSink();
+  });
+
+  afterAll(() => {
+    if (!process.env.BESTAX_E2E_KEEP) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('migrates every kitchen-sink file', () => {


### PR DESCRIPTION
# Pull Request

## Description

`pnpm all` runs `test` and `test:coverage` inside one turbo invocation, so two jest processes execute `e2e/kitchen-sink.test.ts` concurrently. Both copied the fixture app into the same `.e2e-tmp/kitchen-sink` path, and each began with an `rmSync` of it — so one process could wipe and re-copy the pristine fixture while the other was asserting against its migrated output.

The failure reads as though the codemod silently did nothing:

```
Expected substring: not "react-bulma-components"
Received string:    "import { Columns } from 'react-bulma-components';
```

on a file that migrates correctly in isolation.

`mkdtemp` gives each process its own directory, so the suites no longer interact under any scheduler. Cleaned up in `afterAll`; `BESTAX_E2E_KEEP=1` keeps it for inspection.

### Reproduced before fixing

Two *identical* concurrent runs stay in lockstep and never collide — 0 of 6 failed, which would have been a false all-clear. Pairing an instrumented `--coverage` run against a plain one (the actual `pnpm all` shape, where coverage runs slower and lands mid-way through the other's read phase) is what interleaves:

| | failures |
|---|---|
| pre-fix, asymmetric pair ×3 | **2 of 6** |
| post-fix, same harness ×4 | **0 of 8** |

`pnpm all` then green three consecutive times, no scratch directories left behind.

### Scope note

This is **not** a CI flake — `ci.yml` runs `pnpm run test` (line 58) and `pnpm run test:coverage` (line 61) as separate sequential steps, so they never overlap there. It only bites `pnpm all`, the pre-PR gate CONTRIBUTING tells contributors to run.

## Related Issue(s)

Refs #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Performance
- [ ] Build tooling

Affected packages:

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] docs
- [ ] create-bestax
- [x] bestax-migrate

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] All new and existing tests passed
- [x] I have added/updated documentation as needed — `bestax-migrate/CLAUDE.md` records why the scratch dir must never be a fixed path
- [ ] I have added tests that prove my fix is effective — the fix *is* to the test harness; evidence is the A/B above
- [ ] I have updated Storybook stories as needed — n/a
- [ ] Any relevant dependencies are updated — none

## Additional Context

Scoped `fix(bestax-migrate)` per `commitlint.config.js`, so it cuts an independent patch release of that package only. Say the word if you would rather it not release and I will re-scope to `test(bestax-migrate)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011c6ipfvBsYgF3Jf91ZzSr7)_