### PR TITLE
docs: codify the framing, lint, and reviewer lessons from #471

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,14 @@ green and every AI review thread is resolved.
   an auto-applied `claude-assisted` provenance label.
 - **Deep review on demand:** a triage+ user can apply the opt-in `deep-review` label to any
   PR to run the Claude deep review on it (re-applying the label re-runs it; a
-  `deep-review:`-prefixed PR comment from a triage+ user pre-steers its focus).
+  `deep-review:`-prefixed PR comment from a triage+ user pre-steers its focus). Its output
+  lands as a PR review from `claude` marked `<!-- claude-deep-review -->`, tied to the head
+  sha it started from — after later pushes, look for that review, not the current head's
+  checks.
+- **Reviewer mechanics:** CodeRabbit reviews incrementally and rate-limits on OSS — after a
+  "review limit reached" skip nothing retries on its own; push a commit or have a triage+
+  user comment `@coderabbitai review` once the window resets. Copilot also auto-reviews PRs
+  and re-reviews on push.
 - **State comment:** the `<!-- ai-loop-state … -->` PR comment is machine-managed — never
   reformat its first line.
 - **Refusals:** the loop refuses PRs that touch `.github/**` or the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,13 +105,14 @@ green and every AI review thread is resolved.
 - **Deep review on demand:** a triage+ user can apply the opt-in `deep-review` label to any
   PR to run the Claude deep review on it (re-applying the label re-runs it; a
   `deep-review:`-prefixed PR comment from a triage+ user pre-steers its focus). Its output
-  lands as a PR review from `claude` marked `<!-- claude-deep-review -->`, tied to the head
-  sha it started from — after later pushes, look for that review, not the current head's
-  checks.
-- **Reviewer mechanics:** CodeRabbit reviews incrementally and rate-limits on OSS — after a
-  "review limit reached" skip nothing retries on its own; push a commit or have a triage+
-  user comment `@coderabbitai review` once the window resets. Copilot also auto-reviews PRs
-  and re-reviews on push.
+  lands as a PR review from `claude` marked `<!-- claude-deep-review -->`; it reviewed the
+  code checked out when its workflow started, which a racing push may have superseded — so
+  look for that review comment (not the current head's checks) and verify its findings
+  against current code.
+- **Reviewer mechanics:** CodeRabbit reviews incrementally and rate-limits on OSS. After it
+  posts "review limit reached" it will not retry on its own; once the window resets, push a
+  commit or comment `@coderabbitai review`. Copilot also auto-reviews PRs and re-reviews on
+  push.
 - **State comment:** the `<!-- ai-loop-state … -->` PR comment is machine-managed — never
   reformat its first line.
 - **Refusals:** the loop refuses PRs that touch `.github/**` or the

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -110,8 +110,9 @@ it, so a novel non-standard `package.json` key and extra release churn weren't w
 - Markdown is prettier-formatted (`pnpm format:check` covers `md`/`mdx`).
 - Scripts in `docs/scripts/` are covered by the root `pnpm lint` — run it before pushing even
   a docs-only PR (#471 broke CI on exactly this). Playwright `page.evaluate` callbacks
-  execute in the browser, so declare `/* global document, getComputedStyle */` the way
-  `rasterize-cover.mjs` and bulma-ui's `capture-stories.mjs` do — and when a script already
+  execute in the browser, so declare the browser globals each callback actually uses
+  (`/* global document */` in bulma-ui's `capture-stories.mjs`;
+  `/* global document, getComputedStyle */` in `rasterize-cover.mjs`) — and when a script already
   has the page open, validate through the parsed DOM and computed styles, not regexes over
   the source (quoting, `data-*` attributes, and transparent paint all fool regexes; two
   review rounds proved it).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -108,3 +108,10 @@ it, so a novel non-standard `package.json` key and extra release churn weren't w
   `docusaurus.config.js` does not override it. That is load-bearing but easy to miss: setting
   `format: 'detect'` would make every `.md` page render its tags as literal text.
 - Markdown is prettier-formatted (`pnpm format:check` covers `md`/`mdx`).
+- Scripts in `docs/scripts/` are covered by the root `pnpm lint` — run it before pushing even
+  a docs-only PR (#471 broke CI on exactly this). Playwright `page.evaluate` callbacks
+  execute in the browser, so declare `/* global document, getComputedStyle */` the way
+  `rasterize-cover.mjs` and bulma-ui's `capture-stories.mjs` do — and when a script already
+  has the page open, validate through the parsed DOM and computed styles, not regexes over
+  the source (quoting, `data-*` attributes, and transparent paint all fool regexes; two
+  review rounds proved it).

--- a/docs/blog/CLAUDE.md
+++ b/docs/blog/CLAUDE.md
@@ -20,6 +20,13 @@ version bump) and the intro of the first State of React edition: candid, plain, 
   accidental major bump. Never open with "We're excited to announce" (the pre-guide posts do;
   don't copy them). No superlatives, no hype adjectives. If a thing shipped late, say it
   shipped late.
+- **Sell what the reader keeps, never the absence.** When the angle is something the library
+  deliberately omits (no form library, no date library), state the stance once, factually,
+  with the reasons, then let demos carry the argument: lead with what the reader keeps, name
+  competing libraries neutrally, and include an explicit bring-your-own path. Titles too:
+  "Form Library Agnostic" shipped over "Building Forms Without a Form Library" because
+  absence-titles read as missing features (#471). The v3 post's "no date library in your
+  bundle" paragraph is the model.
 - **Work all three appeals.** A post should persuade on ethos, pathos, and logos together.
   _Ethos_: write from first-hand maintainer experience, link your sources, and own the
   mistakes (the candor above is the credibility play). _Pathos_: name the pain a change


### PR DESCRIPTION
Follow-up to #471 (merged before this landed on its branch). Three small contract additions distilled from shipping the Form Library Agnostic post, so the next agent gets there faster:

- **`docs/blog/CLAUDE.md`** (voice): sell what the reader keeps, never the absence — stance stated once with reasons, neutral naming, an explicit bring-your-own path, and absence-free titles. Both framing corrections on #471 were this same lesson.
- **`docs/CLAUDE.md`** (conventions): `docs/scripts/` is covered by root `pnpm lint` even on docs-only PRs (#471 broke CI on exactly this); Playwright `page.evaluate` callbacks need `/* global … */` declarations; and a script that already has the page open should validate via the parsed DOM and computed styles, not source regexes.
- **`CLAUDE.md`** (AI development loop): where the deep review output lands (`claude` PR review, `<!-- claude-deep-review -->`, tied to its starting sha) and how CodeRabbit's rate-limited incremental reviews resume (push, or triage+ `@coderabbitai review`).

Deliberately excluded as issue-specific: cover-art technique, the hero pipeline and syndication flow (already codified in-PR on #471), and anything the `rasterize-cover.mjs` comments now carry. `skills/CLAUDE.md` needs no rule change; the `bestax-form` SignupForm bug found during #471 gets its own `fix(create-bestax)` PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded AI development guidance for review feedback, attribution, commit tracking, rate limits, and automated review behavior.
  * Added documentation testing conventions, including linting, browser global declarations, and DOM-based validation.
  * Updated blog-writing guidance to focus on retained value, factual reasoning, neutral alternatives, and practical user paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->