### PR TITLE
docs: settle the bestax-migrate bundling call, create-bestax ships it

### DIFF
--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -75,8 +75,9 @@ the component library), and `scripts/pack-manifest.mjs` resolves any remaining
 left in `devDependencies` only with the pack hooks present. It does **not**
 check which section `@allxsmith/bestax-bulma` sits in — re-adding it as a
 plain-semver runtime dependency passes CI, so that one is on review. The skill lives at repo-root
-`skills/bestax-migrate/`. Whether it bundles into create-bestax is contested: the original
-policy was existing-sites-only, but `sync-skills.mjs` has shipped it since #345 — see #385
-and don't change either side ahead of that call. When the mapping
-gains or loses coverage, update `skills/bestax-migrate/references/` and the docs migration
-guide in the same PR.
+`skills/bestax-migrate/`. It **is** bundled into create-bestax (settled in #385): the
+original existing-sites-only policy lost to one uniform bundle, and the skill sits idle
+in a fresh scaffold until legacy imports show up. Keep `sync-skills.mjs`, the `CLAUDE_MD`
+roster in `create-bestax/src/constants.ts`, and the docs skills pages in agreement. When
+the mapping gains or loses coverage, update `skills/bestax-migrate/references/` and the
+docs migration guide in the same PR.

--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -77,7 +77,7 @@ check which section `@allxsmith/bestax-bulma` sits in — re-adding it as a
 plain-semver runtime dependency passes CI, so that one is on review. The skill lives at repo-root
 `skills/bestax-migrate/`. It **is** bundled into create-bestax (settled in #385): the
 original existing-sites-only policy lost to one uniform bundle, and the skill sits idle
-in a fresh scaffold until legacy imports show up. Keep `sync-skills.mjs`, the `CLAUDE_MD`
-roster in `create-bestax/src/constants.ts`, and the docs skills pages in agreement. When
-the mapping gains or loses coverage, update `skills/bestax-migrate/references/` and the
-docs migration guide in the same PR.
+in a fresh scaffold until legacy imports show up. The canonical roster of surfaces that
+must agree on bundling lives in `create-bestax/CLAUDE.md`'s sync rules — don't restate
+it here. When the mapping gains or loses coverage, update
+`skills/bestax-migrate/references/` and the docs migration guide in the same PR.

--- a/create-bestax/CLAUDE.md
+++ b/create-bestax/CLAUDE.md
@@ -22,9 +22,9 @@ path (`-y` + flags, no TTY) must never hang or regress (#192).
   package. An unlisted skill silently doesn't bundle; a delisted one silently vanishes (the
   script empties the destination first, and its success line reports the array length either
   way); no CI check compares the list against `skills/*`. Bundling is a per-skill policy
-  decision (see #385) — when adding a skill, decide it explicitly and keep the allowlist,
-  `skills/README.md`, `docs/docs/skills/intro.md`, and the `CLAUDE_MD` roster in
-  `src/constants.ts` in agreement. **Never edit the bundled copy** — change `skills/` at the
+  decision (bestax-migrate's was settled as bundled, #385) — when adding a skill, decide it
+  explicitly and keep the allowlist, `skills/README.md`, `docs/docs/skills/intro.md`, and
+  the `CLAUDE_MD` roster in `src/constants.ts` in agreement. **Never edit the bundled copy** — change `skills/` at the
   repo root; the build re-syncs.
 - The `CLAUDE_MD` template in `constants.ts` is what every generated app tells its AI agents.
   When library conventions, skills, or the canonical docs entrypoint change (#203), check

--- a/create-bestax/CLAUDE.md
+++ b/create-bestax/CLAUDE.md
@@ -23,8 +23,9 @@ path (`-y` + flags, no TTY) must never hang or regress (#192).
   script empties the destination first, and its success line reports the array length either
   way); no CI check compares the list against `skills/*`. Bundling is a per-skill policy
   decision (bestax-migrate's was settled as bundled, #385) — when adding a skill, decide it
-  explicitly and keep the allowlist, `skills/README.md`, `docs/docs/skills/intro.md`, and
-  the `CLAUDE_MD` roster in `src/constants.ts` in agreement. **Never edit the bundled copy** — change `skills/` at the
+  explicitly and keep the allowlist, `skills/README.md`, `docs/docs/skills/intro.md`, any
+  per-skill docs page that states bundling (`docs/docs/skills/migrate.mdx` does), and the
+  `CLAUDE_MD` roster in `src/constants.ts` in agreement. **Never edit the bundled copy** — change `skills/` at the
   repo root; the build re-syncs.
 - The `CLAUDE_MD` template in `constants.ts` is what every generated app tells its AI agents.
   When library conventions, skills, or the canonical docs entrypoint change (#203), check

--- a/docs/docs/skills/intro.md
+++ b/docs/docs/skills/intro.md
@@ -38,7 +38,6 @@ Then explore each skill — what it does, how to install it, and live examples:
 - **[Icons](./icons)** — use `Icon`/`IconText` with any of the five supported icon libraries:
   per-library setup, name formats, variants, and decorative-vs-labeled accessibility.
 - **[Migrate](./migrate)** — move an existing app off `react-bulma-components`: run the
-  `bestax-migrate` codemod, then resolve every `TODO(bestax-migrate)` it leaves. Not bundled by
-  `create-bestax` (it's for existing sites, not new ones).
+  `bestax-migrate` codemod, then resolve every `TODO(bestax-migrate)` it leaves.
 - **[Optimize](./optimize)** — reduce the built CSS size: measure raw+gzip, then the cheapest
   first-party lever that fits (lighter flavor, modular Sass build, import/asset hygiene).

--- a/docs/docs/skills/migrate.mdx
+++ b/docs/docs/skills/migrate.mdx
@@ -13,8 +13,8 @@ skill teaches an agent to move an existing app from
 [`bestax-migrate` codemod](../guides/getting-started/migration/react-bulma-components.md) and then
 resolves everything the codemod flags.
 
-Unlike the other skills, this one is **not** bundled by `create-bestax` — it's for existing sites,
-not new ones.
+Like the rest of the bundle, `create-bestax` preinstalls this skill; it stays idle until the
+agent meets code that still imports `react-bulma-components`.
 
 ## Install
 

--- a/docs/docs/skills/migrate.mdx
+++ b/docs/docs/skills/migrate.mdx
@@ -13,8 +13,8 @@ skill teaches an agent to move an existing app from
 [`bestax-migrate` codemod](../guides/getting-started/migration/react-bulma-components.md) and then
 resolves everything the codemod flags.
 
-Like the rest of the bundle, `create-bestax` preinstalls this skill; it stays idle until the
-agent meets code that still imports `react-bulma-components`.
+Like the rest of the bundle, `create-bestax` offers to preinstall this skill; it stays idle
+until the agent meets code that still imports `react-bulma-components`.
 
 ## Install
 


### PR DESCRIPTION
## What

Aligns the last docs with the call made in #385: the `bestax-migrate` skill **is** part of the create-bestax bundle. Four files, prose only:

- `docs/docs/skills/intro.md`: the Migrate bullet loses its "Not bundled by `create-bestax`" sentence.
- `docs/docs/skills/migrate.mdx`: the "Unlike the other skills, this one is **not** bundled" paragraph becomes the bundled framing (preinstalled, idle until legacy imports show up).
- `bestax-migrate/CLAUDE.md`: the "contested, see #385" note becomes the settled policy, with the keep-in-agreement list (`sync-skills.mjs`, the `CLAUDE_MD` roster, the docs skills pages).
- `create-bestax/CLAUDE.md`: the per-skill bundling rule now cites #385 as settled instead of open.

## Why

The code has shipped the skill since #345 (`sync-skills.mjs` allowlist, the scaffolded `CLAUDE_MD` roster, `setupSkills()`), while two docs pages still said it was deliberately not bundled. #385 asked for a direction decision; the decision is recorded on the issue: one uniform bundle, no per-skill carve-out to keep in sync, and the skill costs a fresh scaffold nothing.

## Not in this PR

- No behavior changes: `sync-skills.mjs` and `setupSkills()` are untouched.
- `pnpm gen` produced no diff (the MCP index and skill catalog are unchanged), so there is no regeneration commit.

## Testing

- `pnpm all` green locally. The first cold run tripped the known pre-existing `bestax-mcp` sync-skills race (`ENOTEMPTY` on `data/skills/`); the constituent tasks pass sequentially, as documented in #508.
- `git grep -ni "not bundled"` over `*.md`/`*.mdx`: no skill-related hits remain.

Closes #385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the migration skill is bundled with new `create-bestax` projects.
  * Documented that migration guidance remains inactive unless legacy imports are detected.
  * Updated release and synchronization guidance to keep related tooling and documentation aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->