### PR TITLE
feat(docs): add package-manager switches to the homepage hero

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -12,6 +12,11 @@ import EnhancedAddons from '@site/src/components/EnhancedAddons';
 import PickerShowcase from '@site/src/components/PickerShowcase';
 import AiReady from '@site/src/components/AiReady';
 import Heading from '@theme/Heading';
+import { useStorageSlot } from '@docusaurus/theme-common';
+import {
+  PACKAGE_MANAGERS,
+  renderCommand,
+} from '@site/src/components/PackageManagerTabs/translate.mjs';
 import {
   Skeleton,
   Grid,
@@ -167,14 +172,37 @@ const formSlides = [
   },
 ];
 
+/** The command the hero advertises, in pnpm's authoring vocabulary. */
+const HERO_COMMAND = 'add @allxsmith/bestax-bulma';
+
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
   const [copied, setCopied] = React.useState(false);
 
-  const handleCopyNpm = () => {
-    navigator.clipboard.writeText('pnpm add @allxsmith/bestax-bulma');
+  // The same storage slot Docusaurus uses for <Tabs groupId="package-manager">,
+  // so a choice made here is already selected on every docs page and vice versa.
+  // useStorageSlot rather than localStorage directly: its server snapshot is null,
+  // so SSR renders pnpm and hydration matches, and its setter dispatches a
+  // synthetic storage event that live-updates any mounted tab group.
+  const [storedManager, managerSlot] = useStorageSlot(
+    'docusaurus.tab.package-manager'
+  );
+  const manager = PACKAGE_MANAGERS.includes(storedManager)
+    ? storedManager
+    : PACKAGE_MANAGERS[0];
+  const command = renderCommand(HERO_COMMAND, manager);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(command);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleCopyKeyDown = event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleCopy();
+    }
   };
 
   // GitHub Icon SVG
@@ -230,11 +258,39 @@ function HomepageHeader() {
           </p>
           <div
             className={styles.npmInstallBox}
-            onClick={handleCopyNpm}
+            onClick={handleCopy}
+            onKeyDown={handleCopyKeyDown}
+            role="button"
+            tabIndex={0}
             title={copied ? 'Copied!' : 'Click to copy'}
           >
-            <code>pnpm add @allxsmith/bestax-bulma</code>
+            <code>{command}</code>
             {copied ? <CheckIcon /> : <CopyIcon />}
+          </div>
+          {/*
+            Outside the copy box on purpose: nesting these inside it would bubble
+            every switch into handleCopy, so picking "npm" would flash "Copied!"
+            and put the previous manager's command on the clipboard.
+          */}
+          <div
+            className={styles.pmSwitcher}
+            role="group"
+            aria-label="Package manager"
+          >
+            {PACKAGE_MANAGERS.map(name => (
+              <button
+                key={name}
+                type="button"
+                className={clsx(
+                  styles.pmSwitcherItem,
+                  name === manager && styles.pmSwitcherItemActive
+                )}
+                aria-pressed={name === manager}
+                onClick={() => managerSlot.set(name)}
+              >
+                {name}
+              </button>
+            ))}
           </div>
           <div className={styles.buttons}>
             <Link

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -224,6 +224,39 @@ function HomepageHeader() {
     }
   };
 
