### PR TITLE
ci: split the preview deploy so build-time code can't reach Cloudflare creds

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,20 +1,40 @@
 name: Test deployment
 
+# Security: the build and the deploy are SEPARATE jobs, and only `deploy`
+# holds the Cloudflare credentials.
+#
+# `build` installs and executes PR-authored code — `pnpm install`, plus every
+# build-time hook the repo owns (docs/docusaurus.config.js,
+# bulma-ui/.storybook/main.ts, any package.json script). Those files are NOT
+# covered by the AI agents' `--disallowedTools` deny lists (which protect
+# .github/**, pnpm-workspace.yaml, the jest/commitlint/release configs), so a
+# claude/* PR can legitimately change code that runs here before any human
+# reviews it. Keeping CLOUDFLARE_API_TOKEN out of that job means build-time
+# code has no credential to reach for.
+#
+# `deploy` runs no repo code at all: it downloads the built site as an
+# artifact and hands it to wrangler. Deliberately no checkout. Same split as
+# visual-regression.yml and story-screenshots.yml.
+
 on:
   pull_request:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: write
+# No workflow-level grants; each job takes exactly what it needs.
+permissions: {}
 
 jobs:
-  test-deploy:
-    name: Test and Preview Deployment
+  build:
+    name: Build preview site
     runs-on: ubuntu-latest
+    # Read-only, and no secrets: this job executes PR-authored code.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -36,6 +56,33 @@ jobs:
         run: |
           mkdir -p docs/build/storybook
           cp -r bulma-ui/storybook-static/* docs/build/storybook/
+
+      # The deploy job never checks out the repo — this artifact is the only
+      # thing that crosses the boundary. Fail loudly if the build produced
+      # nothing rather than deploying an empty site over the preview.
+      - name: Upload preview site
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: preview-site
+          path: docs/build
+          retention-days: 1
+          if-no-files-found: error
+
+  # Job id and display name are unchanged from the single-job version so any
+  # required status check referencing "Test and Preview Deployment" still
+  # resolves.
+  test-deploy:
+    name: Test and Preview Deployment
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pull-requests: write # comment the preview URL
+    steps:
+      - name: Download preview site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: preview-site
+          path: docs/build
 
       # github.head_ref is attacker-chosen text (the PR branch name) — never
       # interpolate it into a command. Reduce it to [A-Za-z0-9-] first; the


### PR DESCRIPTION
# Pull Request

## Description

Splits `.github/workflows/test-deploy.yml` into two jobs so the Cloudflare credentials are no longer reachable by code that runs during the build.

Before, it was a single job: `pnpm install` → build Docusaurus → build Storybook → `wrangler pages deploy`, with `CLOUDFLARE_API_TOKEN` in the job environment for all of it. Those build steps execute repo-owned hooks (`docs/docusaurus.config.js`, `bulma-ui/.storybook/main.ts`, `package.json` scripts) that are **not** covered by the AI agents' `--disallowedTools` deny lists or by `claude-pr-loop.yml`'s `protected-path` halt — both of which protect `.github/**`, `pnpm-workspace.yaml` and the jest/commitlint/release configs, but not the docs or Storybook build config.

After:

- **`build`** — `contents: read`, **no secrets**, installs and builds, uploads `docs/build` as the `preview-site` artifact
- **`test-deploy`** — downloads that artifact, holds the Cloudflare credentials, and does **no checkout and no repo code**

This is the same split already used by `visual-regression.yml` and `story-screenshots.yml`.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): CI / workflow security

## Related Issue(s)

Closes #441

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [x] Build tooling
- [ ] Other (please describe):

## Compatibility notes

- **Fork PRs are unaffected.** GitHub already withholds secrets from fork `pull_request` runs, so the token was never reachable from a fork. No fork guard was added, deliberately — a *skipped* required check blocks merges the same way a failing one does, so fork behaviour stays byte-identical to today.
- **Required status checks still resolve.** The deploy job keeps both its id (`test-deploy`) and display name (`Test and Preview Deployment`). The new `build` job appears as an additional check.
- **The AI loop is unaffected.** `claude-pr-loop.yml`'s green-gate whitelist covers `Build and Test`, the React compatibility matrix, `Dependency Review` and CodeRabbit — it never referenced this workflow.
- **Cost:** one artifact round-trip of the built site, roughly 30–90s of extra wall clock per PR.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] My changes require a change to the documentation
- [ ] All new and existing tests passed
- [ ] Any relevant dependencies are updated
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

Notes on the unchecked boxes: this is a workflow-only change with no unit-testable surface — the verification is this PR's own CI run. `prettier` does not cover `.yml` (its glob is `ts,tsx,js,jsx,mjs,md,mdx`), so there is no formatting gate to satisfy. No commands, conventions, or package structure changed, so no `CLAUDE.md` update is needed.

## Additional Context

**The one thing to watch on this run:** the deploy job intentionally has no `actions/checkout`, so `cloudflare/wrangler-action` runs in a directory containing only the downloaded artifact. It should install wrangler via npm and deploy normally, but this PR's own CI is the verification — if the deploy step fails on package-manager detection, the fix is to pin the `packageManager` input rather than to reintroduce a checkout.

Note that this PR touches `.github/**`, so it is outside the AI loop by design and requires Code Owner review per `.github/CODEOWNERS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmwqmBPu2Fo3hSzayr3mwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmwqmBPu2Fo3hSzayr3mwz)_