### PR TITLE
feat(create-bestax): require Node 22 and take chalk 6

### DIFF
--- a/create-bestax/README.md
+++ b/create-bestax/README.md
@@ -12,6 +12,12 @@ The scaffolder for [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@al
 
 Part of the [bestax monorepo](https://github.com/allxsmith/bestax) — see also [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) for the components themselves.
 
+## Requirements
+
+- **Node.js 22 or newer.** Node 18 and 20 are both past end-of-life. On an older runtime the
+  CLI exits immediately with an explicit upgrade message.
+- npm 10 or newer (ships with Node 22), or yarn/pnpm.
+
 ## Usage
 
 ### Quick Start


### PR DESCRIPTION
# Pull Request

## Description

Restores the release signal that #447 lost. Safe to squash **or** merge-commit — this PR has a
single commit with a single scope, and the title matches the commit subject exactly.

#447 was squash-merged, which collapsed its three scoped commits into one
`chore(deps): …` commit. `chore` maps to `release: false` in all three `release.config.js`
files, and the squash commit's scope is `deps`, which matches the
`{ scope: '!(create-bestax)', release: false }` guard rule — and a matching `release: false`
always wins. So the implementation is on `main` but nothing was published: npm still has
`create-bestax@3.8.0`.

The code change (chalk `^6.0.0`, `engines.node` `>=22`, and a version guard that no longer
depends on chalk to report a too-old runtime) already landed in #447. This PR adds the
`Requirements` section the README never had, and carries the `BREAKING CHANGE:` footer that
makes the release come out as a major.

Verified by running the real `releaseRules` from `create-bestax/release.config.js` against the
actual commits since `create-bestax@3.8.0`: **MAJOR → 4.0.0** (was `NO RELEASE`).

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)

## Related Issue(s)

Refs #447

## Type of Change

- [x] Bug fix
- [x] Documentation

## Merge order

> Merge this **before** #446. #446 is the GitHub App token fix; the moment it lands, the next
> push to `main` can actually publish. Landing this first is what makes that publish a
> correct 4.0.0.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] All new and existing tests passed

Documentation-only diff; `prettier --check` passes. No source changed, so the existing suites
are unaffected.
