### PR TITLE
feat(docs): show all posts in the blog sidebar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -55,6 +55,8 @@ const config = {
         },
         blog: {
           showReadingTime: true,
+          blogSidebarCount: 'ALL',
+          blogSidebarTitle: 'All posts',
           // Docusaurus globs every markdown file in blog/ as a post. Keep the
           // default exclusions and also skip CLAUDE.md (an agent runbook that
           // lives in blog/, not a post).

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -71,7 +71,7 @@ pre.prism-code {
 }
 
 /* "The State of React" comparison posts: give the wide table room by
-   collapsing the blog "Recent posts" sidebar. The right-hand table of contents
+   collapsing the blog "All posts" sidebar. The right-hand table of contents
    is removed per-post via `hide_table_of_contents: true` in the frontmatter.
    Scoped with :has() to posts that actually render <ComponentComparison /> (the
    `.sor-comparison` root), so it is flash-free (present at SSR) and never


### PR DESCRIPTION
## Summary

The blog sidebar was titled "Recent posts" and capped at 5 entries — the
`blog` block in `docs/docusaurus.config.js` never set `blogSidebarCount`,
so it inherited the `@docusaurus/plugin-content-blog` default of `5`. With
20 published posts, three quarters of the blog was unreachable from the
sidebar, and older posts fell off permanently as new ones published.

## Changes

- `docs/docusaurus.config.js`: set `blogSidebarCount: 'ALL'` (a literal
  supported by the installed Docusaurus 3.10.2) so the sidebar always
  lists every post, and `blogSidebarTitle: 'All posts'` since "Recent
  posts" is no longer accurate.
- `docs/src/css/custom.css`: updated a comment referencing "Recent posts"
  by name to match the new title (the CSS rule itself — hiding the
  sidebar on "The State of React" comparison posts — is unaffected, since
  it's scoped by `:has(.sor-comparison)` rather than item count).

## Verification

- `pnpm exec turbo run build --filter=@allxsmith/bestax-docs` — built
  successfully; confirmed in `docs/build/blog.html` that the sidebar
  title is "All posts" and lists all posts (no longer capped at 5).
- Confirmed `docs/build/blog/state-of-react-2026-07.html` still renders
  `.sor-comparison`, and the `:has(.sor-comparison) aside` CSS rule is
  present in the built stylesheet, so the wide-table override still
  applies independent of item count.
- `pnpm run lint`, `pnpm run format:check`, `pnpm run gen:catalog:check`,
  `pnpm run check:conformance` all pass.

No component/API changes, so no story, Jest test, or API doc updates
were needed — this is a Docusaurus preset config change plus a matching
comment update.

Fixes #483

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the blog sidebar to display all posts under the “All posts” label.
  * Updated the comparison-post guidance to reference collapsing the “All posts” sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->