### PR TITLE
docs: v3.0.0 recap, the forms mega-release

### DIFF
--- a/docs/blog/2026-08-02-v3-forms-release.md
+++ b/docs/blog/2026-08-02-v3-forms-release.md
@@ -1,0 +1,150 @@
+---
+slug: v3-forms-release
+title: 'bestax-bulma v3.0.0: The Forms Mega-Release'
+authors: [asmith]
+tags: [release, v3, forms, bulma]
+---
+
+Back in January, our [Extra Components post](/blog/extra-components) ended with a promise: DateInput, TimeInput, and Colorpicker were coming. In June, v3.0.0 delivered the date and time pickers (plus a DateTimeInput we never promised) inside a release that added about 30 new components in one shot. Two out of three ain't bad.
+
+<!-- truncate -->
+
+Some honesty up front: this is a recap, not breaking news. v3.0.0 was tagged on June 17, 2026, the library sits at 5.8.0 today, and the blog fell behind the code. This post starts a series that catches things up, one release at a time. (And no, Colorpicker hasn't shipped yet. We're not going to pretend otherwise.)
+
+## What Shipped in v3
+
+v3 was the forms release. The 2.x form story covered the basics (Input, Select, TextArea, File, Checkbox, Radio), and 3.0 filled in just about everything else:
+
+| Component                                       | What you get                                                      |
+| ----------------------------------------------- | ----------------------------------------------------------------- |
+| **DateInput**                                   | Popover calendar with segmented keyboard entry right in the field |
+| **TimeInput**                                   | Popover wheel spinner for time of day, 12-hour or 24-hour         |
+| **DateTimeInput**                               | Calendar and time wheels combined in a single popover             |
+| **Switch**                                      | Bulma switch toggle                                               |
+| **Slider**                                      | Range slider with dual-thumb mode and ticks                       |
+| **Numberinput**                                 | Number input with +/- steppers                                    |
+| **Rate**                                        | Star rating with half-star precision                              |
+| **Autocomplete**                                | Filterable suggest input                                          |
+| **Taginput**                                    | Multi-tag input with autocomplete                                 |
+| **Checkbox** and **Radio**                      | Themed styling with color and size variants                       |
+| **Checkboxes** and **Radios**                   | Optional group-state containers                                   |
+| **InputBase**, **SelectBase**, **TextAreaBase** | The bare 2.x-style elements, when you want them                   |
+
+The same release also brought a wave of UI components (Tooltip, Dialog, Toast, Steps, Sidebar, Carousel, and more) and a set of text elements, but this post sticks to the forms story. The [2.x to 3.x migration guide](/docs/guides/getting-started/migration/bulma-ui-2-to-3) has the complete list.
+
+## Native Date & Time Pickers
+
+The standout of the release. The pickers run on native `Date` and `Intl` alone: no date library in your bundle, no peer dependency to version-match, and no locale data to ship. If you've ever shipped an entire date library just so a user could pick a Tuesday, you know exactly why that matters.
+
+What that buys you:
+
+- A popover calendar for dates and a wheel spinner for times
+- Segmented keyboard entry directly in the field, so typing a date never requires the popover
+- Min/max bounds, disabled-date predicates, custom formats, locales, and an inline mode
+- A focus trap while the popover is open, and a native fallback on touch devices so phones get the platform picker
+- On TimeInput, 12-hour or 24-hour formats, optional seconds, and custom minute increments for slot-style pickers
+
+Here's a controlled DateInput clamped to the current month:
+
+```tsx live
+function DateDemo() {
+  const [date, setDate] = React.useState(null);
+  const today = new Date();
+  const min = new Date(today.getFullYear(), today.getMonth(), 1);
+  const max = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+  return (
+    <Block>
+      <DateInput
+        label="Pick a day this month"
+        placeholder="YYYY-MM-DD"
+        min={min}
+        max={max}
+        value={date}
+        onChange={setDate}
+      />
+      <Paragraph mt="2">
+        Selected: {date ? date.toDateString() : 'nothing yet'}
+      </Paragraph>
+    </Block>
+  );
+}
+```
+
+And a controlled TimeInput on the 12-hour clock:
+
+```tsx live
+function TimeDemo() {
+  const [time, setTime] = React.useState(null);
+  return (
+    <Block>
+      <TimeInput
+        label="Departure"
+        placeholder="HH:MM AM"
+        hourFormat="12"
+        value={time}
+        onChange={setTime}
+      />
+      <Paragraph mt="2">
+        Selected: {time ? time.toLocaleTimeString() : 'nothing yet'}
+      </Paragraph>
+    </Block>
+  );
+}
+```
+
+Note the `onChange`: it hands you a `Date` (or `null`), not an event, so a state setter drops straight in. When you need both halves at once, `DateTimeInput` combines the calendar and the wheels in a single popover with an iOS-style footer; click the time and the spinner floats over the calendar, which is a pretty cool trick.
+
+## Field/Control Auto-Wrap
+
+The one breaking change in v3, told straight. In 2.x, `<Input>` rendered a bare `<input class="input">`. In 3.x, `Input`, `Select`, `TextArea`, and `File` detect whether they're already inside a `<Field>` and `<Control>`, and wrap themselves when they're not:
+
+```jsx
+<Input value="hi" />
+// 2.x → <input class="input" value="hi" />
+// 3.x → <div class="field"><div class="control"><input class="input" value="hi" /></div></div>
+```
+
+Why make wrapping the default? Because `<Field><Control><Input /></Control></Field>` is the single most common pattern in Bulma forms, and once the wrapper is guaranteed, props like `label`, `message`, and `iconLeftName` can exist at all:
+
+```jsx
+<Input
+  label="Email"
+  type="email"
+  iconLeftName="envelope"
+  message="We'll never share your email."
+/>
+```
+
+Code that already wrapped its inputs keeps working (context detection skips the re-wrap), and CSS that targets `.input` still matches. If a snapshot test asserted the root element, or a layout dropped `<Input>` straight into a flex or grid container, the [migration guide](/docs/guides/getting-started/migration/bulma-ui-2-to-3) has the watch-for list. And if you want the bare element back, `InputBase`, `SelectBase`, and `TextAreaBase` render exactly what 2.x did.
+
+## Themed Checkbox & Radio
+
+`Checkbox` and `Radio` got the themed treatment: a visually hidden native input plus a custom indicator span, which unlocks color and size variants like `<Radio color="primary" size="large">`. The catch is that the indicator needs the new extras stylesheet. Upgrade without it and your radios become invisible click targets.
+
+The easy path is swapping your `bulma.css` import for `bestax.css`, a drop-in superset that bundles Bulma plus every bestax extra in one file:
+
+```jsx
+import '@allxsmith/bestax-bulma/dist/bestax.css';
+```
+
+```tsx live
+<Checkboxes>
+  <Checkbox defaultChecked>I agree to the terms</Checkbox>
+  <Checkbox color="primary">Subscribe to newsletter</Checkbox>
+  <Checkbox disabled>Disabled option</Checkbox>
+</Checkboxes>
+```
+
+`Checkboxes` and `Radios` also grew optional group state: pass `value` and `onChange` to the container and skip wiring each control. Existing JSX keeps working, since the new props are all optional.
+
+## Documentation
+
+- [Upgrading bestax-bulma 2.x to 3.x](/docs/guides/getting-started/migration/bulma-ui-2-to-3): the complete change list and every watch-for
+- [Form components guide](/docs/guides/library/form): live examples of every input
+- API references: [DateInput](/docs/api/form/datetime/dateinput), [TimeInput](/docs/api/form/datetime/timeinput), and [DateTimeInput](/docs/api/form/datetime/datetimeinput)
+
+## What's Next
+
+v3 was the first of three majors that landed in under two weeks this June, so the recaps continue: v4.0.0 (React 18 becomes the floor), then v5.0.0 (one CSS story, any prefix). After that, the series digs into bestax-migrate, building forms without a form library, and the AI loop that helps maintain this project. The full plan lives in the [blog revival tracker](https://github.com/allxsmith/bestax/issues/384).
+
+Last time we said "coming soon" it took five months, so no dates this time. Yeah, we learned.

--- a/docs/blog/2026-08-02-v3-forms-release.md
+++ b/docs/blog/2026-08-02-v3-forms-release.md
@@ -95,7 +95,9 @@ function TimeDemo() {
 Note the `onChange`: it hands you a `Date` (or `null`), not an event, so a state setter drops straight in. When you need both halves at once, `DateTimeInput` combines the calendar and the wheels in a single popover with an iOS-style footer; click the time and the spinner floats over the calendar, which is a pretty cool trick:
 
 ```tsx live
-<DateTimeInput label="Appointment" placeholder="YYYY-MM-DD HH:MM" />
+<Block>
+  <DateTimeInput label="Appointment" placeholder="YYYY-MM-DD HH:MM" />
+</Block>
 ```
 
 ## Field/Control Auto-Wrap

--- a/docs/blog/2026-08-02-v3-forms-release.md
+++ b/docs/blog/2026-08-02-v3-forms-release.md
@@ -1,6 +1,6 @@
 ---
 slug: v3-forms-release
-title: 'bestax-bulma v3.0.0: The Forms Mega-Release'
+title: The Forms Mega-Release
 authors: [asmith]
 tags: [release, v3, forms, bulma]
 ---
@@ -15,20 +15,20 @@ Some honesty up front: this is a recap, not breaking news. v3.0.0 was tagged on 
 
 v3 was the forms release. The 2.x form story covered the basics (Input, Select, TextArea, File, Checkbox, Radio), and 3.0 filled in just about everything else:
 
-| Component                                       | What you get                                                      |
-| ----------------------------------------------- | ----------------------------------------------------------------- |
-| **DateInput**                                   | Popover calendar with segmented keyboard entry right in the field |
-| **TimeInput**                                   | Popover wheel spinner for time of day, 12-hour or 24-hour         |
-| **DateTimeInput**                               | Calendar and time wheels combined in a single popover             |
-| **Switch**                                      | Bulma switch toggle                                               |
-| **Slider**                                      | Range slider with dual-thumb mode and ticks                       |
-| **Numberinput**                                 | Number input with +/- steppers                                    |
-| **Rate**                                        | Star rating with half-star precision                              |
-| **Autocomplete**                                | Filterable suggest input                                          |
-| **Taginput**                                    | Multi-tag input with autocomplete                                 |
-| **Checkbox** and **Radio**                      | Themed styling with color and size variants                       |
-| **Checkboxes** and **Radios**                   | Optional group-state containers                                   |
-| **InputBase**, **SelectBase**, **TextAreaBase** | The bare 2.x-style elements, when you want them                   |
+| Component                                                                           | What you get                                                                                                                |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [**DateInput**](/docs/api/form/datetime/dateinput)                                  | Popover calendar with segmented keyboard entry right in the field                                                           |
+| [**TimeInput**](/docs/api/form/datetime/timeinput)                                  | Popover wheel spinner for time of day, 12-hour or 24-hour                                                                   |
+| [**DateTimeInput**](/docs/api/form/datetime/datetimeinput)                          | Calendar and time wheels combined in a single popover                                                                       |
+| [**Switch**](/docs/api/form/switch)                                                 | Bulma switch toggle                                                                                                         |
+| [**Slider**](/docs/api/form/slider)                                                 | Range slider with dual-thumb mode and ticks                                                                                 |
+| [**Numberinput**](/docs/api/form/numberinput)                                       | Number input with +/- steppers                                                                                              |
+| [**Rate**](/docs/api/form/rate)                                                     | Star rating with half-star precision                                                                                        |
+| [**Autocomplete**](/docs/api/form/autocomplete)                                     | Filterable suggest input                                                                                                    |
+| [**Taginput**](/docs/api/form/taginput)                                             | Multi-tag input with autocomplete                                                                                           |
+| [**Checkbox**](/docs/api/form/checkbox) and [**Radio**](/docs/api/form/radio)       | Themed styling with color and size variants                                                                                 |
+| [**Checkboxes**](/docs/api/form/checkboxes) and [**Radios**](/docs/api/form/radios) | Optional group-state containers                                                                                             |
+| **InputBase**, **SelectBase**, **TextAreaBase**                                     | The bare 2.x-style elements, when you want them ([migration guide](/docs/guides/getting-started/migration/bulma-ui-2-to-3)) |
 
 The same release also brought a wave of UI components (Tooltip, Dialog, Toast, Steps, Sidebar, Carousel, and more) and a set of text elements, but this post sticks to the forms story. The [2.x to 3.x migration guide](/docs/guides/getting-started/migration/bulma-ui-2-to-3) has the complete list.
 
@@ -36,13 +36,13 @@ The same release also brought a wave of UI components (Tooltip, Dialog, Toast, S
 
 The standout of the release. The pickers run on native `Date` and `Intl` alone: no date library in your bundle, no peer dependency to version-match, and no locale data to ship. If you've ever shipped an entire date library just so a user could pick a Tuesday, you know exactly why that matters.
 
-What that buys you:
+What that buys you (each link lands on a live example in the API docs):
 
-- A popover calendar for dates and a wheel spinner for times
-- Segmented keyboard entry directly in the field, so typing a date never requires the popover
-- Min/max bounds, disabled-date predicates, custom formats, locales, and an inline mode
-- A focus trap while the popover is open, and a native fallback on touch devices so phones get the platform picker
-- On TimeInput, 12-hour or 24-hour formats, optional seconds, and custom minute increments for slot-style pickers
+- A [popover calendar](/docs/api/form/datetime/dateinput#basic-dateinput) for dates and a [wheel spinner](/docs/api/form/datetime/timeinput#basic-timeinput) for times
+- [Segmented keyboard entry](/docs/api/form/datetime/dateinput#manual-keyboard-entry) directly in the field, so typing a date never requires the popover
+- [Min/max bounds](/docs/api/form/datetime/dateinput#min-and-max), [disabled-date predicates](/docs/api/form/datetime/dateinput#disabled-dates), [custom formats](/docs/api/form/datetime/dateinput#custom-format), [locales](/docs/api/form/datetime/dateinput#locale), and an [inline mode](/docs/api/form/datetime/dateinput#inline)
+- A focus trap while the popover is open, with [keyboard navigation](/docs/api/form/datetime/dateinput#keyboard-navigation) fully mapped, and a [native fallback on touch devices](/docs/api/form/datetime/dateinput#mobile-native) so phones get the platform picker
+- On TimeInput, [12-hour](/docs/api/form/datetime/timeinput#12-hour-format) or [24-hour](/docs/api/form/datetime/timeinput#24-hour-format) formats, [optional seconds](/docs/api/form/datetime/timeinput#with-seconds), and [custom minute increments](/docs/api/form/datetime/timeinput#increment-steps) for slot-style pickers
 
 Here's a controlled DateInput clamped to the current month:
 
@@ -92,11 +92,15 @@ function TimeDemo() {
 }
 ```
 
-Note the `onChange`: it hands you a `Date` (or `null`), not an event, so a state setter drops straight in. When you need both halves at once, `DateTimeInput` combines the calendar and the wheels in a single popover with an iOS-style footer; click the time and the spinner floats over the calendar, which is a pretty cool trick.
+Note the `onChange`: it hands you a `Date` (or `null`), not an event, so a state setter drops straight in. When you need both halves at once, `DateTimeInput` combines the calendar and the wheels in a single popover with an iOS-style footer; click the time and the spinner floats over the calendar, which is a pretty cool trick:
+
+```tsx live
+<DateTimeInput label="Appointment" placeholder="YYYY-MM-DD HH:MM" />
+```
 
 ## Field/Control Auto-Wrap
 
-The one breaking change in v3, told straight. In 2.x, `<Input>` rendered a bare `<input class="input">`. In 3.x, `Input`, `Select`, `TextArea`, and `File` detect whether they're already inside a `<Field>` and `<Control>`, and wrap themselves when they're not:
+The one breaking change in v3, told straight. In 2.x, `<Input>` rendered a bare `<input class="input">`. In 3.x, [`Input`](/docs/api/form/input), [`Select`](/docs/api/form/select), [`TextArea`](/docs/api/form/textarea), and [`File`](/docs/api/form/file) detect whether they're already inside a `<Field>` and `<Control>`, and wrap themselves when they're not:
 
 ```jsx
 <Input value="hi" />
@@ -104,9 +108,11 @@ The one breaking change in v3, told straight. In 2.x, `<Input>` rendered a bare 
 // 3.x → <div class="field"><div class="control"><input class="input" value="hi" /></div></div>
 ```
 
+That wrapper pattern isn't something we invented, it's Bulma stuff. Bulma's form markup puts every control inside a `<div class="control">` and groups controls under a `<div class="field">` that handles spacing, labels, addons, and icons; [Bulma's own form docs](https://bulma.io/documentation/form/general/) build everything on that skeleton. Our [`Field`](/docs/api/form/field) and [`Control`](/docs/api/form/control) components render exactly that structure, so in 3.x the inputs guarantee the markup Bulma expects.
+
 Why make wrapping the default? Because `<Field><Control><Input /></Control></Field>` is the single most common pattern in Bulma forms, and once the wrapper is guaranteed, props like `label`, `message`, and `iconLeftName` can exist at all:
 
-```jsx
+```tsx live
 <Input
   label="Email"
   type="email"
@@ -114,6 +120,10 @@ Why make wrapping the default? Because `<Field><Control><Input /></Control></Fie
   message="We'll never share your email."
 />
 ```
+
+:::tip Inspect and see
+That example is live. Right-click the rendered input and hit Inspect: there's a `field` div wrapping a `control` div wrapping the `input`, and you wrote none of them.
+:::
 
 Code that already wrapped its inputs keeps working (context detection skips the re-wrap), and CSS that targets `.input` still matches. If a snapshot test asserted the root element, or a layout dropped `<Input>` straight into a flex or grid container, the [migration guide](/docs/guides/getting-started/migration/bulma-ui-2-to-3) has the watch-for list. And if you want the bare element back, `InputBase`, `SelectBase`, and `TextAreaBase` render exactly what 2.x did.
 
@@ -148,6 +158,181 @@ And the radios:
 ```
 
 `Checkboxes` and `Radios` also grew optional group state: pass `value` and `onChange` to the container and skip wiring each control. Existing JSX keeps working, since the new props are all optional.
+
+## The Rest of the Form Suite
+
+The pickers got the spotlight, but the rest of the suite pulls its weight. Every link below lands on a live example in the API docs, and every demo here is poke-able.
+
+### Switch
+
+A styled checkbox that renders as a toggle, made for settings screens.
+
+- [Colors](/docs/api/form/switch#colors), [sizes](/docs/api/form/switch#sizes), and [rounded](/docs/api/form/switch#rounded-style), [thin](/docs/api/form/switch#thin-style), and [outlined](/docs/api/form/switch#outlined-style) styles
+- [RTL layout](/docs/api/form/switch#rtl-layout) and a [controlled mode](/docs/api/form/switch#controlled-usage)
+
+```tsx live
+function SwitchDemo() {
+  const [enabled, setEnabled] = React.useState(false);
+  return (
+    <Block>
+      <Switch
+        checked={enabled}
+        onChange={e => setEnabled(e.target.checked)}
+        color="success"
+        isRounded
+      >
+        Enable notifications
+      </Switch>
+      <Paragraph mt="2">Status: {enabled ? 'Enabled' : 'Disabled'}</Paragraph>
+    </Block>
+  );
+}
+```
+
+### Slider
+
+A range slider for picking values.
+
+- [Output display](/docs/api/form/slider#with-output-display) with a [custom format](/docs/api/form/slider#custom-output-format)
+- [Custom ranges](/docs/api/form/slider#custom-range), [colors](/docs/api/form/slider#color-variants), [sizes](/docs/api/form/slider#size-variants), and [rounded or circle](/docs/api/form/slider#rounded-and-circle) thumbs
+- [Controlled](/docs/api/form/slider#controlled-mode) and [uncontrolled](/docs/api/form/slider#uncontrolled-mode) modes
+
+```tsx live
+function SliderDemo() {
+  const [value, setValue] = React.useState(50);
+  return (
+    <Block>
+      <Slider
+        value={value}
+        onChange={setValue}
+        min={0}
+        max={100}
+        showOutput
+        color="primary"
+        isRounded
+      />
+      <Paragraph mt="2">Value: {value}</Paragraph>
+    </Block>
+  );
+}
+```
+
+### Numberinput
+
+A number input with +/- stepper buttons.
+
+- [Min/max](/docs/api/form/numberinput#with-min-and-max) and a [custom step](/docs/api/form/numberinput#custom-step)
+- [Controls position](/docs/api/form/numberinput#controls-position), [colors](/docs/api/form/numberinput#color-variants), [sizes](/docs/api/form/numberinput#size-variants), and [rounded buttons](/docs/api/form/numberinput#rounded-buttons)
+
+```tsx live
+function NumberDemo() {
+  const [quantity, setQuantity] = React.useState(1);
+  return (
+    <Block>
+      <Numberinput
+        value={quantity}
+        onChange={setQuantity}
+        min={1}
+        max={10}
+        color="primary"
+      />
+      <Paragraph mt="2">Quantity: {quantity}</Paragraph>
+    </Block>
+  );
+}
+```
+
+### Rate
+
+Star ratings without hand-rolling the stars.
+
+- [Score display](/docs/api/form/rate#with-score-display) and [text labels](/docs/api/form/rate#with-text-labels) alongside the icons
+- [Custom max](/docs/api/form/rate#custom-max-value), [custom icons](/docs/api/form/rate#custom-icons), and [sizes](/docs/api/form/rate#size-variants)
+
+```tsx live
+function RateDemo() {
+  const [rating, setRating] = React.useState(3);
+  return (
+    <Block>
+      <Rate
+        value={rating}
+        onChange={setRating}
+        showScore
+        showText
+        texts={['Poor', 'Fair', 'Average', 'Good', 'Excellent']}
+      />
+    </Block>
+  );
+}
+```
+
+### Autocomplete
+
+An input with filtered dropdown suggestions and keyboard navigation.
+
+- [Open on focus](/docs/api/form/autocomplete#open-on-focus), a [clear button](/docs/api/form/autocomplete#with-clear-button), and [keep-first highlighting](/docs/api/form/autocomplete#keep-first-highlighted)
+- [Object data](/docs/api/form/autocomplete#with-object-data), [custom item templates](/docs/api/form/autocomplete#custom-item-template), and [loading](/docs/api/form/autocomplete#loading-state) and [empty](/docs/api/form/autocomplete#with-empty-state) states
+
+```tsx live
+function AutocompleteDemo() {
+  const [selected, setSelected] = React.useState(null);
+  const fruits = [
+    'Apple',
+    'Banana',
+    'Cherry',
+    'Date',
+    'Elderberry',
+    'Fig',
+    'Grape',
+  ];
+  return (
+    <Block>
+      <Autocomplete
+        data={fruits}
+        placeholder="Search fruit..."
+        onSelect={setSelected}
+        openOnFocus
+        clearable
+      />
+      {selected && <Paragraph mt="2">Selected: {selected}</Paragraph>}
+    </Block>
+  );
+}
+```
+
+### Taginput
+
+A tag and chip input for managing multiple values.
+
+- [Autocomplete suggestions](/docs/api/form/taginput#with-autocomplete), optionally [restricted to the list](/docs/api/form/taginput#restrict-to-suggestions)
+- [Max tags](/docs/api/form/taginput#maximum-tags), [duplicate control](/docs/api/form/taginput#allow-duplicates), and [custom confirm keys](/docs/api/form/taginput#custom-confirm-keys)
+- [Tag colors](/docs/api/form/taginput#tag-colors) and [non-closable tags](/docs/api/form/taginput#non-closable-tags)
+
+```tsx live
+function TaginputDemo() {
+  const [tags, setTags] = React.useState(['React', 'TypeScript']);
+  const suggestions = [
+    'React',
+    'Vue',
+    'Angular',
+    'Svelte',
+    'TypeScript',
+    'JavaScript',
+  ];
+  return (
+    <Block>
+      <Taginput
+        value={tags}
+        onChange={setTags}
+        data={suggestions}
+        placeholder="Add frameworks..."
+        tagColor="primary"
+      />
+      <Paragraph mt="2">Tags: {tags.join(', ')}</Paragraph>
+    </Block>
+  );
+}
+```
 
 ## Documentation
 

--- a/docs/blog/2026-08-02-v3-forms-release.md
+++ b/docs/blog/2026-08-02-v3-forms-release.md
@@ -127,12 +127,24 @@ The easy path is swapping your `bulma.css` import for `bestax.css`, a drop-in su
 import '@allxsmith/bestax-bulma/dist/bestax.css';
 ```
 
+Here's what the checkboxes look like once the CSS is loaded:
+
 ```tsx live
 <Checkboxes>
   <Checkbox defaultChecked>I agree to the terms</Checkbox>
   <Checkbox color="primary">Subscribe to newsletter</Checkbox>
   <Checkbox disabled>Disabled option</Checkbox>
 </Checkboxes>
+```
+
+And the radios:
+
+```tsx live
+<Radios name="answer">
+  <Radio defaultChecked>Yes</Radio>
+  <Radio>No</Radio>
+  <Radio disabled>Maybe</Radio>
+</Radios>
 ```
 
 `Checkboxes` and `Radios` also grew optional group state: pass `value` and `onChange` to the container and skip wiring each control. Existing JSX keeps working, since the new props are all optional.

--- a/docs/blog/CLAUDE.md
+++ b/docs/blog/CLAUDE.md
@@ -1,8 +1,69 @@
-# blog — posts, and the "The State of React" series
+# blog — voice, post conventions, and the "The State of React" series
 
-General blog conventions live in `docs/CLAUDE.md` (frontmatter, `authors.yml`, the
-`<!-- truncate -->` fold, and dev.to syndication via `plugins/devto-preprocessor.js`). This file
-is the **runbook for the recurring component-comparison series** so each edition is turnkey.
+This file owns how posts get written here: the voice, the general post conventions, and (in the
+back half) the runbook for the recurring component-comparison series. Site-wide build rules and
+the LLM docs pipeline live in `docs/CLAUDE.md`.
+
+## Voice & style (all posts)
+
+Posts are written in Alex's voice. The register is conversational; the copy is clean. When in
+doubt, reread the `:::info` admonition in the v2 release post (owning the accidental 2.0.0
+version bump) and the intro of the first State of React edition: candid, plain, direct.
+
+- **Get to the point.** The first sentence of the post, and of most sections, states the point.
+  Background comes after, briefly, as a "why" before the "what".
+- **Conversational register.** Contractions always. Short plain sentences. Write to one reader,
+  not an audience. A rhetorical question is a good move ("So which one do you import?"), about
+  one per post. Casual markers are welcome where they'd land in speech: "cool", "yeah",
+  "kinda", "pretty" as an intensifier.
+- **Candid, not salesy.** Own mistakes and rough edges plainly, the way the v2 post owns its
+  accidental major bump. Never open with "We're excited to announce" (the pre-guide posts do;
+  don't copy them). No superlatives, no hype adjectives. If a thing shipped late, say it
+  shipped late.
+- **Work all three appeals.** A post should persuade on ethos, pathos, and logos together.
+  _Ethos_: write from first-hand maintainer experience, link your sources, and own the
+  mistakes (the candor above is the credibility play). _Pathos_: name the pain a change
+  removes and the small joy it adds; let the humor and era nods carry feeling, and never
+  manufacture drama. _Logos_: back every claim with a reason, a number, a table, or runnable
+  code (a live demo is an argument the reader can poke). Before publishing, check the draft
+  lands all three: all logos reads like a changelog, and all pathos reads like marketing.
+- **Structure the middle.** Hyphen bullets for detail dumps, numbered lists only for ordered
+  procedures, bold on the load-bearing word, section headings even in medium-length posts.
+- **MLA conventions.** MLA title case for the post title and headings (first word, last word,
+  and all principal words capitalized; articles, prepositions, and coordinating conjunctions
+  lowercase). Serial comma. Italicize standalone-work titles (_The State of React_). Cite by
+  linking. Product tokens keep their branding (`bestax-bulma`, v3, pnpm) even in titles.
+- **No em dashes. Ever.** Use a comma, parentheses, or a period instead. This covers prose,
+  headings, and string literals inside demos (no `'—'` placeholder text). Older posts and the
+  docs tree use them; leave those alone. The rule governs new blog writing.
+- **Era references, sparingly.** Alex grew up in the 80s, 90s, and early 00s (NES, arcades,
+  dial-up, mixtapes). One reference that genuinely fits beats three that don't; zero is fine.
+- **Clean mechanics.** Casual voice, boring spelling. Proofread and prettier-format; the fast
+  loose typos of email and chat don't ship.
+
+## Post conventions (all posts)
+
+- **File naming:** `docs/blog/YYYY-MM-DD-slug.md`, or the folder form `YYYY-MM-DD-slug/index.md`
+  when the post ships images. The date prefix is the publish date; there is no `date:`
+  frontmatter field. If a PR merges after the date in its filename, rename before merging.
+- **Frontmatter:** `slug`, `title` (quote it when it contains a colon), `authors: [asmith]`
+  (the only entry in `authors.yml`), and inline `tags: [...]`. `onInlineTags: 'ignore'` means a
+  new tag needs no `tags.yml` entry; add one only for a custom label/permalink/description.
+  dev.to syndication is opt-in: `publish_to_devto: true` plus a `cover_image`
+  (`plugins/devto-preprocessor.js` skips posts without the flag).
+- **The fold:** `<!-- truncate -->` goes after a 1–3 sentence hook (the config warns when it's
+  missing). A leading `:::info` admonition sits above the fold when the post needs one.
+- **Live examples:** ` ```tsx live ` fences. Every library export plus `React`, `useState`, and
+  `useEffect` is already in scope (`docs/src/theme/CodeBlock/index.js` spreads the whole
+  package into react-live; import lines are stripped anyway). No inline `style={{}}`; use
+  `Block`/helper props, and space children with `m*`/`p*` (there is no `gap` helper).
+- **Links:** internal links are absolute (`/docs/...`, `/blog/...`); `onBrokenLinks: 'throw'`
+  build-validates every one.
+- **Verify:** `pnpm format`, then `pnpm exec turbo run build --filter=@allxsmith/bestax-docs`,
+  then `pnpm format:check`. Commits and PR titles use the non-releasing `docs` type.
+
+The rest of this file is the **runbook for the recurring component-comparison series** so each
+edition is turnkey.
 
 ## What the series is
 


### PR DESCRIPTION
## Summary

Two commits:

- **`docs/blog/CLAUDE.md`**: adds a "Voice & style" guide (register, MLA conventions, no em dashes, the ethos/pathos/logos check, era references used sparingly) and a general "Post conventions" section (file naming, frontmatter, the truncate fold, live code blocks, link rules, verify commands). The State of React runbook below is unchanged; the stale pointer claiming general conventions live in `docs/CLAUDE.md` is fixed.
- **`docs/blog/2026-08-02-v3-forms-release.md`**: the v3.0.0 recap post per the issue spec. The hook calls back to the January Extra Components "coming soon" promise, the framing is an honest recap (tagged 2026-06-17, library at 5.8.0 today), the sections follow the prescribed structure, and there are two `tsx live` demos: a controlled DateInput clamped to the current month via min/max, and a controlled TimeInput on the 12-hour clock.

## Acceptance criteria (from #373)

- [x] Post builds cleanly (`pnpm exec turbo run build --filter=@allxsmith/bestax-docs`)
- [x] `pnpm format:check` passes (both files prettier-clean)
- [x] `<!-- truncate -->` present after the 3-sentence hook
- [x] `authors: [asmith]`
- [x] Every claim traces to the named sources; Colorpicker is never claimed as shipped (the post says so outright)
- [x] All in-post doc links resolve (`onBrokenLinks: 'throw'` build passed)

## Notes

- If this merges after 2026-08-02, rename the post's date prefix to the actual publish date (issue requirement).
- Follow-up worth filing separately: the 2.x to 3.x migration guide's "What's new" table omits DateInput/TimeInput/DateTimeInput even though they shipped in 3.0.0, so the post cites the form guide and component source for picker claims instead.

Closes #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a v3.0.0 release recap covering expanded form components, native date/time pickers, auto-wrapping, themed controls, grouped state, and migration guidance.
  * Included interactive examples for date inputs, time inputs, and grouped checkboxes.
  * Expanded blog-writing guidance for style, naming, frontmatter, live examples, links, and content verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->