### PR TITLE
chore: force patched js-yaml for CVE-2026-59870

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,8 @@ overrides:
   undici@7: '>=7.29.0 <8'
   minimatch@9: '>=9.0.7 <10'
   yaml@2: '>=2.8.3'
+  js-yaml@3: '>=3.15.1 <4'
+  js-yaml@4: '>=4.3.1 <5'
 
 importers:
 
@@ -6877,12 +6879,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jscodeshift@17.4.0:
@@ -10240,7 +10242,7 @@ snapshots:
 
   '@11ty/gray-matter@1.0.0':
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -12065,7 +12067,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.4.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -12708,7 +12710,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(postcss@8.5.21)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       fs-extra: 11.3.5
       joi: 17.13.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -12742,7 +12744,7 @@ snapshots:
       github-slugger: 1.5.0
       globby: 11.1.0
       jiti: 1.21.7
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -12783,7 +12785,7 @@ snapshots:
       github-slugger: 1.5.0
       globby: 11.1.0
       jiti: 1.21.7
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -13225,7 +13227,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -16129,7 +16131,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -16139,7 +16141,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -17360,7 +17362,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -18378,12 +18380,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,11 +32,6 @@ minimumReleaseAge: 4320
 # (which would cause recurring reformat churn). Not shipped to users.
 minimumReleaseAgeExclude:
   - prettier
-  # undici 7.29.0 (published 2026-08-03) is the only release patching
-  # GHSA-4cwx-7wf7-3272 and is younger than the cooldown. Exact-version
-  # selector so no other undici release skips the cooldown; drop this entry
-  # once 7.29.0 is older than the cooldown (after 2026-08-06).
-  - 'undici@7.29.0'
 
 # Pin a single prettier version workspace-wide so eslint-plugin-prettier and
 # `prettier --check` never disagree (patch versions format union types
@@ -96,6 +91,16 @@ overrides:
   # Prune both once the plugin widens its ranges again.
   'minimatch@9': '>=9.0.7 <10'
   'yaml@2': '>=2.8.3'
+  # Force patched js-yaml per major — high advisory GHSA-5p4m-2wfm-xmqj
+  # (CVE-2026-59870): quadratic CPU consumption resolving !!omap. The 3.x copy
+  # rides the jest coverage chain (babel-plugin-istanbul >
+  # @istanbuljs/load-nyc-config); the 4.x copies ride cosmiconfig (commitlint,
+  # semantic-release) and the Docusaurus frontmatter pipeline. Both patched
+  # releases (2026-07-31) are already older than the cooldown, and every parent
+  # range admits them — the lockfile just predates them. Prune each entry once
+  # its line resolves to >=3.15.1 / >=4.3.1 without the force.
+  'js-yaml@3': '>=3.15.1 <4'
+  'js-yaml@4': '>=4.3.1 <5'
 
 # Strict, symlinked node_modules prevents phantom dependencies (using packages
 # we never declared). Narrow public hoists only for tooling that needs a flat


### PR DESCRIPTION
## What

`pnpm audit --audit-level=high` started failing on every branch (including docs-only PR #478) when GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 was published: js-yaml quadratic CPU consumption resolving `!!omap`, affecting both majors in our tree.

- **js-yaml 3.x** (needs ≥3.15.1) — rides the jest coverage chain (`babel-plugin-istanbul > @istanbuljs/load-nyc-config`)
- **js-yaml 4.x** (needs ≥4.3.1) — rides cosmiconfig (commitlint, semantic-release) and the Docusaurus frontmatter pipeline (~100 paths)

Every parent range already admits the patched releases; the lockfile just predates them (both published 2026-07-31, so already older than the 3-day cooldown — no `minimumReleaseAgeExclude` entry needed). Following the established overrides pattern in `pnpm-workspace.yaml`, this adds per-major scoped forces with the advisory documented and a prune condition:

```yaml
'js-yaml@3': '>=3.15.1 <4'
'js-yaml@4': '>=4.3.1 <5'
```

Also drops the `undici@7.29.0` cooldown-exclude entry, exactly as its own comment schedules ("drop this entry once 7.29.0 is older than the cooldown (after 2026-08-06)"); the `undici@7` override itself stays.

## Verification

- `pnpm install` re-resolves cleanly; the lockfile now carries exactly `js-yaml@3.15.1` and `js-yaml@4.3.1` (only additions, no other resolution changes).
- `pnpm audit --audit-level=high` exits 0 (remaining advisories: 1 low, 7 moderate — below the gate).
- Full `pnpm all` gate green: build, typecheck, tests + coverage, bundle stats, lint, format check, storybook build.

Dev/build tooling only; js-yaml is not a dependency of the published packages, so this is non-releasing (`chore`). Unblocks #478, which I'll refresh against main once this lands.