### PR TITLE
docs: offer npm/yarn/bun for every install command (#402)

### DIFF
--- a/docs/docs/guides/features/configuration.md
+++ b/docs/docs/guides/features/configuration.md
@@ -138,9 +138,13 @@ For teams building custom Bulma CSS with their own prefixes:
 
 ### 1. Install Dependencies
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add bulma sass
 ```
+
+</PackageManagerTabs>
 
 ### 2. Create Custom Sass File
 

--- a/docs/docs/guides/features/sass-customization.md
+++ b/docs/docs/guides/features/sass-customization.md
@@ -31,10 +31,14 @@ Sass variables feed the generated Bulma CSS — including the values of Bulma's 
 
 To customize Bulma with Sass variables, you need:
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add sass
 pnpm add bulma
 ```
+
+</PackageManagerTabs>
 
 ## Build Configuration
 
@@ -42,9 +46,13 @@ pnpm add bulma
 
 Vite is the default toolchain for projects scaffolded by `pnpm create bestax@latest`, and handles Sass out of the box once `sass` is installed:
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add sass
 ```
+
+</PackageManagerTabs>
 
 **`src/styles/bulma-custom.scss`:**
 
@@ -79,9 +87,13 @@ Next.js has built-in Sass support:
 
 **Install Sass:**
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add sass
 ```
+
+</PackageManagerTabs>
 
 **Custom Sass file (styles/bulma-custom.scss):**
 

--- a/docs/docs/guides/getting-started/alternative-icons.md
+++ b/docs/docs/guides/getting-started/alternative-icons.md
@@ -20,9 +20,13 @@ Font Awesome is the default icon library — no `library` prop required.
 
 **Install:**
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add @fortawesome/fontawesome-free
 ```
+
+</PackageManagerTabs>
 
 **Import:**
 
@@ -66,9 +70,13 @@ Material Design Icons (MDI) is a comprehensive icon library that follows Google'
 
 **Install:**
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add @mdi/font
 ```
+
+</PackageManagerTabs>
 
 **Import:**
 
@@ -101,9 +109,13 @@ Ionicons is a modern icon library with 1,300+ icons designed specifically for we
 
 **Install:**
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add ionicons@^8.0.13
 ```
+
+</PackageManagerTabs>
 
 **Import:**
 
@@ -216,9 +228,13 @@ Google's official Material Icons library provides the core set of Material Desig
 
 **Install:**
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add material-icons
 ```
+
+</PackageManagerTabs>
 
 **Import:**
 
@@ -326,9 +342,13 @@ The newest icon library from Google, offering more comprehensive icon coverage a
 
 **Install:**
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add material-symbols
 ```
+
+</PackageManagerTabs>
 
 **Import:**
 

--- a/docs/docs/guides/getting-started/installation.md
+++ b/docs/docs/guides/getting-started/installation.md
@@ -56,23 +56,13 @@ The viewport meta tag is **essential** for Bulma's responsive features. Without 
 `pnpm create bestax@latest` installs the package, wires up the CSS, and scaffolds a working app in one step. Only follow the manual steps below if you're adding bestax-bulma to an existing project or using a toolchain the installer doesn't cover.
 :::
 
-### Using npm (recommended)
+<PackageManagerTabs>
 
 ```bash
 pnpm add @allxsmith/bestax-bulma
 ```
 
-### Using yarn
-
-```bash
-yarn add @allxsmith/bestax-bulma
-```
-
-### Using pnpm
-
-```bash
-pnpm add @allxsmith/bestax-bulma
-```
+</PackageManagerTabs>
 
 ### Version Management
 
@@ -142,9 +132,13 @@ Or if you only need Bulma itself:
 
 1. Install Sass as a dev dependency (Bulma is already installed):
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add -D sass
 ```
+
+</PackageManagerTabs>
 
 2. Create a custom SCSS file:
 
@@ -177,9 +171,13 @@ bestax-bulma components support multiple icon libraries. Icons are optional but 
 
 ### Font Awesome (Most Popular)
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add @fortawesome/fontawesome-free
 ```
+
+</PackageManagerTabs>
 
 Import in your main file:
 
@@ -191,9 +189,13 @@ Usage: `<Icon name="user" />` or `<Icon name="github" variant="brands" />`
 
 ### Material Design Icons
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add @mdi/font
 ```
+
+</PackageManagerTabs>
 
 ```js
 import '@mdi/font/css/materialdesignicons.min.css';
@@ -203,9 +205,13 @@ Usage: `<Icon name="account" library="mdi" />`
 
 ### Material Icons (Google)
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add material-icons
 ```
+
+</PackageManagerTabs>
 
 ```js
 import 'material-icons/iconfont/material-icons.css';
@@ -215,9 +221,13 @@ Usage: `<Icon name="person" library="material-icons" />`
 
 ### Ionicons
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add ionicons
 ```
+
+</PackageManagerTabs>
 
 ```js
 import 'ionicons/dist/css/ionicons.min.css';
@@ -273,9 +283,13 @@ bestax-bulma includes TypeScript definitions. For the best experience:
 
 ### Install Type Definitions
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add -D typescript @types/react @types/react-dom
 ```
+
+</PackageManagerTabs>
 
 ### TypeScript Configuration
 
@@ -325,15 +339,23 @@ To analyze your bundle:
 
 1. Install bundle analyzer:
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add -D webpack-bundle-analyzer
 ```
 
+</PackageManagerTabs>
+
 2. Check what's included:
+
+<PackageManagerTabs>
 
 ```bash
 pnpm dlx webpack-bundle-analyzer stats.json
 ```
+
+</PackageManagerTabs>
 
 ### Expected Sizes
 

--- a/docs/docs/guides/getting-started/migration/bulma-0-9-to-1.md
+++ b/docs/docs/guides/getting-started/migration/bulma-0-9-to-1.md
@@ -47,7 +47,7 @@ Bulma v1 uses **Dart Sass** instead of the deprecated Node Sass:
 
 ```bash
 # Remove old dependency
-npm uninstall node-sass
+pnpm remove node-sass
 
 # Install modern Sass compiler
 pnpm add sass

--- a/docs/docs/guides/getting-started/migration/bulma-ui-3-to-4.md
+++ b/docs/docs/guides/getting-started/migration/bulma-ui-3-to-4.md
@@ -37,9 +37,13 @@ React 16.8 and 17 are no longer supported. The library is built and tested again
 - ✅ On React 18 or 19 — upgrade with no code changes. Your existing components, props, imports, and CSS all behave exactly as they did in 3.x.
 - ⚠️ On React 16 or 17 — `pnpm add @allxsmith/bestax-bulma@4` will emit a peer-dependency warning, and some components rely on hooks/behavior that assume a modern React. **Stay on `@3`** until you can upgrade React:
 
+  <PackageManagerTabs>
+
   ```bash
   pnpm add @allxsmith/bestax-bulma@^3
   ```
+
+  </PackageManagerTabs>
 
 **Why this changed:** dropping the legacy React versions lets the library use modern React idioms (e.g. `useId` for accessible, SSR-safe element IDs) without compatibility shims, and keeps the maintenance surface focused on the versions the ecosystem actually runs.
 

--- a/docs/docs/guides/getting-started/modular.md
+++ b/docs/docs/guides/getting-started/modular.md
@@ -97,9 +97,13 @@ Hand-rolling modular SCSS is worthwhile only when you have a demonstrated CSS-si
 
 Install Sass as a dev dependency (Bulma is already installed as a transitive dependency):
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add -D sass
 ```
+
+</PackageManagerTabs>
 
 #### Required base styles
 

--- a/docs/docs/guides/getting-started/optimizing-css.md
+++ b/docs/docs/guides/getting-started/optimizing-css.md
@@ -46,9 +46,13 @@ The `npm create bestax` scaffold's `--bulma` flag selects a flavor at project cr
 Most of the remaining weight is selectors your app never renders. An opt-in
 [PurgeCSS](https://purgecss.com/) step removes them at build time. In a Vite app:
 
+<PackageManagerTabs>
+
 ```bash
-npm install -D @fullhuman/postcss-purgecss
+pnpm add -D @fullhuman/postcss-purgecss
 ```
+
+</PackageManagerTabs>
 
 ```js title="postcss.config.js"
 import purgecss from '@fullhuman/postcss-purgecss';

--- a/docs/docs/guides/getting-started/react-setups.md
+++ b/docs/docs/guides/getting-started/react-setups.md
@@ -26,11 +26,15 @@ Vite is a modern, fast build tool that's become the go-to choice for React appli
 
 1. **Create a new Vite React project:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm create vite@latest my-bulma-vite-app -- --template react
    cd my-bulma-vite-app
    pnpm install
    ```
+
+   </PackageManagerTabs>
 
    :::info Template Argument Explained
    - `--template react`: Uses the official React template with JavaScript
@@ -44,9 +48,13 @@ Vite is a modern, fast build tool that's become the go-to choice for React appli
 
 2. **Install bestax-bulma and dependencies:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm add @allxsmith/bestax-bulma @fortawesome/fontawesome-free
    ```
+
+   </PackageManagerTabs>
 
 3. **Update your main.jsx file:**
 
@@ -132,9 +140,13 @@ Vite is a modern, fast build tool that's become the go-to choice for React appli
 
 5. **Run your application:**
 
+   <PackageManagerTabs>
+
    ```bash
-   pnpm dev
+   pnpm run dev
    ```
+
+   </PackageManagerTabs>
 
    :::tip Application Available
    Your Vite + React + bestax-bulma application will be available at `http://localhost:5173`
@@ -144,11 +156,15 @@ Vite is a modern, fast build tool that's become the go-to choice for React appli
 
 1. **Create a new Vite React TypeScript project:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm create vite@latest my-bulma-vite-ts-app -- --template react-ts
    cd my-bulma-vite-ts-app
    pnpm install
    ```
+
+   </PackageManagerTabs>
 
    :::info Template Argument Explained
    - `--template react-ts`: Uses the official React template with TypeScript
@@ -162,9 +178,13 @@ Vite is a modern, fast build tool that's become the go-to choice for React appli
 
 2. **Install bestax-bulma and dependencies:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm add @allxsmith/bestax-bulma @fortawesome/fontawesome-free
    ```
+
+   </PackageManagerTabs>
 
    :::note
    The `react-ts` template already includes `@types/react` and `@types/react-dom` — no extra type packages needed.
@@ -254,9 +274,13 @@ Vite is a modern, fast build tool that's become the go-to choice for React appli
 
 5. **Run your application:**
 
+   <PackageManagerTabs>
+
    ```bash
-   pnpm dev
+   pnpm run dev
    ```
+
+   </PackageManagerTabs>
 
    :::tip Application Available
    Your Vite + React + TypeScript + bestax-bulma application will be available at `http://localhost:5173`
@@ -272,10 +296,14 @@ Next.js is a popular React framework that provides server-side rendering, static
 
 1. **Create a new Next.js project:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm dlx create-next-app@latest my-bulma-next-app --js --eslint --no-tailwind --src-dir --app --import-alias "@/*" --turbopack
    cd my-bulma-next-app
    ```
+
+   </PackageManagerTabs>
 
    :::info Command Arguments Explained
    - `--js`: Use JavaScript (not TypeScript)
@@ -293,9 +321,13 @@ Next.js is a popular React framework that provides server-side rendering, static
 
 2. **Install bestax-bulma and dependencies:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm add @allxsmith/bestax-bulma @fortawesome/fontawesome-free
    ```
+
+   </PackageManagerTabs>
 
 3. **Update your root layout:**
 
@@ -385,9 +417,13 @@ Next.js is a popular React framework that provides server-side rendering, static
 
 5. **Run your application:**
 
+   <PackageManagerTabs>
+
    ```bash
-   pnpm dev
+   pnpm run dev
    ```
+
+   </PackageManagerTabs>
 
    :::tip Application Available
    Your Next.js + React + bestax-bulma application will be available at `http://localhost:3000`
@@ -397,10 +433,14 @@ Next.js is a popular React framework that provides server-side rendering, static
 
 1. **Create a new Next.js TypeScript project:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm dlx create-next-app@latest my-bulma-next-ts-app --ts --eslint --no-tailwind --src-dir --app --import-alias "@/*" --turbopack
    cd my-bulma-next-ts-app
    ```
+
+   </PackageManagerTabs>
 
    :::info Command Arguments Explained
    - `--ts`: Use TypeScript (not JavaScript)
@@ -418,9 +458,13 @@ Next.js is a popular React framework that provides server-side rendering, static
 
 2. **Install bestax-bulma and dependencies:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm add @allxsmith/bestax-bulma @fortawesome/fontawesome-free
    ```
+
+   </PackageManagerTabs>
 
 3. **Update your root layout:**
 
@@ -515,9 +559,13 @@ Next.js is a popular React framework that provides server-side rendering, static
 
 5. **Run your application:**
 
+   <PackageManagerTabs>
+
    ```bash
-   pnpm dev
+   pnpm run dev
    ```
+
+   </PackageManagerTabs>
 
    :::tip Application Available
    Your Next.js + TypeScript + bestax-bulma application will be available at `http://localhost:3000`
@@ -537,16 +585,24 @@ For Create React App and other legacy bundlers like Webpack 4, the setup process
 
 1. **Create a new CRA project:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm dlx create-react-app my-bulma-cra-app
    cd my-bulma-cra-app
    ```
 
+   </PackageManagerTabs>
+
 2. **Install bestax-bulma and dependencies:**
+
+   <PackageManagerTabs>
 
    ```bash
    pnpm add @allxsmith/bestax-bulma @fortawesome/fontawesome-free
    ```
+
+   </PackageManagerTabs>
 
 3. **Update your index.js:**
 
@@ -639,9 +695,13 @@ For Create React App and other legacy bundlers like Webpack 4, the setup process
 
 5. **Run your application:**
 
+   <PackageManagerTabs>
+
    ```bash
-   npm start
+   pnpm run start
    ```
+
+   </PackageManagerTabs>
 
    :::tip Application Available
    Your Create React App + bestax-bulma application will be available at `http://localhost:3000`
@@ -651,16 +711,24 @@ For Create React App and other legacy bundlers like Webpack 4, the setup process
 
 1. **Create a new CRA TypeScript project:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm dlx create-react-app my-bulma-cra-ts-app --template typescript
    cd my-bulma-cra-ts-app
    ```
 
+   </PackageManagerTabs>
+
 2. **Install bestax-bulma and dependencies:**
+
+   <PackageManagerTabs>
 
    ```bash
    pnpm add @allxsmith/bestax-bulma @fortawesome/fontawesome-free
    ```
+
+   </PackageManagerTabs>
 
 3. **Update your index.tsx:**
 
@@ -755,9 +823,13 @@ For Create React App and other legacy bundlers like Webpack 4, the setup process
 
 5. **Run your application:**
 
+   <PackageManagerTabs>
+
    ```bash
-   npm start
+   pnpm run start
    ```
+
+   </PackageManagerTabs>
 
    :::tip Application Available
    Your Create React App + TypeScript + bestax-bulma application will be available at `http://localhost:3000`
@@ -819,9 +891,13 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 
 **Solution**: Ensure you have the latest TypeScript version and proper type declarations:
 
+<PackageManagerTabs>
+
 ```bash
 pnpm add -D typescript @types/react @types/react-dom
 ```
+
+</PackageManagerTabs>
 
 ### Tree Shaking Issues
 

--- a/docs/docs/guides/getting-started/variations.md
+++ b/docs/docs/guides/getting-started/variations.md
@@ -205,9 +205,13 @@ For teams that want a custom class prefix matching their brand or organization. 
 
 1. **Install dependencies:**
 
+   <PackageManagerTabs>
+
    ```bash
    pnpm add bulma sass
    ```
+
+   </PackageManagerTabs>
 
 2. **Create a custom SCSS file:**
 

--- a/docs/docs/guides/intro.md
+++ b/docs/docs/guides/intro.md
@@ -10,12 +10,16 @@ sidebar_position: 1
 
 The fastest way to get started. The scaffolder sets up a Vite + React project with bestax-bulma and CSS pre-configured:
 
+<PackageManagerTabs>
+
 ```bash
 pnpm create bestax@latest my-bestax-app
 cd my-bestax-app
 pnpm install
-pnpm dev
+pnpm run dev
 ```
+
+</PackageManagerTabs>
 
 :::info CSS is included automatically
 The scaffolder configures `bestax.css` for you — a single stylesheet that includes both Bulma and all bestax extras. No manual CSS setup needed.
@@ -94,9 +98,13 @@ export default App;
 
 ## Run Your App
 
+<PackageManagerTabs>
+
 ```bash
-pnpm dev
+pnpm run dev
 ```
+
+</PackageManagerTabs>
 
 Visit http://localhost:5173 to see your app running.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -10,10 +10,14 @@ For detailed installation options, framework-specific guides, or troubleshooting
 
 ## 1. Run the Installer
 
+<PackageManagerTabs>
+
 ```bash
 pnpm create bestax@latest my-bestax-app
 cd my-bestax-app
 ```
+
+</PackageManagerTabs>
 
 The installer walks you through a few prompts and sets up everything for you:
 
@@ -60,9 +64,13 @@ export default App;
 
 ## 3. Run Your App
 
+<PackageManagerTabs>
+
 ```bash
-pnpm dev
+pnpm run dev
 ```
+
+</PackageManagerTabs>
 
 **That's it!** Visit http://localhost:5173 to see your app running.
 


### PR DESCRIPTION
# Pull Request

## Description

Wraps **46 command blocks across 12 guides** in `<PackageManagerTabs>`, so readers on npm, yarn
or bun stop translating pnpm commands by hand. The component derives the other three from the
authored pnpm fence, and the shared tab group means a choice made on one page — or in the
homepage hero from #434 — is already selected everywhere else.

## Fixes a live error on the way

`installation.md` had three hand-written sections:

- **`### Using npm (recommended)`** sitting above a **`pnpm add`** command
- a **`### Using pnpm`** section that was a byte-for-byte duplicate of it
- no bun at all

So the page told npm readers to run pnpm. All three collapse into one component that renders
the correct command per manager. No inbound links referenced the removed anchors (checked
across `docs/`, `skills/`, the packages and the README).

## Four commands rewritten into the authoring vocabulary

The component authors in pnpm's verb vocabulary and derives the rest, so these had to move into
it. The only visible change for pnpm readers is `pnpm dev` → the equivalent `pnpm run dev`:

| before | after | |
|---|---|---|
| `pnpm dev` | `pnpm run dev` | 7 blocks |
| `npm start` | `pnpm run start` | 2 blocks, CRA setups |
| `npm install -D @fullhuman/postcss-purgecss` | `pnpm add -D …` | |
| `npm uninstall node-sass` | `pnpm remove …` | |

## Deliberately **not** converted

Worth reading, because two of these are correctness constraints rather than taste:

- **`contributing.md` (9 blocks).** These are monorepo commands — `pnpm exec`, `--filter`,
  `audit`, `approve-builds`, `why` — which aren't package-manager verbs, so the round-trip
  assertion rejects them and the build fails. I verified this:
  ```
  FAILS "pnpm exec turbo run build"             -> "exec turbo run build"
  FAILS "pnpm --filter create-bestax run build" -> "--filter create-bestax run build"
  ```
  It's also the wrong advice: the repo pins pnpm via `packageManager`, so a contributor has no
  npm/yarn/bun equivalent to be offered.
- **`npx skills add …` (9 blocks)** — the command the skills ecosystem documents. Rewriting it
  to `pnpm dlx` form to fit our component would be the tail wagging the dog.
- **`npm view` / `npm list`** — informational, not installs; they'd render identically on all
  four tabs.
- **Three blocks with a blank line inside the fence.** `splitSegments` drops empty segments, so
  they can't round-trip. Left as plain fences, which preserves the visual grouping the blank
  line exists for. This is a real limitation of the component worth knowing about.
- **`api/elements/pre.md`** (a live `<Pre>` demo, not an instruction) and the stock Docusaurus
  `tutorial-basics`/`tutorial-extras` pages.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)

## Related Issue(s)

Closes #402

## Type of Change

- [x] Documentation
- [x] Bug fix (the `installation.md` npm/pnpm error)

## Verification

**Every converted block is checked at build time.** The component derives the authored command
back out of the fence and throws unless it renders to exactly what was written, so a bad
conversion fails the prerender rather than shipping three wrong tabs. The build passing *is*
the assertion that all 46 are correct.

Also checked:

- **Nested lists work** — `react-setups.md` has 19 blocks inside numbered list items. I probed
  that shape before converting anything: all four tabs render, the `<ol>` survives, and the LLM
  artifact keeps the fence at its list indentation.
- `installation.md` now renders all four (`pnpm add` / `npm install` / `yarn add` / `bun add`)
  and the wrong heading is gone.
- `pnpm run check:conformance` — 0 violations; `check:urls` — all 6 resolve; docs tests 21/21;
  prettier clean.

## Additional Context

The LLM artifacts keep the pnpm fence by construction — the plugin strips the wrapper and
leaves the code block — so `llms.txt` shows exactly what a reader sees on the default tab. No
build step involved; see `docs/CLAUDE.md`.
