### PR TITLE
ci: release bestax-mcp from the pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,3 +294,13 @@ jobs:
         run: |
           git log -1 --show-signature
           pnpm exec semantic-release
+
+      - name: Semantic Release (bestax-mcp)
+        working-directory: bestax-mcp
+        env:
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git log -1 --show-signature
+          pnpm exec semantic-release

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -12,7 +12,9 @@ The source of truth is the `releaseRules` in each package's semantic-release con
 
 ## Release Rules
 
-A commit releases **only** the package its scope names:
+A commit releases **only** the package its scope names. Representative examples — the same
+`feat`/`fix`/`perf`/`refactor`/`style` and `BREAKING CHANGE:` rules apply to every package
+through its own scope:
 
 | Commit                                                            | bestax-bulma | create-bestax | bestax-migrate | bestax-mcp |
 | ----------------------------------------------------------------- | ------------ | ------------- | -------------- | ---------- |
@@ -29,10 +31,16 @@ Notes:
 
 - **Breaking changes require a `BREAKING CHANGE:` footer** in the commit body. The angular
   commit-analyzer preset does **not** parse `feat(bulma-ui)!:` bang headers.
-- Commits of a releasing type (`feat`, `fix`, `perf`, `refactor`, `style`) **must** carry a
-  scope of `bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, or `bestax-mcp` — enforced by commitlint
-  ([`commitlint.config.js`](./commitlint.config.js)) via the husky `commit-msg` hook. This is
-  what guarantees the per-scope release rules can't be bypassed by an unscoped commit.
+- Commits of a releasing type (`feat`, `fix`, `perf`, `refactor`, `style`, `revert`) **must**
+  carry a scope of `bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, or `bestax-mcp` —
+  enforced by commitlint ([`commitlint.config.js`](./commitlint.config.js)) via the husky
+  `commit-msg` hook. This is what guarantees the per-scope release rules can't be bypassed by
+  an unscoped commit.
+- `revert` is scope-gated too: commit-analyzer's default rules ship
+  `{ revert: true, release: 'patch' }`, so an unscoped revert would patch-release **every**
+  package. A scoped `revert(bulma-ui): …` patch-releases only its package. Caveat: commitlint's
+  default ignores skip git-revert-style `Revert "…"` messages entirely, so keep reverts in
+  conventional form.
 - A commit scoped to `docs` never releases any package.
 
 ## Tags & Changelogs

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,36 +1,39 @@
 # Independent Versioning Strategy
 
-`@allxsmith/bestax-bulma` and `create-bestax` are versioned and released **independently**.
-Each package releases only when a commit is scoped to it — the two version numbers are
-unrelated (e.g. bestax-bulma 5.x alongside create-bestax 3.x).
+`@allxsmith/bestax-bulma`, `create-bestax`, `bestax-migrate`, and `bestax-mcp` are versioned
+and released **independently**. Each package releases only when a commit is scoped to it — the
+version numbers are unrelated (e.g. bestax-bulma 5.x alongside create-bestax 3.x).
 
 The source of truth is the `releaseRules` in each package's semantic-release config:
-[`bulma-ui/release.config.js`](./bulma-ui/release.config.js) and
-[`create-bestax/release.config.js`](./create-bestax/release.config.js).
+[`bulma-ui/release.config.js`](./bulma-ui/release.config.js),
+[`create-bestax/release.config.js`](./create-bestax/release.config.js),
+[`bestax-migrate/release.config.js`](./bestax-migrate/release.config.js), and
+[`bestax-mcp/release.config.js`](./bestax-mcp/release.config.js).
 
 ## Release Rules
 
 A commit releases **only** the package its scope names:
 
-| Commit                                                            | bestax-bulma | create-bestax |
-| ----------------------------------------------------------------- | ------------ | ------------- |
-| `feat(bulma-ui): …`                                               | minor        | —             |
-| `fix(bulma-ui): …`                                                | patch        | —             |
-| `perf/refactor/style(bulma-ui): …`                                | patch        | —             |
-| `feat(create-bestax): …`                                          | —            | minor         |
-| `fix(create-bestax): …`                                           | —            | patch         |
-| `feat(bulma-ui): …` + `BREAKING CHANGE:` footer                   | major        | —             |
-| `docs: …`, `chore: …`, `ci: …`, `test: …`, `build: …` (any scope) | —            | —             |
+| Commit                                                            | bestax-bulma | create-bestax | bestax-migrate | bestax-mcp |
+| ----------------------------------------------------------------- | ------------ | ------------- | -------------- | ---------- |
+| `feat(bulma-ui): …`                                               | minor        | —             | —              | —          |
+| `fix(bulma-ui): …`                                                | patch        | —             | —              | —          |
+| `perf/refactor/style(bulma-ui): …`                                | patch        | —             | —              | —          |
+| `feat(create-bestax): …`                                          | —            | minor         | —              | —          |
+| `fix(bestax-migrate): …`                                          | —            | —             | patch          | —          |
+| `feat(bestax-mcp): …`                                             | —            | —             | —              | minor      |
+| `feat(bulma-ui): …` + `BREAKING CHANGE:` footer                   | major        | —             | —              | —          |
+| `docs: …`, `chore: …`, `ci: …`, `test: …`, `build: …` (any scope) | —            | —             | —              | —          |
 
 Notes:
 
 - **Breaking changes require a `BREAKING CHANGE:` footer** in the commit body. The angular
   commit-analyzer preset does **not** parse `feat(bulma-ui)!:` bang headers.
 - Commits of a releasing type (`feat`, `fix`, `perf`, `refactor`, `style`) **must** carry a
