### PR TITLE
chore: keep local agent worktrees out of prettier's sweep

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,3 +26,11 @@ bestax-migrate/.e2e-tmp/
 # read off these files. Same argument as the codemod fixtures above. The
 # harness's own scripts (eval/agent-loop/bin, lib) are ours and stay formatted.
 eval/agent-loop/runs-*/*/app-src/
+
+# Local agent worktrees: full checkouts of other branches that agent sessions
+# leave under .claude/. Each branch is format-checked by its own PR's CI; seen
+# from here they only re-trip root-anchored patterns above (a worktree's
+# bestax-migrate/fixtures/ no longer matches, so `pnpm format:check` fails on
+# files this file already exempts). Deliberately narrow — .claude/commands/ is
+# tracked, hand-written markdown and stays formatted.
+.claude/worktrees/


### PR DESCRIPTION
## What

Adds `.claude/worktrees/` to the root `.prettierignore`.

## Why

Agent sessions leave git worktrees (full checkouts of other branches) under `.claude/worktrees/`, and the root `format:check` glob walks into them. A worktree's copy of `bestax-migrate/fixtures/` no longer matches that root-anchored exemption, so `pnpm all` fails locally on files this repo already declines to format, on branches whose own PR CI format-checks them from a clean tree. Surfaced while running the gate for #512.

Deliberately narrow: `.claude/commands/` is tracked, hand-written markdown and stays formatted. CI behavior is unchanged (checkouts there never contain local worktrees); this only makes the local gate truthful.

## Testing

- With three stale agent worktrees present, `pnpm run format:check` went from 9 failures (all under `.claude/worktrees/`) to clean.
- The tracked `.claude/commands/*.md` files are still checked (verified they match the glob and are not excluded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded local agent worktree files from automated formatting checks.
  * Documented the formatting exclusion for improved development workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->