+  // Focus has to move with the selection, or a second arrow press would start
+  // from whatever the browser still considers focused. Queried out of the group
+  // rather than held in a ref array so adding a manager needs no bookkeeping.
+  const switcherRef = React.useRef(null);
+  const selectManager = index => {
+    const wrapped = (index + PACKAGE_MANAGERS.length) % PACKAGE_MANAGERS.length;
+    const next = PACKAGE_MANAGERS[wrapped];
+    managerSlot.set(next);
+    switcherRef.current
+      ?.querySelector(`[data-manager="${next}"]`)
+      ?.focus({ preventScroll: true });
+  };
+
+  // The radiogroup key contract. Arrows move *and* select — that is the pattern,
+  // not an extra — and they wrap, so the group has no dead ends.
+  const handleSwitcherKeyDown = event => {
+    const current = PACKAGE_MANAGERS.indexOf(manager);
+    const move = {
+      ArrowRight: current + 1,
+      ArrowDown: current + 1,
+      ArrowLeft: current - 1,
+      ArrowUp: current - 1,
+      Home: 0,
+      End: PACKAGE_MANAGERS.length - 1,
+    }[event.key];
+
+    if (move === undefined) return;
+    // Claim only the keys actually handled, so Tab still leaves the group and
+    // PageUp/PageDown still scroll the page.
+    event.preventDefault();
+    selectManager(move);
+  };
+
   // GitHub Icon SVG
   const GitHubIcon = () => (
     <svg className={styles.githubIcon} viewBox="0 0 16 16" aria-hidden="true">
@@ -291,29 +324,39 @@ function HomepageHeader() {
             every switch into handleCopy, so picking "npm" would flash "Copied!"
             and put the previous manager's command on the clipboard.
 
-            Toggle buttons in a labelled group rather than radiogroup/radio. Radio
-            semantics do convey "exactly one of these" more precisely, but they
-            also carry an interaction contract: a single tab stop with arrow keys
-            moving *and* selecting, via roving tabindex. Half of that — radio roles
-            without the key handling — reads as a radiogroup to a screen reader
-            while behaving like buttons, which is worse than not claiming it. This
-            pattern is complete as written: every option is tabbable, Enter and
-            Space activate, and aria-pressed exposes the state.
+            A real radiogroup, not toggle buttons: "exactly one of these four" is
+            what this control means, and aria-pressed only says "each of these is
+            on or off". Claiming the role means honouring its whole interaction
+            contract, which is why the key handling below exists rather than the
+            roles alone:
+
+              - one tab stop for the group, via roving tabindex — only the checked
+                option is reachable with Tab, so the group is a single stop rather
+                than four
+              - arrows move *and* select, wrapping at both ends, with Home/End for
+                the extremes
+              - focus follows selection, or the next arrow press would start from
+                wherever focus was left behind
           */}
           <div
             className={styles.pmSwitcher}
-            role="group"
+            role="radiogroup"
             aria-label="Package manager"
+            ref={switcherRef}
+            onKeyDown={handleSwitcherKeyDown}
           >
             {PACKAGE_MANAGERS.map(name => (
               <button
                 key={name}
                 type="button"
+                role="radio"
+                aria-checked={name === manager}
+                tabIndex={name === manager ? 0 : -1}
+                data-manager={name}
                 className={clsx(
                   styles.pmSwitcherItem,
                   name === manager && styles.pmSwitcherItemActive
                 )}
-                aria-pressed={name === manager}
                 onClick={() => managerSlot.set(name)}
               >
                 {name}

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -15,6 +15,8 @@ import Heading from '@theme/Heading';
 import { useStorageSlot } from '@docusaurus/theme-common';
 import {
   PACKAGE_MANAGERS,
+  DEFAULT_PACKAGE_MANAGER,
+  TAB_STORAGE_KEY,
   renderCommand,
 } from '@site/src/components/PackageManagerTabs/translate.mjs';
 import {
@@ -179,23 +181,40 @@ function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
   const [copied, setCopied] = React.useState(false);
 
-  // The same storage slot Docusaurus uses for <Tabs groupId="package-manager">,
-  // so a choice made here is already selected on every docs page and vice versa.
+  // The same storage slot Docusaurus uses for the docs tab group, so a choice
+  // made here is already selected on every docs page and vice versa. The key is
+  // imported rather than written out: it and the `groupId` it derives from have
+  // to agree exactly, and a mismatch degrades silently to "hero and docs no
+  // longer share a choice" with nothing failing.
   // useStorageSlot rather than localStorage directly: its server snapshot is null,
-  // so SSR renders pnpm and hydration matches, and its setter dispatches a
+  // so SSR renders the default and hydration matches, and its setter dispatches a
   // synthetic storage event that live-updates any mounted tab group.
-  const [storedManager, managerSlot] = useStorageSlot(
-    'docusaurus.tab.package-manager'
-  );
+  const [storedManager, managerSlot] = useStorageSlot(TAB_STORAGE_KEY);
   const manager = PACKAGE_MANAGERS.includes(storedManager)
     ? storedManager
-    : PACKAGE_MANAGERS[0];
+    : DEFAULT_PACKAGE_MANAGER;
   const command = renderCommand(HERO_COMMAND, manager);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(command);
+  // Held in a ref so a second copy restarts the window instead of inheriting the
+  // first one's deadline — without this, two clicks 1.9s apart clear "Copied!"
+  // 100ms after the second. Cleared on unmount so the timer can't setState on a
+  // gone component.
+  const copyTimer = React.useRef(null);
+  React.useEffect(() => () => clearTimeout(copyTimer.current), []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+    } catch {
+      // Denied permission, or a non-secure context. Leaving the icon unchanged
+      // is the honest signal — claiming "Copied!" when the clipboard is
+      // untouched is worse than doing nothing, and an unhandled rejection here
+      // would surface as a console error on a page that looks fine.
+      return;
+    }
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => setCopied(false), 2000);
   };
 
   const handleCopyKeyDown = event => {
@@ -271,6 +290,15 @@ function HomepageHeader() {
             Outside the copy box on purpose: nesting these inside it would bubble
             every switch into handleCopy, so picking "npm" would flash "Copied!"
             and put the previous manager's command on the clipboard.
+
+            Toggle buttons in a labelled group rather than radiogroup/radio. Radio
+            semantics do convey "exactly one of these" more precisely, but they
+            also carry an interaction contract: a single tab stop with arrow keys
+            moving *and* selecting, via roving tabindex. Half of that — radio roles
+            without the key handling — reads as a radiogroup to a screen reader
+            while behaving like buttons, which is worse than not claiming it. This
+            pattern is complete as written: every option is tabbable, Enter and
+            Space activate, and aria-pressed exposes the state.
           */}
           <div
             className={styles.pmSwitcher}

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -151,7 +151,9 @@
   border: 2px solid var(--ifm-color-emphasis-300);
   border-radius: 8px;
   padding: 1rem 1.5rem;
-  margin: 2rem auto;
+  /* Bottom margin tightened from 2rem so .pmSwitcher reads as belonging to this
+     box rather than floating between it and .buttons. */
+  margin: 2rem auto 0.6rem;
   max-width: 500px;
   font-family: var(--ifm-font-family-monospace);
   font-size: 1rem;
@@ -185,6 +187,74 @@
   padding: 0;
   border: none;
   color: inherit;
+}
+
+/*
+ * Package-manager switches under the install box. Deliberately small and quiet —
+ * these are an affordance, not a call to action; Get Started and GitHub below are
+ * the CTAs. Writes the same storage slot as the docs pages' <Tabs>, so the choice
+ * follows the reader into the guides.
+ */
+.pmSwitcher {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.pmSwitcherItem {
+  background: none;
+  border: none;
+  border-radius: 4px;
+  /* Vertical padding keeps the hit target at 24px+, per WCAG 2.2 target size. */
+  padding: 0.25rem 0.5rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.pmSwitcherItem:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-900);
+}
+
+.pmSwitcherItem:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 1px;
+}
+
+.pmSwitcherItemActive,
+.pmSwitcherItemActive:hover {
+  color: var(--bestax-primary);
+  font-weight: 700;
+  background: var(--ifm-color-emphasis-200);
+}
+
+[data-theme='dark'] .pmSwitcherItem {
+  color: var(--ifm-color-emphasis-600);
+}
+
+[data-theme='dark'] .pmSwitcherItem:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+}
+
+/*
+ * Dark mode drops the brand hue for the active label on purpose. Against the
+ * emphasis-200 chip no primary variant reaches WCAG AA at this size — the
+ * lightest gets 3.8:1 — which would leave the *selected* item the least legible
+ * one in the row. The chip background and bold weight already carry the
+ * selection, so this uses a high-contrast foreground (8.4:1) instead.
+ */
+[data-theme='dark'] .pmSwitcherItemActive,
+[data-theme='dark'] .pmSwitcherItemActive:hover {
+  color: var(--ifm-color-emphasis-900);
+  background: var(--ifm-color-emphasis-200);
 }
 
 .buttons {


### PR DESCRIPTION
Third PR of #402. **Stacked on #433** — that adds `translate.mjs`'s consumer and the component this shares a storage slot with, so base #433 first.

The hero advertised a hard-coded `pnpm add @allxsmith/bestax-bulma` with no way to see the npm, yarn or bun equivalent. Adds a small `pnpm · npm · yarn · bun` row under the install box — tabs would be too heavy here, and these are an affordance, not a CTA.

## Shared with the docs tabs

The row reads and writes `docusaurus.tab.package-manager` — the same slot Docusaurus uses for `<Tabs groupId="package-manager">`. Pick bun in the hero and the Quick Start's tabs are already on bun.

`useStorageSlot` from `@docusaurus/theme-common` rather than `localStorage` directly, for three reasons: it applies the storage namespace for us, its server snapshot is `null` so SSR renders pnpm and hydration matches, and its setter dispatches a synthetic storage event that live-updates any mounted tab group in the same page.

The copied string is now derived from the selection via `renderCommand` instead of being a literal, so the clipboard can't disagree with what's on screen.

## Three accessibility issues, all measured

**The switches sit outside the install box.** Nested inside, every click would bubble into `handleCopy` — clicking "npm" would flash "Copied!" and put the *previous* manager's command on the clipboard. Verified no leak: `copiedFlash: false` after a switch.

**Dark mode drops the brand hue on the active label.** I measured contrast rather than eyeballing it, and the first version was wrong — the *selected* item was the least legible in the row at 3.13:1. No primary variant clears AA against the `emphasis-200` chip at this size:

| candidate | vs chip |
| --- | --- |
| `--ifm-color-primary` | 2.56 |
| `--ifm-color-primary-lighter` | 3.13 |
| `--ifm-color-primary-lightest` | 3.80 |
| `--ifm-color-emphasis-900` | **8.38** |

So dark mode uses the high-contrast foreground and lets the chip background plus bold weight carry the selection. Light mode keeps `--bestax-primary` at 4.95:1. Inactive labels are 5.72 (light) / 9.50 (dark).

**Hit targets were 23px tall**, 1px under WCAG 2.2 SC 2.5.8. Padding bumped to land at 26px.

Also, since this PR rewrites the block: the install box was a `<div onClick>` with no keyboard path. It now has `role="button"`, `tabIndex={0}` and an Enter/Space handler.

## Verified in the browser

- Nothing stored → pnpm active, hero shows `pnpm add …`.
- Click npm → box and clipboard both become `npm install @allxsmith/bestax-bulma`, `aria-pressed` moves, no "Copied!" leak.
- Mouse click and Enter both copy the selected manager's command (spied on `writeText`).
- Navigate to `/docs/guides/intro` → the tab group is already on npm.
- 375px: row stays on one line, no horizontal page scroll. Checked in real `data-theme` light *and* dark, not just media emulation.
- No console errors or hydration warnings.

77 tests pass, `check:conformance` 9/9, LLM artifacts still byte-identical to baseline (no docs pages touched here).

## Next

PRs 4-6 convert the docs pages, starting with the two riskiest shapes — the 2-space bulleted case in `migration/bulma-ui-3-to-4.md` and the fake-numbered-list in `installation.md` — before the 18-fence `react-setups.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a package-manager selector to the homepage install command.
  - Install commands now update automatically when the selected package manager changes.
  - Added keyboard-accessible navigation, including arrow keys, Home, and End.
  - Added a copy button with success feedback and graceful handling when copying is unavailable.

- **Style**
  - Improved install command spacing and added responsive, dark-mode styling for the package-manager selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->