-  scope of `bulma-ui`, `docs`, or `create-bestax` — enforced by commitlint
+  scope of `bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, or `bestax-mcp` — enforced by commitlint
   ([`commitlint.config.js`](./commitlint.config.js)) via the husky `commit-msg` hook. This is
   what guarantees the per-scope release rules can't be bypassed by an unscoped commit.
-- A commit scoped to `docs` never releases either package.
+- A commit scoped to `docs` never releases any package.
 
 ## Tags & Changelogs
 
@@ -38,6 +41,8 @@ Each package tags and logs its own releases:
 
 - `@allxsmith/bestax-bulma@X.Y.Z` tags, changelog at `bulma-ui/CHANGELOG.md`
 - `create-bestax@X.Y.Z` tags, changelog at `create-bestax/CHANGELOG.md`
+- `bestax-migrate@X.Y.Z` tags, changelog at `bestax-migrate/CHANGELOG.md`
+- `bestax-mcp@X.Y.Z` tags, changelog at `bestax-mcp/CHANGELOG.md`
 
 ## Release Process
 
@@ -47,7 +52,7 @@ On merge to `main`, CI (`.github/workflows/ci.yml`) runs semantic-release in eac
 2. If a release is due: version bump, `CHANGELOG.md` update, npm publish (OIDC trusted
    publishing — no `NPM_TOKEN`), a signed `chore(release): X.Y.Z [skip ci]` commit, git tag,
    and GitHub release.
-3. A push may release one package, both, or neither — they never bump each other.
+3. A push may release any subset of the packages — they never bump each other.
 
 `main` is ruleset-protected, so the release commit and tag are pushed by a dedicated
 GitHub App that is the ruleset's only automation bypass — not by `github-actions[bot]`.

--- a/bestax-mcp/data/catalog.json
+++ b/bestax-mcp/data/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedFrom": { "package": "@allxsmith/bestax-bulma", "version": "5.9.0" },
+  "generatedFrom": { "package": "@allxsmith/bestax-bulma", "version": "5.9.1" },
   "docsBase": "https://bestax.io/docs",
   "categories": [
     {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,9 +1,13 @@
 // Types that trigger a semantic-release in the per-package release configs
-// (bulma-ui/release.config.js, create-bestax/release.config.js). Those
-// configs key releases off the scope, and unscoped commits of these types
-// would fall back to the angular defaults and bump BOTH packages — so a
-// recognized scope is mandatory here.
-const RELEASE_TYPES = ['feat', 'fix', 'perf', 'refactor', 'style'];
+// (each package's release.config.js). Those configs key releases off the
+// scope, and unscoped commits of these types would fall back to the angular
+// defaults and bump EVERY package — so a recognized scope is mandatory here.
+// `revert` is included because commit-analyzer's default rules ship
+// `{ revert: true, release: 'patch' }`: an unscoped revert matches no
+// package's negated-scope suppression and would patch-release all of them.
+// (Residual: commitlint's default ignores skip git-revert-style
+// `Revert "..."` messages entirely — keep reverts conventional and scoped.)
+const RELEASE_TYPES = ['feat', 'fix', 'perf', 'refactor', 'style', 'revert'];
 const RELEASE_SCOPES = [
   'bulma-ui',
   'docs',


### PR DESCRIPTION
## What

Adds the missing **Semantic Release (bestax-mcp)** step to `ci.yml`'s release job, and updates `VERSIONING.md` (which still described the two-package world) to cover `bestax-migrate` and `bestax-mcp` in the intro, release-rules table, commitlint scope list, and tag/changelog roster.

## Security review notes (per .github/CLAUDE.md)

- The new step is an **exact mirror** of the three existing Semantic Release steps: same GPG committer setup, same one-hour app token (minted after install/build so repo-owned build code never sees it), OIDC trusted publishing with no `NPM_TOKEN`.
- **No allowlist grows, no new action, no new credential, no permissions change.** No model session is involved in this job.
- `bestax-mcp/release.config.js` already scopes releases strictly to `bestax-mcp`-scoped commits (`scope: '!(bestax-mcp)' → release: false`), and commitlint already includes the scope, so this cannot bump any other package.

## Sequencing

Merge **after** the npm-side Trusted Publisher for `bestax-mcp` is configured (repo `allxsmith/bestax`, workflow `ci.yml`) — otherwise the first publish fails auth. On the first `main` run after merge, semantic-release finds no `bestax-mcp@*` tag and publishes **1.0.0** with provenance, superseding the manually claimed `0.0.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing for the `bestax-mcp` package.
  * Enabled independent releases for `bestax-migrate` and `bestax-mcp`.

* **Documentation**
  * Updated versioning guidance with package-specific release rules, tags, changelogs, and commit scopes.
  * Clarified that each push may release one or more packages independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->