### PR TITLE
feat(bestax-migrate): require Node 22 and take chalk 6

### DIFF
--- a/bestax-migrate/README.md
+++ b/bestax-migrate/README.md
@@ -16,6 +16,14 @@ Currently supported source libraries:
 | -------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | [`react-bulma-components`](https://github.com/couds/react-bulma-components) (v4) | ✅ All 32 components mapped (a few patterns are flagged as TODOs) |
 
+## Requirements
+
+**Node.js 22 or newer.** Node 18 and 20 are both past end-of-life. On an older runtime the CLI
+exits immediately with an explicit upgrade message.
+
+This applies only to the Node version the codemod itself runs on. It places no requirement on
+the app being migrated — the source is read as text and is never executed.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
# Pull Request

## Description

Restores the release signal that #447 lost, and prevents a breaking change from shipping as a
patch. Safe to squash **or** merge-commit — single commit, single scope, title matches the
commit subject exactly.

#447 was squash-merged, collapsing its three scoped commits into one `chore(deps): …` commit,
so the `feat(bestax-migrate)` scope and its `BREAKING CHANGE:` footer were lost.

**This one is not just a missed release.** Four `fix(bestax-migrate)` commits from #412/#417
have been queued since `bestax-migrate@1.0.0`. With the breaking footer gone, the next release
computes as a **patch → 1.0.1** — and that tarball would carry `engines.node: ">=22"` and the
chalk 6 major, both of which landed in #447. A raised Node floor published inside a patch is
exactly wrong, and `npx bestax-migrate` users on Node 18/20 would break without warning.

Verified against the real `releaseRules` in `bestax-migrate/release.config.js`, over the actual
commits since `bestax-migrate@1.0.0`:

| | release type | version |
|---|---|---|
| before this PR | PATCH | 1.0.1 ← wrong |
| with this PR | **MAJOR** | **2.0.0** |

The code change already landed in #447. This PR adds the `Requirements` section the README
never had — including the distinction that the Node floor applies to the runtime the codemod
executes on, not to the app being migrated — and carries the `BREAKING CHANGE:` footer.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] Other (please specify): `bestax-migrate`

## Related Issue(s)

Refs #447
Refs #412
Refs #417

## Type of Change

- [x] Bug fix
- [x] Documentation

## Merge order

> Merge this **before** #446. Until #446 lands, the publish job still fails at the GH006 push,
> so nothing can be published — that failure is currently the only thing preventing the
> incorrect 1.0.1. Landing this first turns the first working publish into a correct 2.0.0.

## Additional Context

`@babel/parser` deliberately stays on 7.x — see #430. Babel 8 removes the
`deprecatedImportAssert` plugin with no replacement, and this package has a regression test
("parses the legacy import-assert syntax") asserting that
`import data from './data.json' assert { type: 'json' }` both parses and survives into the
output. A codemod for older codebases must not crash on the syntax those codebases contain.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] All new and existing tests passed

Documentation-only diff; `prettier --check` passes. No source changed, so the existing suites
(185 tests, plus the kitchen-sink e2e and corpus validation) are unaffected.
