### PR TITLE
ci: skip the preview deploy on dependabot PRs

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -75,6 +75,31 @@ jobs:
     name: Test and Preview Deployment
     runs-on: ubuntu-latest
     needs: build
+    # Dependabot-triggered runs are scoped to the *Dependabot* secrets store,
+    # not the Actions one, so `secrets.CLOUDFLARE_API_TOKEN` interpolates to an
+    # empty string and wrangler aborts with "it's necessary to set a
+    # CLOUDFLARE_API_TOKEN environment variable". That made this check red on
+    # every dependency PR — noise that trains reviewers to ignore a red check.
+    #
+    # `github.actor` is the right condition because it is the same thing GitHub
+    # keys the secret scoping on: a human pushing to a dependabot/* branch
+    # becomes the actor and does get the Actions secrets, so the preview still
+    # deploys in exactly the cases where it can.
+    #
+    # Only this job is guarded. `build` still runs on dependency PRs, so a bump
+    # that breaks the Docusaurus or Storybook build is still caught.
+    #
+    # This reports as *skipped*, not success. Fine while the check is not
+    # required (the main ruleset requires Build and Test, the React 18/19
+    # matrix, and Dependency Review). If it is ever promoted to required, move
+    # this condition down to the steps so the job itself still concludes green.
+    #
+    # Adding the Cloudflare credentials to the Dependabot secrets store would
+    # also turn the check green, and is deliberately not done: it would hand a
+    # live deploy token to auto-generated PRs that pull in unreviewed
+    # transitive dependencies — the exact exposure the build/deploy split above
+    # exists to prevent.
+    if: github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: write # comment the preview URL
     steps:


### PR DESCRIPTION
# Pull Request

## Description

Fixes the permanently-red `Test and Preview Deployment` check on dependency PRs — the failing
check on #425, and on every Dependabot PR before it.

It was never a dependency problem. GitHub scopes Dependabot-triggered runs to the separate
**Dependabot secrets** store rather than the Actions one, so `secrets.CLOUDFLARE_API_TOKEN`
interpolates to an empty string and wrangler aborts:

```
✘ [ERROR] In a non-interactive environment, it's necessary to set a
CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

The correlation is total. Across the last 60 runs of this workflow, **every** run with
`actor: dependabot[bot]` failed and **every** run by a human or `claude[bot]` passed — with no
exception in either direction, and unbroken across the #442 build/deploy split. So this
predates #442 rather than being caused by it.

A check that is red on an entire class of PRs is worse than no check: it trains reviewers to
scroll past red. #392 was merged with it red back in July for exactly this reason.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): CI

## Related Issue(s)

Refs #425
Refs #442

## Type of Change

- [x] Bug fix
- [x] Build tooling

## Why this shape

**Only the deploy job is guarded.** `build` still runs on dependency PRs, so a bump that breaks
the Docusaurus or Storybook build is still caught — which is the part of this workflow that
carries real signal for a dependency change.

**`github.actor` is the correct condition**, not the PR author. It is the same thing GitHub
keys the secret scoping on, so the guard matches the failure exactly: a human pushing to a
`dependabot/*` branch becomes the actor and *does* receive the Actions secrets, and in that
case the preview still deploys.

**This reports as _skipped_, not success.** That is fine while the check is not required — the
`main` ruleset requires `Build and Test`, the React 18/19 matrix, and `Dependency Review`. The
comment records that if it is ever promoted to required, the condition must move down to the
steps so the job itself still concludes green, since a skipped required check blocks merge the
same way a failing one does.

## Alternative deliberately not taken

Adding `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` to the Dependabot secrets store would
also turn the check green. It is not done here: that hands a live deploy token to
auto-generated PRs that pull unreviewed transitive dependencies into `pnpm install` — precisely
the exposure the build/deploy split in #442 was written to eliminate.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] All new and existing tests passed

Workflow-only change with no unit-testable surface; `prettier` does not cover `.yml`. The
verification is behavioural: this PR is human-authored, so `test-deploy` should still **run and
pass** here, and the next Dependabot PR should show it **skipped** instead of failed.

## Additional Context

Touches `.github/**`, so it is outside the AI loop by design and needs Code Owner review.
