### PR TITLE
chore: give every supply-chain bypass a review date and a gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,12 @@ Full versioning details (breaking-change footers, tag formats): `VERSIONING.md`.
 
 - Install/postinstall scripts are **blocked by default** — new native deps need an `allowBuilds` entry.
 - `minimumReleaseAge` cooldown: versions younger than 3 days won't install.
+- **Every bypass carries an expiry.** Entries in `overrides`, `minimumReleaseAgeExclude` and
+  `auditConfig.ignoreGhsas` need `# bestax:review YYYY-MM-DD — why` (or `# bestax:permanent — why`
+  for standing policy) in the comment above them. `check:conformance --only=bypass-expiry` fails
+  on a missing annotation and again once a date arrives, so a temporary bypass can't silently
+  become permanent (#391). A blocking audit gate plus the cooldown means a fresh advisory can red
+  every open PR — CONTRIBUTING.md has the runbook.
 - Isolated node linker: undeclared (phantom) dependencies fail — declare everything you import.
 - Published packages must not ship a `workspace:` or `catalog:` specifier — `npm publish`
   (what semantic-release runs) resolves neither, and the tarball becomes uninstallable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,12 @@ is not your PR's fault, and this is the way out:
 
 1. Force the patched version in `overrides` — scoped to the affected major (`'thing@3': '>=3.1.5 <4'`)
    rather than unscoped, so other majors in the tree are untouched.
-2. If the patch is still inside the cooldown, add the package to `minimumReleaseAgeExclude` too.
-   Without step 2 the resolver refuses the version step 1 demands.
+2. If the patch is still inside the cooldown, add it to `minimumReleaseAgeExclude` too — without
+   this the resolver refuses the version step 1 demands. **Qualify it with the exact version**
+   (`- 'fast-uri@3.1.5'`, not `- fast-uri`): a bare package name waives the cooldown for every
+   future release of that package, so a later lockfile refresh could pull in a different
+   just-published version that nobody reviewed. That is the whole defence you are stepping
+   around, so step around it as narrowly as possible.
 3. Annotate both entries with a review date — this is required, not a nicety:
 
    ```yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,37 @@ pnpm is what powers our supply-chain hardening (see [`pnpm-workspace.yaml`](pnpm
 the [Security guide](./docs/docs/guides/security.md)): lifecycle/postinstall scripts are blocked by
 default, and a 3-day `minimumReleaseAge` cooldown prevents installing just-published versions. If you
 add a dependency whose install scripts must run, add it to `allowBuilds` (run `pnpm approve-builds`);
-if you need a version younger than the cooldown, add it to `minimumReleaseAgeExclude`.
+if you need a version younger than the cooldown, see the runbook below.
+
+#### When a fresh advisory turns CI red
+
+`pnpm audit --audit-level=high` is a blocking gate, and the cooldown refuses anything published in
+the last 72 hours. When an advisory's only patched release is younger than that, the two rules
+genuinely conflict: the gate demands a version the resolver won't fetch, and **every open PR goes
+red**, including yours, over a transitive dependency you never touched (#391). That is expected, it
+is not your PR's fault, and this is the way out:
+
+1. Force the patched version in `overrides` — scoped to the affected major (`'thing@3': '>=3.1.5 <4'`)
+   rather than unscoped, so other majors in the tree are untouched.
+2. If the patch is still inside the cooldown, add the package to `minimumReleaseAgeExclude` too.
+   Without step 2 the resolver refuses the version step 1 demands.
+3. Annotate both entries with a review date — this is required, not a nicety:
+
+   ```yaml
+   # bestax:review 2026-11-13 — drop once the ajv chain resolves to >=3.1.5 itself
+   'fast-uri@3': '>=3.1.5 <4'
+   ```
+
+4. Run `pnpm install`, confirm `pnpm audit --audit-level=high` is clean, and commit the lockfile
+   with it.
+
+Every bypass is temporary by construction, so `pnpm check:conformance --only=bypass-expiry` fails
+the build if an entry has no annotation, and fails again once a review date arrives — that is your
+reminder to drop it, re-resolve, and leave it out if nothing changed. A standing policy that is not
+debt (the `prettier` pin) uses `# bestax:permanent — why` instead and never expires.
+
+Note that `pnpm all` does **not** run the conformance checks; CI does. Run
+`pnpm check:conformance` yourself after editing `pnpm-workspace.yaml`.
 
 ### 2. Clone and Install
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,12 @@ genuinely conflict: the gate demands a version the resolver won't fetch, and **e
 red**, including yours, over a transitive dependency you never touched (#391). That is expected, it
 is not your PR's fault, and this is the way out:
 
-1. Force the patched version in `overrides` — scoped to the affected major (`'thing@3': '>=3.1.5 <4'`)
-   rather than unscoped, so other majors in the tree are untouched.
+1. Force the patched version in `overrides`, scoped to the affected range rather than unscoped.
+   When each major ships its own backport, scope per major (`'thing@3': '>=3.1.5 <4'`) so the
+   other majors are untouched. When the advisory has a single patched floor across majors, use
+   an unbounded-lower selector instead (`'thing@<3.1.5': '>=3.1.5'`), as the committed
+   `postcss` and `sharp` entries do — scoping that case to whichever major the lockfile happens
+   to hold today leaves older majors unguarded if a future dependency edge pulls one in.
 2. If the patch is still inside the cooldown, add it to `minimumReleaseAgeExclude` too — without
    this the resolver refuses the version step 1 demands. **Qualify it with the exact version**
    (`- 'fast-uri@3.1.5'`, not `- fast-uri`): a bare package name waives the cooldown for every

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,8 +27,14 @@ Measures active in this repository and its release pipeline:
   are the deliberate minority: `prettier` is excluded (and pinned) so
   formatting stays deterministic and is never shipped to users, and an
   individual package may be excluded temporarily to pull an urgent security
-  patch in ahead of the cooldown — each such entry carries an inline rationale
-  and a removal date.
+  patch in ahead of the cooldown. Every such bypass — here, in `overrides`, and
+  in `auditConfig.ignoreGhsas` — carries a `# bestax:review <date>` marker in
+  the comment above it stating why, and CI fails once that date arrives
+  (`check:conformance --only=bypass-expiry`), so a temporary exception cannot
+  quietly become permanent. The date is a review-by, not a removal deadline:
+  it forces the question, and the answer may be to extend it with a reason.
+  Standing policy that is not debt, like the `prettier` pin, is marked
+  `# bestax:permanent` instead.
 - **Isolated `node_modules`** — pnpm's isolated linker prevents phantom
   (undeclared) dependencies from being imported.
 - **Frozen lockfile in CI** — builds and releases install with

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,15 @@ allowBuilds:
 # The date is a review-by, not a deadline: when it lands, re-check whether the
 # entry still earns its place, then drop it or push the date out with a reason.
 # CONTRIBUTING.md has the runbook for adding one during a live advisory.
+#
+# The entries below deliberately share ONE sweep date rather than staggered
+# ones. Staggering would spread the same work over more red-gate events, and
+# it would be false precision: we cannot predict which parent widens its range
+# first, so per-entry dates would be guesses dressed as schedule. One date means
+# one sweep, one PR, and (via grouped reporting) one violation rather than
+# fourteen. The cost is that the sweep day lands on whoever pushes next — the
+# same "unrelated PR goes red" problem #391 is about, which only the deferred
+# option C removes. Push the whole batch out together when you sweep.
 
 # Dependency cooldown: refuse to install versions published less than 3 days
 # ago (defends against just-published malicious releases, which are usually

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,7 +72,7 @@ overrides:
   # auto-loading follows `../` out of the source directory and discloses
   # arbitrary .map files.
   'postcss@<8.5.18': '>=8.5.18 <9'
-  # bestax:review 2026-11-13 — quarterly sweep; covers all four majors below
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched brace-expansion per major — high advisories
   # GHSA-mh99-v99m-4gvg (unbounded expansion length, OOM) and its follow-up
   # GHSA-rgw5-rvv9-x895 (DoS via unbounded intermediate arrays) both ship
@@ -85,8 +85,11 @@ overrides:
   # if one ever appears the audit gate will flag it — decide the cross-major
   # question then, against that consumer's import style.
   'brace-expansion@1': '>=1.1.18 <2'
+  # bestax:review 2026-11-13 — quarterly sweep; 2.x line, prunable on its own
   'brace-expansion@2': '>=2.1.4 <3'
+  # bestax:review 2026-11-13 — quarterly sweep; 3.x line, prunable on its own
   'brace-expansion@3': '>=3.0.6 <4'
+  # bestax:review 2026-11-13 — quarterly sweep; 5.x line, prunable on its own
   'brace-expansion@5': '>=5.0.9 <6'
   # bestax:review 2026-11-13 — quarterly sweep
   # Force patched fast-uri under ajv@8 (transitive via commitlint, webpack's
@@ -103,7 +106,7 @@ overrides:
   # Scoped to the affected 7.x major; the 6.x copy under @actions/http-client
   # is not affected. Prune once those parents require >=7.29.0 themselves.
   'undici@7': '>=7.29.0 <8'
-  # bestax:review 2026-11-13 — quarterly sweep; covers minimatch and yaml below
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched minimatch/yaml under docusaurus-plugin-llms. From 0.5.0 that
   # plugin pins its own dependencies exactly ("minimatch": "9.0.3" rather than
   # "^9.0.3"), so the range no longer floats to a patched release the way it did
@@ -113,8 +116,9 @@ overrides:
   # the affected major so the minimatch 10.x already in the tree is untouched.
   # Prune both once the plugin widens its ranges again.
   'minimatch@9': '>=9.0.7 <10'
+  # bestax:review 2026-11-13 — quarterly sweep; same plugin, separate advisory
   'yaml@2': '>=2.8.3'
-  # bestax:review 2026-11-13 — quarterly sweep; covers both majors below
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched js-yaml per major — high advisory GHSA-5p4m-2wfm-xmqj
   # (CVE-2026-59870): quadratic CPU consumption resolving !!omap. The 3.x copy
   # rides the jest coverage chain (babel-plugin-istanbul >
@@ -124,6 +128,7 @@ overrides:
   # range admits them — the lockfile just predates them. Prune each entry once
   # its line resolves to >=3.15.1 / >=4.3.1 without the force.
   'js-yaml@3': '>=3.15.1 <4'
+  # bestax:review 2026-11-13 — quarterly sweep; 4.x line, prunable on its own
   'js-yaml@4': '>=4.3.1 <5'
   # bestax:review 2026-11-13 — quarterly sweep
   # Force patched nanoid under the vite>postcss chain (storybook build
@@ -151,10 +156,11 @@ overrides:
 # Docusaurus chain resolves to it.
 auditConfig:
   ignoreGhsas:
-    # bestax:review 2026-11-13 — quarterly sweep; covers both advisories. These
-    # are the only bypasses here with no patched version to move to, so the
-    # review is "has image-size published a fix yet", not "can we drop this".
+    # bestax:review 2026-11-13 — quarterly sweep. These are the only bypasses
+    # here with no patched version to move to, so the review is "has image-size
+    # published a fix yet", not "can we drop this".
     - GHSA-w3rx-r6r6-pgpr
+    # bestax:review 2026-11-13 — quarterly sweep; second image-size advisory
     - GHSA-5p2g-fcmc-qvqq
 
 # Strict, symlinked node_modules prevents phantom dependencies (using packages

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,8 @@ overrides:
   # stops being load-bearing once its parents widen their own ranges, so prune
   # periodically: drop an entry, re-resolve, and leave it out if the resolved
   # version is unchanged and `pnpm audit --audit-level=high` stays clean.
-  # bestax:review 2026-11-13 — all reviewed 2026-08-13; quarterly sweep
+  # Every entry below carries its own marker; this prose annotates nothing.
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force the patched serialize-javascript (transitive via Docusaurus webpack
   # plugins) — <=7.0.2 has an RCE advisory (GHSA-5c6j-r48x-rmvq).
   serialize-javascript: '>=7.0.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,36 +24,55 @@ allowBuilds:
   # (@swc/core-darwin-arm64 etc.), so no script needs to run.
   '@swc/core': false
 
+# Every entry in the three bypass lists below (overrides, the cooldown
+# exclusions, and auditConfig.ignoreGhsas) must carry one of these markers in
+# the comment directly above it — `check:conformance --only=bypass-expiry`
+# fails the build without one, and again once a review date arrives (#391):
+#
+#   # bestax:review YYYY-MM-DD — why this date
+#   # bestax:permanent — why this is not debt
+#
+# The date is a review-by, not a deadline: when it lands, re-check whether the
+# entry still earns its place, then drop it or push the date out with a reason.
+# CONTRIBUTING.md has the runbook for adding one during a live advisory.
+
 # Dependency cooldown: refuse to install versions published less than 3 days
 # ago (defends against just-published malicious releases, which are usually
 # yanked within hours). Add packages to the exclude list for urgent patches.
 minimumReleaseAge: 4320
-# Dev-only formatter: its output must be deterministic, so we track the exact
-# version the code is formatted with rather than lag it behind the cooldown
-# (which would cause recurring reformat churn). Not shipped to users.
 minimumReleaseAgeExclude:
+  # bestax:permanent — not a bypass to prune: this formatter's output must be
+  # deterministic, so we track the exact version the code is formatted with
+  # rather than lag it behind the cooldown (which would cause recurring
+  # reformat churn). Dev-only, never shipped to users.
   - prettier
 
 # Pin a single prettier version workspace-wide so eslint-plugin-prettier and
 # `prettier --check` never disagree (patch versions format union types
 # differently, which otherwise splits into two resolved copies).
 overrides:
+  # bestax:permanent — a deliberate single-version pin for formatting
+  # determinism, not an advisory patch waiting on the ecosystem.
   prettier: 3.9.6
   # The entries below force patched versions of transitive dependencies. Each
   # stops being load-bearing once its parents widen their own ranges, so prune
   # periodically: drop an entry, re-resolve, and leave it out if the resolved
   # version is unchanged and `pnpm audit --audit-level=high` stays clean.
+  # bestax:review 2026-11-13 — all reviewed 2026-08-13; quarterly sweep
   # Force the patched serialize-javascript (transitive via Docusaurus webpack
   # plugins) — <=7.0.2 has an RCE advisory (GHSA-5c6j-r48x-rmvq).
   serialize-javascript: '>=7.0.3'
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched sharp (transitive via wrangler>miniflare, CI-only deploy
   # tooling with its native build blocked above) — high libvips CVEs.
   'sharp@<0.35.0': '>=0.35.0'
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched postcss (transitive via vite/storybook and the Docusaurus
   # webpack CSS pipeline) — high advisory GHSA-r28c-9q8g-f849: sourceMappingURL
   # auto-loading follows `../` out of the source directory and discloses
   # arbitrary .map files.
   'postcss@<8.5.18': '>=8.5.18 <9'
+  # bestax:review 2026-11-13 — quarterly sweep; covers all four majors below
   # Force patched brace-expansion per major — high advisories
   # GHSA-mh99-v99m-4gvg (unbounded expansion length, OOM) and its follow-up
   # GHSA-rgw5-rvv9-x895 (DoS via unbounded intermediate arrays) both ship
@@ -69,12 +88,14 @@ overrides:
   'brace-expansion@2': '>=2.1.4 <3'
   'brace-expansion@3': '>=3.0.6 <4'
   'brace-expansion@5': '>=5.0.9 <6'
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched fast-uri under ajv@8 (transitive via commitlint, webpack's
   # schema-utils, and the eslint toolchain) — high advisory
   # GHSA-7p8r-x3mc-p8w7: host confusion via a backslash authority introducer.
   # Scoped to the affected 3.x major. Prune once the ajv chain resolves to
   # >=3.1.5 on its own.
   'fast-uri@3': '>=3.1.5 <4'
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched undici 7.x (transitive via semantic-release/github and
   # wrangler>miniflare — release and CI-deploy tooling, never published
   # output) — high advisory GHSA-4cwx-7wf7-3272: cross-user information
@@ -82,6 +103,7 @@ overrides:
   # Scoped to the affected 7.x major; the 6.x copy under @actions/http-client
   # is not affected. Prune once those parents require >=7.29.0 themselves.
   'undici@7': '>=7.29.0 <8'
+  # bestax:review 2026-11-13 — quarterly sweep; covers minimatch and yaml below
   # Force patched minimatch/yaml under docusaurus-plugin-llms. From 0.5.0 that
   # plugin pins its own dependencies exactly ("minimatch": "9.0.3" rather than
   # "^9.0.3"), so the range no longer floats to a patched release the way it did
@@ -92,6 +114,7 @@ overrides:
   # Prune both once the plugin widens its ranges again.
   'minimatch@9': '>=9.0.7 <10'
   'yaml@2': '>=2.8.3'
+  # bestax:review 2026-11-13 — quarterly sweep; covers both majors below
   # Force patched js-yaml per major — high advisory GHSA-5p4m-2wfm-xmqj
   # (CVE-2026-59870): quadratic CPU consumption resolving !!omap. The 3.x copy
   # rides the jest coverage chain (babel-plugin-istanbul >
@@ -102,6 +125,7 @@ overrides:
   # its line resolves to >=3.15.1 / >=4.3.1 without the force.
   'js-yaml@3': '>=3.15.1 <4'
   'js-yaml@4': '>=4.3.1 <5'
+  # bestax:review 2026-11-13 — quarterly sweep
   # Force patched nanoid under the vite>postcss chain (storybook build
   # tooling) — high advisory GHSA-2v37-7h3g-55p8: custom generators can loop
   # indefinitely when size is zero. The advisory's affected range was widened
@@ -127,6 +151,9 @@ overrides:
 # Docusaurus chain resolves to it.
 auditConfig:
   ignoreGhsas:
+    # bestax:review 2026-11-13 — quarterly sweep; covers both advisories. These
+    # are the only bypasses here with no patched version to move to, so the
+    # review is "has image-size published a fix yet", not "can we drop this".
     - GHSA-w3rx-r6r6-pgpr
     - GHSA-5p2g-fcmc-qvqq
 

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -539,11 +539,19 @@ overrides:
 });
 
 test('the committed pnpm-workspace.yaml satisfies its own contract', async () => {
-  const { entries, problems } = parseBypassEntries(
+  const { entries, problems, blocksSeen } = parseBypassEntries(
     await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8')
   );
-  // A parser that silently matched nothing would pass every assertion below.
-  assert.ok(entries.length >= 15, `parsed only ${entries.length} entries`);
+  // A parser that silently matched nothing would pass every assertion below,
+  // so anchor on the blocks being FOUND rather than on how many bypasses
+  // happen to exist. Asserting a minimum entry count would make pruning them —
+  // the entire point of this gate — fail the suite, and the parser explicitly
+  // supports all three blocks standing empty.
+  assert.deepEqual(
+    [...blocksSeen].sort(),
+    BYPASS_BLOCKS.map(b => b.key).sort(),
+    'every bypass block must be found in the committed file'
+  );
   assert.deepEqual(problems, []);
   const { unannotated, malformed } = findExpired(entries, '2026-08-13');
   assert.deepEqual(

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -35,22 +35,21 @@ overrides:
   assert.equal(entries[0].label, 'overrides');
 });
 
-test('consecutive entries share one comment block', () => {
+test('an entry directly beneath an annotated one inherits nothing', () => {
+  // The fail-open this contract exists to close: appending a bypass under an
+  // annotated neighbour, with no comment of its own, must not borrow its date.
   const { entries } = parseBypassEntries(`
 overrides:
-  # bestax:review 2026-11-13 — covers both majors
-  # Force patched thing per major.
+  # bestax:review 2026-11-13 — annotated
   'thing@1': '>=1.2.3'
-  'thing@2': '>=2.3.4'
+  'appended@2': '>=2.3.4'
 `);
   assert.equal(entries.length, 2);
-  assert.equal(entries[0].review, '2026-11-13');
-  assert.equal(entries[1].review, '2026-11-13');
+  assert.equal(byName(entries, 'thing@1').review, '2026-11-13');
+  assert.equal(byName(entries, 'appended@2').review, null);
 });
 
-test('a comment after an entry starts a new block instead of extending it', () => {
-  // The regression that makes this check decorative: without the reset, the
-  // unannotated second entry inherits the first's date and passes.
+test('a comment after an entry annotates only the next entry', () => {
   const { entries } = parseBypassEntries(`
 overrides:
   # bestax:review 2026-11-13 — annotated

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * Guards on the supply-chain bypass expiry parser (#391).
+ *
+ * The failure mode worth guarding is silent and specific: comment-block
+ * association. Entries in pnpm-workspace.yaml share comment blocks on purpose
+ * (the four brace-expansion majors sit under one explanation), so the parser
+ * cannot simply consume a block at the first entry — but it also must not let
+ * a block leak forward past an entry, or a NEW unannotated bypass inherits the
+ * date of whatever happened to precede it and the gate waves it through. Both
+ * directions are asserted below, because a diff review cannot tell them apart.
+ *
+ * `.mjs` and `node --test` rather than jest: these are root-level scripts with
+ * no package of their own, matching how docs/scripts is covered.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseBypassEntries, findExpired } from './lib/bypass-annotations.mjs';
+
+const REPO = join(import.meta.dirname, '..');
+const byName = (entries, name) => entries.find(e => e.name === name);
+
+test('reads the annotation from the comment block above each entry', () => {
+  const entries = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — quarterly sweep
+  # Force patched thing.
+  'thing@1': '>=1.2.3'
+`);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, 'thing@1');
+  assert.equal(entries[0].review, '2026-11-13');
+  assert.equal(entries[0].permanent, false);
+  assert.equal(entries[0].label, 'overrides');
+});
+
+test('consecutive entries share one comment block', () => {
+  const entries = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — covers both majors
+  # Force patched thing per major.
+  'thing@1': '>=1.2.3'
+  'thing@2': '>=2.3.4'
+`);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].review, '2026-11-13');
+  assert.equal(entries[1].review, '2026-11-13');
+});
+
+test('a comment after an entry starts a new block instead of extending it', () => {
+  // The regression that makes this check decorative: without the reset, the
+  // unannotated second entry inherits the first's date and passes.
+  const entries = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — annotated
+  'annotated@1': '>=1.2.3'
+  # Force patched other thing, with no annotation at all.
+  'bare@2': '>=2.3.4'
+`);
+  assert.equal(byName(entries, 'annotated@1').review, '2026-11-13');
+  assert.equal(byName(entries, 'bare@2').review, null);
+});
+
+test('a blank line breaks the association', () => {
+  const entries = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — section prose, not this entry's annotation
+
+  'bare@1': '>=1.2.3'
+`);
+  assert.equal(entries[0].review, null);
+});
+
+test('covers all three bypass lists, including the nested one', () => {
+  const entries = parseBypassEntries(`
+minimumReleaseAgeExclude:
+  # bestax:permanent — deterministic formatting
+  - prettier
+overrides:
+  # bestax:review 2026-11-13 — sweep
+  'thing@1': '>=1.2.3'
+auditConfig:
+  ignoreGhsas:
+    # bestax:review 2026-11-13 — sweep
+    - GHSA-aaaa-bbbb-cccc
+`);
+  assert.deepEqual(
+    entries.map(e => e.label),
+    ['minimumReleaseAgeExclude', 'overrides', 'auditConfig.ignoreGhsas']
+  );
+  assert.equal(byName(entries, 'prettier').permanent, true);
+  assert.equal(byName(entries, 'GHSA-aaaa-bbbb-cccc').review, '2026-11-13');
+});
+
+test('does not mistake a later top-level key for a bypass entry', () => {
+  const entries = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — sweep
+  'thing@1': '>=1.2.3'
+
+nodeLinker: isolated
+publicHoistPattern:
+  - '*eslint*'
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['thing@1']
+  );
+});
+
+test('findExpired separates due, unannotated, and healthy', () => {
+  const entries = [
+    { name: 'due', review: '2026-08-01', permanent: false },
+    { name: 'today', review: '2026-08-13', permanent: false },
+    { name: 'future', review: '2026-11-13', permanent: false },
+    { name: 'bare', review: null, permanent: false },
+    { name: 'forever', review: null, permanent: true },
+  ];
+  const { expired, unannotated } = findExpired(entries, '2026-08-13');
+
+  // An entry is due the day it names, not the day after.
+  assert.deepEqual(
+    expired.map(e => e.name),
+    ['due', 'today']
+  );
+  assert.deepEqual(
+    unannotated.map(e => e.name),
+    ['bare']
+  );
+});
+
+test('permanent entries never expire, however old', () => {
+  const { expired, unannotated } = findExpired(
+    [{ name: 'prettier', review: '2020-01-01', permanent: true }],
+    '2026-08-13'
+  );
+  assert.deepEqual(expired, []);
+  assert.deepEqual(unannotated, []);
+});
+
+test('the committed pnpm-workspace.yaml satisfies its own contract', async () => {
+  const entries = parseBypassEntries(
+    await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8')
+  );
+  // A parser that silently matched nothing would pass every assertion below.
+  assert.ok(entries.length >= 15, `parsed only ${entries.length} entries`);
+  const { unannotated } = findExpired(entries, '2026-08-13');
+  assert.deepEqual(
+    unannotated.map(e => `${e.label}:${e.name}`),
+    [],
+    'every committed bypass must carry a bestax:review or bestax:permanent marker'
+  );
+});

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -16,7 +16,11 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { parseBypassEntries, findExpired } from './lib/bypass-annotations.mjs';
+import {
+  BYPASS_BLOCKS,
+  parseBypassEntries,
+  findExpired,
+} from './lib/bypass-annotations.mjs';
 
 const REPO = join(import.meta.dirname, '..');
 const byName = (entries, name) => entries.find(e => e.name === name);
@@ -393,25 +397,54 @@ publicHoistPattern:
   );
 });
 
-test('an explicitly emptied list counts as seen', () => {
+test('an explicitly emptied block counts as seen, per collection type', () => {
   // Pruning the last entry must not require editing BYPASS_BLOCKS: removing a
   // block definition would unpolice that surface permanently, so an entry
   // added back later would never be checked at all.
+  //
+  // The literal differs by type: `overrides` is a MAPPING, so its empty form
+  // is `{}`. Accepting only `[]` there would reject the correct YAML and the
+  // diagnostic would be telling maintainers to write the wrong type.
+  const { entries, blocksSeen } = parseBypassEntries(`
+minimumReleaseAgeExclude: []
+overrides: {}
+auditConfig:
+  ignoreGhsas: []
+`);
+  assert.deepEqual([...blocksSeen].sort(), [
+    'ignoreGhsas',
+    'minimumReleaseAgeExclude',
+    'overrides',
+  ]);
+  assert.deepEqual(entries, [], 'empty blocks contribute no entries');
+});
+
+test('an emptied block does not swallow what follows it', () => {
   const { entries, blocksSeen } = parseBypassEntries(`
 minimumReleaseAgeExclude: []
 overrides:
   # bestax:review 2026-11-13 — sweep
   'thing@1': '>=1.2.3'
-auditConfig:
-  ignoreGhsas: []
 `);
   assert.ok(blocksSeen.has('minimumReleaseAgeExclude'));
-  assert.ok(blocksSeen.has('ignoreGhsas'));
   assert.deepEqual(
     entries.map(e => e.name),
-    ['thing@1'],
-    'an empty list contributes no entries and swallows nothing after it'
+    ['thing@1']
   );
+});
+
+test('every block declares an empty literal matching its own pattern', () => {
+  // The diagnostic quotes emptyLiteral verbatim, so a mismatch would print
+  // advice the parser itself rejects.
+  for (const block of BYPASS_BLOCKS) {
+    const line = block.emptyLiteral.startsWith('ignoreGhsas')
+      ? `  ${block.emptyLiteral}`
+      : block.emptyLiteral;
+    assert.ok(
+      block.empty.test(line),
+      `${block.key}: emptyLiteral ${JSON.stringify(block.emptyLiteral)} does not match its own empty pattern`
+    );
+  }
 });
 
 test('an unsupported header shape leaves the block unseen, not silently empty', () => {

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -354,6 +354,45 @@ auditConfig:
   ]);
 });
 
+test('an unindented comment does not end the block', () => {
+  // YAML comments carry no structure, so column 0 is a legal place for one
+  // inside an indented block. Treating it as a dedent skipped every entry
+  // below it — no entry, no problem, and blocksSeen still holding the block,
+  // so the gate passed with that bypass entirely unpoliced.
+  const { entries, problems } = parseBypassEntries(`
+overrides:
+# bestax:review 2026-11-13 — unindented but valid YAML
+  'thing@1': '>=1.2.3'
+  # bestax:review 2026-11-13 — normally indented
+  'thing@2': '>=2.3.4'
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['thing@1', 'thing@2'],
+    'entries below an unindented comment must still be seen'
+  );
+  assert.equal(entries[0].review, '2026-11-13', 'and read its annotation');
+  assert.deepEqual(problems, []);
+});
+
+test('a real dedent still ends the block, even after comments', () => {
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — sweep
+  'thing@1': '>=1.2.3'
+
+# a banner comment between sections
+nodeLinker: isolated
+publicHoistPattern:
+  - '*eslint*'
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['thing@1'],
+    'publicHoistPattern entries must not be mistaken for bypasses'
+  );
+});
+
 test('an explicitly emptied list counts as seen', () => {
   // Pruning the last entry must not require editing BYPASS_BLOCKS: removing a
   // block definition would unpolice that surface permanently, so an entry

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -358,6 +358,60 @@ auditConfig:
   ]);
 });
 
+test('indentless sequence items are entries, not a dedent', () => {
+  // Valid YAML: a block sequence may sit at its key's own indentation. Reading
+  // those items as a dedent dropped both lists entirely — no entries, no
+  // problems, and blocksSeen still holding both, so the gate passed green.
+  const { entries, problems } = parseBypassEntries(`
+minimumReleaseAgeExclude:
+# bestax:permanent — deterministic formatting
+- prettier
+auditConfig:
+  ignoreGhsas:
+  # bestax:review 2026-11-13 — quarterly sweep
+  - GHSA-aaaa-bbbb-cccc
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['prettier', 'GHSA-aaaa-bbbb-cccc'],
+    'indentless items must still be policed'
+  );
+  assert.equal(byName(entries, 'prettier').permanent, true);
+  assert.equal(byName(entries, 'GHSA-aaaa-bbbb-cccc').review, '2026-11-13');
+  assert.deepEqual(problems, []);
+});
+
+test('an indentless list does not swallow the next top-level list', () => {
+  // The converse risk of accepting items at header indentation: publicHoistPattern
+  // is a sibling sequence and must never be read as a bypass.
+  const { entries } = parseBypassEntries(`
+minimumReleaseAgeExclude:
+# bestax:permanent — deterministic formatting
+- prettier
+publicHoistPattern:
+- '*eslint*'
+- '*prettier*'
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['prettier']
+  );
+});
+
+test('a mapping block still ends at a same-indent sibling', () => {
+  // overrides is list:false, so nothing at its own indentation continues it.
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — sweep
+  'thing@1': '>=1.2.3'
+nodeLinker: isolated
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['thing@1']
+  );
+});
+
 test('an unindented comment does not end the block', () => {
   // YAML comments carry no structure, so column 0 is a legal place for one
   // inside an indented block. Treating it as a dedent skipped every entry

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -1,13 +1,13 @@
 /**
  * Guards on the supply-chain bypass expiry parser (#391).
  *
- * The failure mode worth guarding is silent and specific: comment-block
- * association. Entries in pnpm-workspace.yaml share comment blocks on purpose
- * (the four brace-expansion majors sit under one explanation), so the parser
- * cannot simply consume a block at the first entry — but it also must not let
- * a block leak forward past an entry, or a NEW unannotated bypass inherits the
- * date of whatever happened to precede it and the gate waves it through. Both
- * directions are asserted below, because a diff review cannot tell them apart.
+ * Every failure mode here is silent and fails OPEN — the gate goes green while
+ * a bypass goes unpoliced, which is the one outcome this check exists to
+ * prevent. So the assertions below are mostly about what must NOT slip past:
+ * an entry inheriting a neighbour's date, a date-shaped non-date that never
+ * comes due, a second marker that is quietly ignored, and an unparsed line
+ * that drops every entry beneath it. A diff review cannot tell any of those
+ * apart from correct behaviour, which is why they are pinned here.
  *
  * `.mjs` and `node --test` rather than jest: these are root-level scripts with
  * no package of their own, matching how docs/scripts is covered.
@@ -168,6 +168,32 @@ overrides:
   assert.match(entries[0].error, /not a real calendar date/);
 });
 
+test('two markers of the same kind is an error, not first-wins', () => {
+  // The likely mistake: adding a fresh date above a stale one instead of
+  // replacing it. Only the first is read, so the due date vanishes silently.
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-12-01 — new date, stacked on top
+  # bestax:review 2026-01-01 — stale, should have been replaced
+  'thing@1': '>=1.2.3'
+`);
+  assert.match(entries[0].error, /2 `bestax:` markers/);
+  assert.equal(entries[0].review, null);
+  assert.deepEqual(findExpired(entries, '2026-08-13').expired, []);
+  assert.equal(findExpired(entries, '2026-08-13').malformed.length, 1);
+});
+
+test('two permanent markers is likewise an error', () => {
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:permanent — one reason
+  # bestax:permanent — another reason
+  'thing@1': '>=1.2.3'
+`);
+  assert.match(entries[0].error, /markers/);
+  assert.equal(entries[0].permanent, false);
+});
+
 test('both markers at once is an error, not a silent permanent', () => {
   const { entries } = parseBypassEntries(`
 overrides:
@@ -175,7 +201,8 @@ overrides:
   # bestax:permanent — incidental mention
   'thing@1': '>=1.2.3'
 `);
-  assert.match(entries[0].error, /both/);
+  assert.match(entries[0].error, /2 `bestax:` markers/);
+  // Permanent must not win the tie-break and bury the overdue date.
   assert.equal(entries[0].permanent, false);
   assert.deepEqual(findExpired(entries, '2026-08-13').expired, []);
 });

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -329,6 +329,29 @@ auditConfig:
   ]);
 });
 
+test('an unsupported header shape leaves the block unseen, not silently empty', () => {
+  // Header matching is deliberately narrow, so semantically equivalent YAML —
+  // a quoted key, or a flow sequence — matches nothing. That is safe ONLY
+  // because blocksSeen makes the absence loud; on its own the other blocks
+  // would keep entries.length nonzero and the gate would pass.
+  for (const shape of [
+    `auditConfig:\n  'ignoreGhsas':\n    - GHSA-aaaa-bbbb-cccc`,
+    `auditConfig:\n  ignoreGhsas: [GHSA-aaaa-bbbb-cccc]`,
+  ]) {
+    const { entries, blocksSeen } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — keeps the total nonzero
+  'thing@1': '>=1.2.3'
+${shape}
+`);
+    assert.ok(entries.length > 0, 'other blocks still parse');
+    assert.ok(
+      !blocksSeen.has('ignoreGhsas'),
+      `unsupported shape must not read as found: ${shape}`
+    );
+  }
+});
+
 test('a renamed block is absent from blocksSeen, not merely empty', () => {
   // The fail-open the per-block guard closes: the other blocks keep the total
   // entry count nonzero, so only the missing KEY reveals the silent list.

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -207,6 +207,42 @@ overrides:
   assert.deepEqual(findExpired(entries, '2026-08-13').expired, []);
 });
 
+test('a near-marker is not a marker', () => {
+  // `\b` matched between "permanent" and a hyphen, so this read as a valid
+  // permanent exemption and disabled expiry forever. A typo must fail CLOSED:
+  // no annotation at all, which the unannotated rule then catches.
+  for (const near of [
+    '# bestax:permanent-ish — reason',
+    '# bestax:permanently — reason',
+    '# bestax:reviewed 2026-11-13 — reason',
+    '# bestax:review-by 2026-11-13 — reason',
+  ]) {
+    const { entries } = parseBypassEntries(`
+overrides:
+  ${near}
+  'thing@1': '>=1.2.3'
+`);
+    assert.equal(entries[0].permanent, false, near);
+    assert.equal(entries[0].review, null, near);
+    assert.equal(entries[0].error, null, near);
+    assert.equal(
+      findExpired(entries, '2026-08-13').unannotated.length,
+      1,
+      `${near} must be caught as unannotated`
+    );
+  }
+});
+
+test('a marker mentioned mid-prose does not annotate', () => {
+  const { entries } = parseBypassEntries(`
+overrides:
+  # Force patched thing. See # bestax:permanent — in the contract above.
+  'thing@1': '>=1.2.3'
+`);
+  assert.equal(entries[0].permanent, false);
+  assert.equal(findExpired(entries, '2026-08-13').unannotated.length, 1);
+});
+
 test('a marker with no reason is an error', () => {
   const { entries: bare } = parseBypassEntries(`
 overrides:

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -22,7 +22,7 @@ const REPO = join(import.meta.dirname, '..');
 const byName = (entries, name) => entries.find(e => e.name === name);
 
 test('reads the annotation from the comment block above each entry', () => {
-  const entries = parseBypassEntries(`
+  const { entries } = parseBypassEntries(`
 overrides:
   # bestax:review 2026-11-13 — quarterly sweep
   # Force patched thing.
@@ -36,7 +36,7 @@ overrides:
 });
 
 test('consecutive entries share one comment block', () => {
-  const entries = parseBypassEntries(`
+  const { entries } = parseBypassEntries(`
 overrides:
   # bestax:review 2026-11-13 — covers both majors
   # Force patched thing per major.
@@ -51,7 +51,7 @@ overrides:
 test('a comment after an entry starts a new block instead of extending it', () => {
   // The regression that makes this check decorative: without the reset, the
   // unannotated second entry inherits the first's date and passes.
-  const entries = parseBypassEntries(`
+  const { entries } = parseBypassEntries(`
 overrides:
   # bestax:review 2026-11-13 — annotated
   'annotated@1': '>=1.2.3'
@@ -63,7 +63,7 @@ overrides:
 });
 
 test('a blank line breaks the association', () => {
-  const entries = parseBypassEntries(`
+  const { entries } = parseBypassEntries(`
 overrides:
   # bestax:review 2026-11-13 — section prose, not this entry's annotation
 
@@ -73,7 +73,7 @@ overrides:
 });
 
 test('covers all three bypass lists, including the nested one', () => {
-  const entries = parseBypassEntries(`
+  const { entries } = parseBypassEntries(`
 minimumReleaseAgeExclude:
   # bestax:permanent — deterministic formatting
   - prettier
@@ -94,7 +94,7 @@ auditConfig:
 });
 
 test('does not mistake a later top-level key for a bypass entry', () => {
-  const entries = parseBypassEntries(`
+  const { entries } = parseBypassEntries(`
 overrides:
   # bestax:review 2026-11-13 — sweep
   'thing@1': '>=1.2.3'
@@ -139,16 +139,123 @@ test('permanent entries never expire, however old', () => {
   assert.deepEqual(unannotated, []);
 });
 
+// --- Malformed annotations. Every shape below fails OPEN if unvalidated: the
+// date never comes due, or a stray marker outranks a real one. ---
+
+test('a date-shaped non-date is rejected, not treated as far future', () => {
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 9999-99-99 — typo
+  'thing@1': '>=1.2.3'
+`);
+  assert.match(entries[0].error, /not a real calendar date/);
+  assert.equal(entries[0].review, null);
+  // Lexicographically "9999-99-99" beats every real date, so an unvalidated
+  // parser would call this healthy forever.
+  const { malformed, expired } = findExpired(entries, '2026-08-13');
+  assert.deepEqual(expired, []);
+  assert.deepEqual(
+    malformed.map(e => e.name),
+    ['thing@1']
+  );
+});
+
+test('a rolled-over date (2026-02-30) is rejected', () => {
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-02-30 — nope
+  'thing@1': '>=1.2.3'
+`);
+  assert.match(entries[0].error, /not a real calendar date/);
+});
+
+test('both markers at once is an error, not a silent permanent', () => {
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-01-01 — due long ago
+  # bestax:permanent — incidental mention
+  'thing@1': '>=1.2.3'
+`);
+  assert.match(entries[0].error, /both/);
+  assert.equal(entries[0].permanent, false);
+  assert.deepEqual(findExpired(entries, '2026-08-13').expired, []);
+});
+
+test('a marker with no reason is an error', () => {
+  const { entries: bare } = parseBypassEntries(`
+overrides:
+  # bestax:permanent
+  'thing@1': '>=1.2.3'
+`);
+  assert.match(bare[0].error, /no reason/);
+
+  const { entries: dated } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13
+  'thing@1': '>=1.2.3'
+`);
+  assert.match(dated[0].error, /no reason/);
+});
+
+test('malformed entries are reported as malformed, not as unannotated', () => {
+  const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 9999-99-99 — typo
+  'thing@1': '>=1.2.3'
+`);
+  const { unannotated, malformed } = findExpired(entries, '2026-08-13');
+  assert.deepEqual(unannotated, [], 'would tell the author the wrong fix');
+  assert.equal(malformed.length, 1);
+});
+
+// --- Block termination. Ending a block early fails open: the skipped entries
+// go unpoliced while other blocks keep the total nonzero. ---
+
+test('a list item with an inline comment is still an entry', () => {
+  const { entries, problems } = parseBypassEntries(`
+minimumReleaseAgeExclude:
+  # bestax:permanent — dev-only formatter
+  - prettier # deterministic output
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['prettier']
+  );
+  assert.deepEqual(problems, []);
+});
+
+test('an unparsable indented line is surfaced, and does not end the block', () => {
+  const { entries, problems } = parseBypassEntries(`
+minimumReleaseAgeExclude:
+  # bestax:permanent — dev-only formatter
+  ? weird: mapping key
+  # bestax:review 2026-11-13 — still policed
+  - after
+`);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0].why, /not recognisable as an entry/);
+  // The entry below the bad line must still be seen.
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['after']
+  );
+});
+
 test('the committed pnpm-workspace.yaml satisfies its own contract', async () => {
-  const entries = parseBypassEntries(
+  const { entries, problems } = parseBypassEntries(
     await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8')
   );
   // A parser that silently matched nothing would pass every assertion below.
   assert.ok(entries.length >= 15, `parsed only ${entries.length} entries`);
-  const { unannotated } = findExpired(entries, '2026-08-13');
+  assert.deepEqual(problems, []);
+  const { unannotated, malformed } = findExpired(entries, '2026-08-13');
   assert.deepEqual(
     unannotated.map(e => `${e.label}:${e.name}`),
     [],
     'every committed bypass must carry a bestax:review or bestax:permanent marker'
+  );
+  assert.deepEqual(
+    malformed.map(e => `${e.label}:${e.name} — ${e.error}`),
+    []
   );
 });

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -243,6 +243,31 @@ overrides:
   assert.equal(findExpired(entries, '2026-08-13').unannotated.length, 1);
 });
 
+test('a terse but real reason is accepted', () => {
+  // The bar is "is there a reason", not "is it a good reason". Rejecting `CI`
+  // put a linter argument in front of someone adding an urgent bypass.
+  for (const reason of ['CI', 'n/a', 'see #391']) {
+    const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 — ${reason}
+  'thing@1': '>=1.2.3'
+`);
+    assert.equal(entries[0].error, null, reason);
+    assert.equal(entries[0].review, '2026-11-13', reason);
+  }
+});
+
+test('separators alone are still not a reason', () => {
+  for (const empty of ['—', '-', ':', '— —', '']) {
+    const { entries } = parseBypassEntries(`
+overrides:
+  # bestax:review 2026-11-13 ${empty}
+  'thing@1': '>=1.2.3'
+`);
+    assert.match(entries[0].error ?? '', /no reason/, JSON.stringify(empty));
+  }
+});
+
 test('a marker with no reason is an error', () => {
   const { entries: bare } = parseBypassEntries(`
 overrides:

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -265,6 +265,46 @@ minimumReleaseAgeExclude:
     entries.map(e => e.name),
     ['after']
   );
+  // And it must read ITS OWN marker. An unparsed line separates the comment
+  // block from what follows, like a blank line does — otherwise the orphaned
+  // marker leaks down and `after` is reported as carrying two markers, which
+  // names a defect that isn't there and hides its real annotation.
+  assert.equal(entries[0].error, null);
+  assert.equal(entries[0].review, '2026-11-13');
+});
+
+test('every expected block is reported as seen', () => {
+  const { blocksSeen } = parseBypassEntries(`
+minimumReleaseAgeExclude:
+  # bestax:permanent — a
+  - prettier
+overrides:
+  # bestax:review 2026-11-13 — b
+  'thing@1': '>=1.2.3'
+auditConfig:
+  ignoreGhsas:
+    # bestax:review 2026-11-13 — c
+    - GHSA-aaaa-bbbb-cccc
+`);
+  assert.deepEqual([...blocksSeen].sort(), [
+    'ignoreGhsas',
+    'minimumReleaseAgeExclude',
+    'overrides',
+  ]);
+});
+
+test('a renamed block is absent from blocksSeen, not merely empty', () => {
+  // The fail-open the per-block guard closes: the other blocks keep the total
+  // entry count nonzero, so only the missing KEY reveals the silent list.
+  const { entries, blocksSeen } = parseBypassEntries(`
+minimumReleaseAgeExcludeRenamed:
+  - prettier
+overrides:
+  # bestax:review 2026-11-13 — b
+  'thing@1': '>=1.2.3'
+`);
+  assert.ok(entries.length > 0, 'total stays nonzero and hides the gap');
+  assert.ok(!blocksSeen.has('minimumReleaseAgeExclude'));
 });
 
 test('the committed pnpm-workspace.yaml satisfies its own contract', async () => {

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -329,6 +329,27 @@ auditConfig:
   ]);
 });
 
+test('an explicitly emptied list counts as seen', () => {
+  // Pruning the last entry must not require editing BYPASS_BLOCKS: removing a
+  // block definition would unpolice that surface permanently, so an entry
+  // added back later would never be checked at all.
+  const { entries, blocksSeen } = parseBypassEntries(`
+minimumReleaseAgeExclude: []
+overrides:
+  # bestax:review 2026-11-13 — sweep
+  'thing@1': '>=1.2.3'
+auditConfig:
+  ignoreGhsas: []
+`);
+  assert.ok(blocksSeen.has('minimumReleaseAgeExclude'));
+  assert.ok(blocksSeen.has('ignoreGhsas'));
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['thing@1'],
+    'an empty list contributes no entries and swallows nothing after it'
+  );
+});
+
 test('an unsupported header shape leaves the block unseen, not silently empty', () => {
   // Header matching is deliberately narrow, so semantically equivalent YAML —
   // a quoted key, or a flow sequence — matches nothing. That is safe ONLY

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -57,7 +57,11 @@ import {
   GENERATED_EXEMPT,
   SCSS_SOURCES,
 } from './lib/api-sources.mjs';
-import { parseBypassEntries, findExpired } from './lib/bypass-annotations.mjs';
+import {
+  BYPASS_BLOCKS,
+  parseBypassEntries,
+  findExpired,
+} from './lib/bypass-annotations.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..');
@@ -1178,17 +1182,22 @@ async function checkPublishableManifests() {
  */
 async function checkBypassExpiry() {
   const path = join(REPO, 'pnpm-workspace.yaml');
-  const { entries, problems } = parseBypassEntries(
+  const { entries, problems, blocksSeen } = parseBypassEntries(
     await readFile(path, 'utf8')
   );
-  if (!entries.length) {
-    return [
-      'pnpm-workspace.yaml parsed to zero bypass entries — the overrides / ' +
-        'minimumReleaseAgeExclude / auditConfig.ignoreGhsas blocks moved or ' +
-        'were renamed, and scripts/lib/bypass-annotations.mjs can no longer ' +
-        'find them. Fix the block patterns there; a silent zero would mean ' +
-        'this gate passes while policing nothing.',
-    ];
+
+  // Per block, not merely in total: one block going silent while the other two
+  // keep the count nonzero is the same fail-open the parser guards against.
+  const missing = BYPASS_BLOCKS.filter(b => !blocksSeen.has(b.key));
+  if (missing.length) {
+    return missing.map(
+      b =>
+        `pnpm-workspace.yaml: the \`${b.label}\` block was not found, so ` +
+        `nothing in it is policed. It moved or was renamed — fix its pattern ` +
+        `in scripts/lib/bypass-annotations.mjs. If the list was deliberately ` +
+        `emptied and removed, drop it from BYPASS_BLOCKS there in the same ` +
+        `change, so the gate never silently covers less than it claims.`
+    );
   }
 
   const today = new Date().toISOString().slice(0, 10);

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -35,6 +35,10 @@
  *                        and names only props that really exist
  *   publishable-manifests  no published package ships a `workspace:`/`catalog:`
  *                        specifier consumers would have to resolve (#412)
+ *   bypass-expiry        every supply-chain bypass in pnpm-workspace.yaml
+ *                        carries a `# bestax:review <date>` or
+ *                        `# bestax:permanent` marker, and no review date has
+ *                        passed (#391)
  */
 import { readFile, readdir, writeFile, access } from 'node:fs/promises';
 import { join, relative, dirname } from 'node:path';
@@ -53,6 +57,7 @@ import {
   GENERATED_EXEMPT,
   SCSS_SOURCES,
 } from './lib/api-sources.mjs';
+import { parseBypassEntries, findExpired } from './lib/bypass-annotations.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..');
@@ -1156,6 +1161,66 @@ async function checkPublishableManifests() {
   return violations;
 }
 
+/**
+ * Supply-chain bypasses expire (#391). `overrides`, `minimumReleaseAgeExclude`
+ * and `auditConfig.ignoreGhsas` each weaken a default we otherwise hold, and
+ * every one of them is written as temporary — but nothing made that observable,
+ * so entries outlived their stated reason until an unrelated PR happened to
+ * audit the file.
+ *
+ * Two failure modes, and the second is what gives this teeth: a review date
+ * that has arrived, and an entry with no annotation at all. Without the latter,
+ * a new bypass just omits the marker and the check is decorative.
+ *
+ * Expired entries report as ONE violation per list rather than one each: a
+ * quarterly batch coming due is a single chore, and this check already risks
+ * failing a PR that has nothing to do with dependencies.
+ */
+async function checkBypassExpiry() {
+  const path = join(REPO, 'pnpm-workspace.yaml');
+  const entries = parseBypassEntries(await readFile(path, 'utf8'));
+  if (!entries.length) {
+    return [
+      'pnpm-workspace.yaml parsed to zero bypass entries — the overrides / ' +
+        'minimumReleaseAgeExclude / auditConfig.ignoreGhsas blocks moved or ' +
+        'were renamed, and scripts/lib/bypass-annotations.mjs can no longer ' +
+        'find them. Fix the block patterns there; a silent zero would mean ' +
+        'this gate passes while policing nothing.',
+    ];
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const { expired, unannotated } = findExpired(entries, today);
+  const violations = [];
+
+  for (const label of new Set(expired.map(e => e.label))) {
+    const due = expired.filter(e => e.label === label);
+    violations.push(
+      `pnpm-workspace.yaml: ${due.length} ${label} entr${
+        due.length === 1 ? 'y is' : 'ies are'
+      } due for review as of ${today} — ` +
+        due.map(e => `${e.name} (line ${e.line}, ${e.review})`).join(', ') +
+        `. For each: drop it, re-resolve, and leave it out if the resolved ` +
+        `version is unchanged and \`pnpm audit --audit-level=high\` stays ` +
+        `clean. Still load-bearing? Push its \`# bestax:review\` date out and ` +
+        `say why in the same comment.`
+    );
+  }
+
+  for (const entry of unannotated) {
+    violations.push(
+      `pnpm-workspace.yaml line ${entry.line}: ${entry.label} entry ` +
+        `"${entry.name}" has no expiry annotation. Add ` +
+        `\`# bestax:review YYYY-MM-DD — why this date\` to the comment ` +
+        `directly above it, or \`# bestax:permanent — why\` if it is a ` +
+        `deliberate standing policy rather than a patch waiting on the ` +
+        `ecosystem. See the contract at the top of pnpm-workspace.yaml.`
+    );
+  }
+
+  return violations;
+}
+
 // ---------------------------------------------------------------------------
 
 const CHECKS = {
@@ -1171,6 +1236,7 @@ const CHECKS = {
   'compound-family': checkCompoundFamily,
   'autodocs-tag': checkAutodocsTag,
   'publishable-manifests': checkPublishableManifests,
+  'bypass-expiry': checkBypassExpiry,
   'inline-style': null, // handled below (takes the flag)
 };
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -1193,10 +1193,12 @@ async function checkBypassExpiry() {
     return missing.map(
       b =>
         `pnpm-workspace.yaml: the \`${b.label}\` block was not found, so ` +
-        `nothing in it is policed. It moved or was renamed — fix its pattern ` +
-        `in scripts/lib/bypass-annotations.mjs. If the list was deliberately ` +
-        `emptied and removed, drop it from BYPASS_BLOCKS there in the same ` +
-        `change, so the gate never silently covers less than it claims.`
+        `nothing in it is policed. If it moved or was renamed, fix its ` +
+        `pattern in scripts/lib/bypass-annotations.mjs. If you pruned its ` +
+        `last entry, keep the key and write \`${b.label.split('.').pop()}: ` +
+        `[]\` rather than deleting it — dropping a block from BYPASS_BLOCKS ` +
+        `unpolices that surface permanently, so entries would sail through ` +
+        `unannotated if the list ever came back.`
     );
   }
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -1178,7 +1178,9 @@ async function checkPublishableManifests() {
  */
 async function checkBypassExpiry() {
   const path = join(REPO, 'pnpm-workspace.yaml');
-  const entries = parseBypassEntries(await readFile(path, 'utf8'));
+  const { entries, problems } = parseBypassEntries(
+    await readFile(path, 'utf8')
+  );
   if (!entries.length) {
     return [
       'pnpm-workspace.yaml parsed to zero bypass entries — the overrides / ' +
@@ -1190,8 +1192,19 @@ async function checkBypassExpiry() {
   }
 
   const today = new Date().toISOString().slice(0, 10);
-  const { expired, unannotated } = findExpired(entries, today);
+  const { expired, unannotated, malformed } = findExpired(entries, today);
   const violations = [];
+
+  for (const { line, why } of problems) {
+    violations.push(`pnpm-workspace.yaml line ${line}: ${why}`);
+  }
+
+  for (const entry of malformed) {
+    violations.push(
+      `pnpm-workspace.yaml line ${entry.line}: ${entry.label} entry ` +
+        `"${entry.name}" ${entry.error}`
+    );
+  }
 
   for (const label of new Set(expired.map(e => e.label))) {
     const due = expired.filter(e => e.label === label);

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -1195,10 +1195,10 @@ async function checkBypassExpiry() {
         `pnpm-workspace.yaml: the \`${b.label}\` block was not found, so ` +
         `nothing in it is policed. If it moved or was renamed, fix its ` +
         `pattern in scripts/lib/bypass-annotations.mjs. If you pruned its ` +
-        `last entry, keep the key and write \`${b.label.split('.').pop()}: ` +
-        `[]\` rather than deleting it — dropping a block from BYPASS_BLOCKS ` +
-        `unpolices that surface permanently, so entries would sail through ` +
-        `unannotated if the list ever came back.`
+        `last entry, keep the key and write \`${b.emptyLiteral}\` rather than ` +
+        `deleting it — dropping a block from BYPASS_BLOCKS unpolices that ` +
+        `surface permanently, so entries would sail through unannotated if ` +
+        `the list ever came back.`
     );
   }
 

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -48,10 +48,17 @@ export const BYPASS_BLOCKS = [
   },
 ];
 
+// A marker must OPEN its comment and END at whitespace or end of line. `\b`
+// is not enough: it matches between "permanent" and a hyphen, so
+// `# bestax:permanent-ish` read as a valid permanent exemption and silently
+// disabled expiry. Anchoring also stops a marker mentioned mid-prose from
+// being mistaken for one. `[ \t]` rather than `\s` throughout, so nothing
+// spans a newline under the /m flag.
+//
 // Capture the rest of the marker line too: the contract asks for a reason, and
 // an unexplained bypass is the thing this whole gate exists to prevent.
-const REVIEW = /#\s*bestax:review\b[ \t]*(\S+)?[ \t]*(.*)$/m;
-const PERMANENT = /#\s*bestax:permanent\b[ \t]*(.*)$/m;
+const REVIEW = /^[ \t]*#[ \t]*bestax:review(?=[ \t]|$)[ \t]*(\S+)?[ \t]*(.*)$/m;
+const PERMANENT = /^[ \t]*#[ \t]*bestax:permanent(?=[ \t]|$)[ \t]*(.*)$/m;
 
 // `String.match` without /g keeps only the first hit, so counting is the only
 // way to notice a block carrying two markers — where the first would silently

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -30,7 +30,10 @@ export const BYPASS_BLOCKS = [
     // `overrides:` sits at column 0; its entries are `key: value` pairs. The
     // trailing `.*` swallows any inline comment — only the key is used.
     header: /^overrides:\s*$/,
-    empty: /^overrides:[ \t]*\[[ \t]*\][ \t]*$/,
+    // A mapping, so its empty literal is `{}` — NOT `[]`, which would be an
+    // empty sequence and the wrong collection type for these key: value pairs.
+    empty: /^overrides:[ \t]*\{[ \t]*\}[ \t]*$/,
+    emptyLiteral: 'overrides: {}',
     entry: /^\s+(.+?):\s*\S.*$/,
     label: 'overrides',
   },
@@ -38,6 +41,7 @@ export const BYPASS_BLOCKS = [
     key: 'minimumReleaseAgeExclude',
     header: /^minimumReleaseAgeExclude:\s*$/,
     empty: /^minimumReleaseAgeExclude:[ \t]*\[[ \t]*\][ \t]*$/,
+    emptyLiteral: 'minimumReleaseAgeExclude: []',
     entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
     label: 'minimumReleaseAgeExclude',
   },
@@ -46,6 +50,7 @@ export const BYPASS_BLOCKS = [
     // Nested under `auditConfig:`, so the header itself is indented.
     header: /^\s+ignoreGhsas:\s*$/,
     empty: /^[ \t]+ignoreGhsas:[ \t]*\[[ \t]*\][ \t]*$/,
+    emptyLiteral: 'ignoreGhsas: []',
     entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
     label: 'auditConfig.ignoreGhsas',
   },

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -53,6 +53,12 @@ export const BYPASS_BLOCKS = [
 const REVIEW = /#\s*bestax:review\b[ \t]*(\S+)?[ \t]*(.*)$/m;
 const PERMANENT = /#\s*bestax:permanent\b[ \t]*(.*)$/m;
 
+// `String.match` without /g keeps only the first hit, so counting is the only
+// way to notice a block carrying two markers — where the first would silently
+// win and the other be ignored.
+const countMatches = (text, re) =>
+  (text.match(new RegExp(re.source, 'gm')) ?? []).length;
+
 const unquote = s => s.replace(/^['"]|['"]$/g, '');
 
 const indentOf = line => line.length - line.trimStart().length;
@@ -90,12 +96,17 @@ function readAnnotation(text) {
   const permanent = text.match(PERMANENT);
   const none = { review: null, permanent: false };
 
-  if (review && permanent) {
+  // Exactly one marker, whatever the mix. Two of the same kind is the likelier
+  // mistake in practice — adding a fresh date above a stale one instead of
+  // replacing it — and only the first would be read.
+  const total = countMatches(text, REVIEW) + countMatches(text, PERMANENT);
+  if (total > 1) {
     return {
       ...none,
       error:
-        'carries both `bestax:review` and `bestax:permanent`; permanent would ' +
-        'win and the date would never be checked. Keep exactly one.',
+        `carries ${total} \`bestax:\` markers; only the first would be read ` +
+        `and the rest silently ignored. Keep exactly one — replace a stale ` +
+        `date rather than stacking a new line above it.`,
     };
   }
   if (permanent) {

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -30,12 +30,14 @@ export const BYPASS_BLOCKS = [
     // `overrides:` sits at column 0; its entries are `key: value` pairs. The
     // trailing `.*` swallows any inline comment — only the key is used.
     header: /^overrides:\s*$/,
+    empty: /^overrides:[ \t]*\[[ \t]*\][ \t]*$/,
     entry: /^\s+(.+?):\s*\S.*$/,
     label: 'overrides',
   },
   {
     key: 'minimumReleaseAgeExclude',
     header: /^minimumReleaseAgeExclude:\s*$/,
+    empty: /^minimumReleaseAgeExclude:[ \t]*\[[ \t]*\][ \t]*$/,
     entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
     label: 'minimumReleaseAgeExclude',
   },
@@ -43,6 +45,7 @@ export const BYPASS_BLOCKS = [
     key: 'ignoreGhsas',
     // Nested under `auditConfig:`, so the header itself is indented.
     header: /^\s+ignoreGhsas:\s*$/,
+    empty: /^[ \t]+ignoreGhsas:[ \t]*\[[ \t]*\][ \t]*$/,
     entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
     label: 'auditConfig.ignoreGhsas',
   },
@@ -196,6 +199,16 @@ export function parseBypassEntries(yaml) {
   };
 
   for (const [i, line] of lines.entries()) {
+    // `key: []` — the list exists and is deliberately empty. Counts as seen so
+    // pruning the last entry never requires editing BYPASS_BLOCKS, which would
+    // unpolice that surface for good if the list came back later.
+    const emptied = BYPASS_BLOCKS.find(b => b.empty.test(line));
+    if (emptied) {
+      blocksSeen.add(emptied.key);
+      endBlock();
+      continue;
+    }
+
     const header = BYPASS_BLOCKS.find(b => b.header.test(line));
     if (header) {
       active = header;

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -231,13 +231,19 @@ export function parseBypassEntries(yaml) {
       comments = [];
       continue;
     }
-    if (indentOf(line) <= headerIndent) {
-      // Dedent to a sibling or parent key: the block is genuinely over.
-      endBlock();
-      continue;
-    }
+    // Comments BEFORE the dedent test: YAML comments carry no structure, so
+    // one at column 0 sits legally inside an indented block. Testing indent
+    // first ended the block on such a line and skipped every entry under it —
+    // silently, since blocksSeen already held the block and the other lists
+    // kept the total nonzero.
     if (line.trimStart().startsWith('#')) {
       comments.push(line);
+      continue;
+    }
+    if (indentOf(line) <= headerIndent) {
+      // Dedent on a real key: the block is genuinely over. Any comments picked
+      // up on the way out belonged to whatever follows, so endBlock drops them.
+      endBlock();
       continue;
     }
 

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -90,8 +90,14 @@ const isCalendarDate = s => {
 
 // Reasons are prose, so accept any separator the house comments already use
 // (em dash, hyphen, colon) and just require some words after it.
+//
+// Two alphanumerics total, not three consecutive: this only has to tell a real
+// reason from an empty one. A stricter bar rejected legitimately terse
+// reasons ("CI", "n/a"), and it would do so while someone is mid-incident
+// adding an urgent bypass — the worst possible moment to argue with a linter
+// about prose. Judging reason QUALITY is review's job, not this gate's.
 const hasReason = text =>
-  /[\p{L}\p{N}]{3}/u.test(text.replace(/^[\s—:-]+/, ''));
+  (text.replace(/^[\s—:-]+/, '').match(/[\p{L}\p{N}]/gu) ?? []).length >= 2;
 
 /**
  * Read the one annotation a comment block is allowed to carry.

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -1,0 +1,151 @@
+/**
+ * Parse the dated annotations on pnpm-workspace.yaml's supply-chain bypasses.
+ *
+ * Three lists in that file weaken a default we otherwise hold: `overrides`
+ * forces a transitive version, `minimumReleaseAgeExclude` waives the cooldown,
+ * and `auditConfig.ignoreGhsas` waives the audit gate itself. Each entry is
+ * meant to be temporary — it stops being load-bearing once the ecosystem
+ * catches up — but nothing made that expiry observable, so entries outlived
+ * their own stated reason and were only ever noticed by an unrelated PR that
+ * happened to audit the file (#391).
+ *
+ * The contract this parser reads: every entry carries either
+ *
+ *   # bestax:review YYYY-MM-DD — why this date
+ *   # bestax:permanent — why this is not debt
+ *
+ * in the comment block directly above it. The dated form is a review-by, not a
+ * hard deadline: the date passing means "re-check whether this is still
+ * needed", which is a decision, not a removal.
+ *
+ * Line scanning rather than a YAML library, matching parseWorkspacePackages in
+ * check-conformance.mjs: the repo declares no YAML parser anywhere, and adding
+ * one to police the cooldown would itself be subject to the cooldown.
+ */
+
+/** Lists we police, in file order, with the vocabulary each violation uses. */
+export const BYPASS_BLOCKS = [
+  {
+    key: 'overrides',
+    // `overrides:` sits at column 0; its entries are `key: value` pairs.
+    header: /^overrides:\s*$/,
+    entry: /^\s+(.+?):\s*\S.*$/,
+    label: 'overrides',
+  },
+  {
+    key: 'minimumReleaseAgeExclude',
+    header: /^minimumReleaseAgeExclude:\s*$/,
+    entry: /^\s+-\s*(\S+)\s*$/,
+    label: 'minimumReleaseAgeExclude',
+  },
+  {
+    key: 'ignoreGhsas',
+    // Nested under `auditConfig:`, so the header itself is indented.
+    header: /^\s+ignoreGhsas:\s*$/,
+    entry: /^\s+-\s*(\S+)\s*$/,
+    label: 'auditConfig.ignoreGhsas',
+  },
+];
+
+const REVIEW = /#\s*bestax:review\s+(\d{4}-\d{2}-\d{2})\b/;
+const PERMANENT = /#\s*bestax:permanent\b/;
+
+const unquote = s => s.replace(/^['"]|['"]$/g, '');
+
+/**
+ * Every bypass entry in the file, each with the annotation found in the comment
+ * block immediately above it.
+ *
+ * A comment block is the run of consecutive `#` lines ending at the entry. A
+ * blank line breaks the association deliberately: a comment separated from the
+ * entry by whitespace is prose about the section, not that entry's annotation.
+ * Entries sharing one comment block (the four brace-expansion majors) each
+ * inherit it, which is why the annotation is read per entry rather than
+ * consumed by the first one.
+ *
+ * @returns {{name: string, block: string, label: string, line: number,
+ *   review: string|null, permanent: boolean}[]}
+ */
+export function parseBypassEntries(yaml) {
+  const entries = [];
+  const lines = yaml.split(/\r?\n/);
+  let active = null;
+  let comments = [];
+  let afterEntry = false;
+
+  for (const [i, line] of lines.entries()) {
+    const header = BYPASS_BLOCKS.find(b => b.header.test(line));
+    if (header) {
+      active = header;
+      comments = [];
+      afterEntry = false;
+      continue;
+    }
+    if (!active) continue;
+
+    if (!line.trim()) {
+      // Blank line: ends the comment association, but not the block — the
+      // audit-exceptions banner sits between `auditConfig:` and its list.
+      comments = [];
+      continue;
+    }
+    if (line.trimStart().startsWith('#')) {
+      // A comment that follows an entry opens a new block rather than
+      // extending the previous one. Without this, an unannotated entry would
+      // inherit the date of whichever annotated entry happened to precede it.
+      if (afterEntry) comments = [];
+      comments.push(line);
+      afterEntry = false;
+      continue;
+    }
+
+    const item = line.match(active.entry);
+    if (!item) {
+      // A non-indented, non-comment line is the next top-level key.
+      active = null;
+      comments = [];
+      afterEntry = false;
+      continue;
+    }
+
+    const text = comments.join('\n');
+    const review = text.match(REVIEW);
+    entries.push({
+      name: unquote(item[1].trim()),
+      block: active.key,
+      label: active.label,
+      line: i + 1,
+      review: review ? review[1] : null,
+      permanent: PERMANENT.test(text),
+    });
+    // Consecutive entries with no comment between them share one block (the
+    // four brace-expansion majors, js-yaml 3 and 4).
+    afterEntry = true;
+  }
+
+  return entries;
+}
+
+/**
+ * Split parsed entries into the two failure modes and the healthy rest.
+ *
+ * `today` is passed in rather than read from the clock so the check is
+ * testable and so a single run cannot disagree with itself across midnight.
+ * Comparison is lexicographic on ISO dates, which is ordering-correct and
+ * sidesteps timezone drift entirely: an entry is due the day it names.
+ */
+export function findExpired(entries, today) {
+  const expired = [];
+  const unannotated = [];
+
+  for (const entry of entries) {
+    if (entry.permanent) continue;
+    if (!entry.review) {
+      unannotated.push(entry);
+      continue;
+    }
+    if (entry.review <= today) expired.push(entry);
+  }
+
+  return { expired, unannotated };
+}

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -27,7 +27,8 @@
 export const BYPASS_BLOCKS = [
   {
     key: 'overrides',
-    // `overrides:` sits at column 0; its entries are `key: value` pairs.
+    // `overrides:` sits at column 0; its entries are `key: value` pairs. The
+    // trailing `.*` swallows any inline comment — only the key is used.
     header: /^overrides:\s*$/,
     entry: /^\s+(.+?):\s*\S.*$/,
     label: 'overrides',
@@ -35,22 +36,99 @@ export const BYPASS_BLOCKS = [
   {
     key: 'minimumReleaseAgeExclude',
     header: /^minimumReleaseAgeExclude:\s*$/,
-    entry: /^\s+-\s*(\S+)\s*$/,
+    entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
     label: 'minimumReleaseAgeExclude',
   },
   {
     key: 'ignoreGhsas',
     // Nested under `auditConfig:`, so the header itself is indented.
     header: /^\s+ignoreGhsas:\s*$/,
-    entry: /^\s+-\s*(\S+)\s*$/,
+    entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
     label: 'auditConfig.ignoreGhsas',
   },
 ];
 
-const REVIEW = /#\s*bestax:review\s+(\d{4}-\d{2}-\d{2})\b/;
-const PERMANENT = /#\s*bestax:permanent\b/;
+// Capture the rest of the marker line too: the contract asks for a reason, and
+// an unexplained bypass is the thing this whole gate exists to prevent.
+const REVIEW = /#\s*bestax:review\b[ \t]*(\S+)?[ \t]*(.*)$/m;
+const PERMANENT = /#\s*bestax:permanent\b[ \t]*(.*)$/m;
 
 const unquote = s => s.replace(/^['"]|['"]$/g, '');
+
+const indentOf = line => line.length - line.trimStart().length;
+
+/**
+ * A real calendar date in ISO form, not merely ten digits shaped like one.
+ * `9999-99-99` matches a naive pattern and then sorts after every real date,
+ * so a typo would silently make a bypass permanent — the exact failure this
+ * check exists to catch.
+ */
+const isCalendarDate = s => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  // `toISOString` throws on an Invalid Date rather than returning a mismatch,
+  // which would take the whole conformance run down with a stack trace.
+  const parsed = new Date(`${s}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return parsed.toISOString().slice(0, 10) === s;
+};
+
+// Reasons are prose, so accept any separator the house comments already use
+// (em dash, hyphen, colon) and just require some words after it.
+const hasReason = text =>
+  /[\p{L}\p{N}]{3}/u.test(text.replace(/^[\s—:-]+/, ''));
+
+/**
+ * Read the one annotation a comment block is allowed to carry.
+ *
+ * Returns `{review, permanent, error}`. Anything malformed becomes an `error`
+ * rather than a silent pass, because every malformed shape here fails OPEN:
+ * an unparsed date never arrives, and a stray `bestax:permanent` outranks a
+ * real review date.
+ */
+function readAnnotation(text) {
+  const review = text.match(REVIEW);
+  const permanent = text.match(PERMANENT);
+  const none = { review: null, permanent: false };
+
+  if (review && permanent) {
+    return {
+      ...none,
+      error:
+        'carries both `bestax:review` and `bestax:permanent`; permanent would ' +
+        'win and the date would never be checked. Keep exactly one.',
+    };
+  }
+  if (permanent) {
+    return hasReason(permanent[1])
+      ? { review: null, permanent: true, error: null }
+      : {
+          ...none,
+          error:
+            '`bestax:permanent` has no reason. Write ' +
+            '`# bestax:permanent — why this is standing policy, not debt`.',
+        };
+  }
+  if (review) {
+    if (!isCalendarDate(review[1] ?? '')) {
+      return {
+        ...none,
+        error:
+          `\`bestax:review\` date ${JSON.stringify(review[1] ?? '')} is not a ` +
+          `real calendar date in YYYY-MM-DD form. An unparseable date never ` +
+          `comes due, so this would be a permanent bypass by typo.`,
+      };
+    }
+    return hasReason(review[2])
+      ? { review: review[1], permanent: false, error: null }
+      : {
+          ...none,
+          error:
+            '`bestax:review` has a date but no reason. Write ' +
+            '`# bestax:review YYYY-MM-DD — why this date`.',
+        };
+  }
+  return { ...none, error: null };
+}
 
 /**
  * Every bypass entry in the file, each with the annotation found in the comment
@@ -63,20 +141,37 @@ const unquote = s => s.replace(/^['"]|['"]$/g, '');
  * inherit it, which is why the annotation is read per entry rather than
  * consumed by the first one.
  *
- * @returns {{name: string, block: string, label: string, line: number,
- *   review: string|null, permanent: boolean}[]}
+ * A block ends only at a real dedent — a non-blank line indented no further
+ * than its header. Ending it at the first line the entry pattern does not
+ * match would fail OPEN: one unsupported-but-valid line (`- GHSA-x # note`
+ * before inline comments were handled) would drop that entry and every entry
+ * below it, while the other blocks kept the total nonzero and the gate green.
+ * Indented lines that do not parse are reported instead, via `problems`.
+ *
+ * @returns {{entries: {name: string, block: string, label: string,
+ *   line: number, review: string|null, permanent: boolean,
+ *   error: string|null}[], problems: {line: number, why: string}[]}}
  */
 export function parseBypassEntries(yaml) {
   const entries = [];
+  const problems = [];
   const lines = yaml.split(/\r?\n/);
   let active = null;
+  let headerIndent = 0;
   let comments = [];
   let afterEntry = false;
+
+  const endBlock = () => {
+    active = null;
+    comments = [];
+    afterEntry = false;
+  };
 
   for (const [i, line] of lines.entries()) {
     const header = BYPASS_BLOCKS.find(b => b.header.test(line));
     if (header) {
       active = header;
+      headerIndent = indentOf(line);
       comments = [];
       afterEntry = false;
       continue;
@@ -87,6 +182,11 @@ export function parseBypassEntries(yaml) {
       // Blank line: ends the comment association, but not the block — the
       // audit-exceptions banner sits between `auditConfig:` and its list.
       comments = [];
+      continue;
+    }
+    if (indentOf(line) <= headerIndent) {
+      // Dedent to a sibling or parent key: the block is genuinely over.
+      endBlock();
       continue;
     }
     if (line.trimStart().startsWith('#')) {
@@ -101,44 +201,53 @@ export function parseBypassEntries(yaml) {
 
     const item = line.match(active.entry);
     if (!item) {
-      // A non-indented, non-comment line is the next top-level key.
-      active = null;
-      comments = [];
-      afterEntry = false;
+      problems.push({
+        line: i + 1,
+        why:
+          `inside \`${active.label}\` but not recognisable as an entry: ` +
+          `${JSON.stringify(line.trim())}. Teach ` +
+          `scripts/lib/bypass-annotations.mjs this shape — an unparsed line ` +
+          `here means an unpoliced bypass.`,
+      });
       continue;
     }
 
-    const text = comments.join('\n');
-    const review = text.match(REVIEW);
     entries.push({
       name: unquote(item[1].trim()),
       block: active.key,
       label: active.label,
       line: i + 1,
-      review: review ? review[1] : null,
-      permanent: PERMANENT.test(text),
+      ...readAnnotation(comments.join('\n')),
     });
     // Consecutive entries with no comment between them share one block (the
     // four brace-expansion majors, js-yaml 3 and 4).
     afterEntry = true;
   }
 
-  return entries;
+  return { entries, problems };
 }
 
 /**
- * Split parsed entries into the two failure modes and the healthy rest.
+ * Split parsed entries into the three failure modes and the healthy rest.
  *
  * `today` is passed in rather than read from the clock so the check is
  * testable and so a single run cannot disagree with itself across midnight.
  * Comparison is lexicographic on ISO dates, which is ordering-correct and
- * sidesteps timezone drift entirely: an entry is due the day it names.
+ * sidesteps timezone drift entirely: an entry is due the day it names — and
+ * `isCalendarDate` has already guaranteed both sides are really dates.
  */
 export function findExpired(entries, today) {
   const expired = [];
   const unannotated = [];
+  const malformed = [];
 
   for (const entry of entries) {
+    // A malformed annotation is neither permanent nor absent — reporting it as
+    // either would tell the author the wrong fix.
+    if (entry.error) {
+      malformed.push(entry);
+      continue;
+    }
     if (entry.permanent) continue;
     if (!entry.review) {
       unannotated.push(entry);
@@ -147,5 +256,5 @@ export function findExpired(entries, today) {
     if (entry.review <= today) expired.push(entry);
   }
 
-  return { expired, unannotated };
+  return { expired, unannotated, malformed };
 }

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -164,13 +164,20 @@ function readAnnotation(text) {
  * below it, while the other blocks kept the total nonzero and the gate green.
  * Indented lines that do not parse are reported instead, via `problems`.
  *
+ * `blocksSeen` reports which headers were actually matched, so the caller can
+ * fail on a block that has moved or been renamed. A total-entries guard is not
+ * enough: one silent block still leaves the other two keeping the count
+ * nonzero, which is the same fail-open shape as the termination bug above.
+ *
  * @returns {{entries: {name: string, block: string, label: string,
  *   line: number, review: string|null, permanent: boolean,
- *   error: string|null}[], problems: {line: number, why: string}[]}}
+ *   error: string|null}[], problems: {line: number, why: string}[],
+ *   blocksSeen: Set<string>}}
  */
 export function parseBypassEntries(yaml) {
   const entries = [];
   const problems = [];
+  const blocksSeen = new Set();
   const lines = yaml.split(/\r?\n/);
   let active = null;
   let headerIndent = 0;
@@ -185,6 +192,7 @@ export function parseBypassEntries(yaml) {
     const header = BYPASS_BLOCKS.find(b => b.header.test(line));
     if (header) {
       active = header;
+      blocksSeen.add(header.key);
       headerIndent = indentOf(line);
       comments = [];
       continue;
@@ -217,6 +225,10 @@ export function parseBypassEntries(yaml) {
           `scripts/lib/bypass-annotations.mjs this shape — an unparsed line ` +
           `here means an unpoliced bypass.`,
       });
+      // An unparsed line separates a comment block from the next entry, the
+      // same way a blank line does. Keeping it would leak this line's marker
+      // onto the following entry and report the wrong defect there.
+      comments = [];
       continue;
     }
 
@@ -232,7 +244,7 @@ export function parseBypassEntries(yaml) {
     comments = [];
   }
 
-  return { entries, problems };
+  return { entries, problems, blocksSeen };
 }
 
 /**

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -35,6 +35,9 @@ export const BYPASS_BLOCKS = [
     empty: /^overrides:[ \t]*\{[ \t]*\}[ \t]*$/,
     emptyLiteral: 'overrides: {}',
     entry: /^\s+(.+?):\s*\S.*$/,
+    // A mapping: its pairs must be indented deeper than the key, so a line at
+    // the key's own indentation really is a sibling and ends the block.
+    list: false,
     label: 'overrides',
   },
   {
@@ -42,7 +45,9 @@ export const BYPASS_BLOCKS = [
     header: /^minimumReleaseAgeExclude:\s*$/,
     empty: /^minimumReleaseAgeExclude:[ \t]*\[[ \t]*\][ \t]*$/,
     emptyLiteral: 'minimumReleaseAgeExclude: []',
-    entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
+    // `\s*` not `\s+`: an indentless item carries no leading whitespace.
+    entry: /^\s*-\s*([^\s#]+)\s*(?:#.*)?$/,
+    list: true,
     label: 'minimumReleaseAgeExclude',
   },
   {
@@ -51,7 +56,8 @@ export const BYPASS_BLOCKS = [
     header: /^\s+ignoreGhsas:\s*$/,
     empty: /^[ \t]+ignoreGhsas:[ \t]*\[[ \t]*\][ \t]*$/,
     emptyLiteral: 'ignoreGhsas: []',
-    entry: /^\s+-\s*([^\s#]+)\s*(?:#.*)?$/,
+    entry: /^\s*-\s*([^\s#]+)\s*(?:#.*)?$/,
+    list: true,
     label: 'auditConfig.ignoreGhsas',
   },
 ];
@@ -245,7 +251,13 @@ export function parseBypassEntries(yaml) {
       comments.push(line);
       continue;
     }
-    if (indentOf(line) <= headerIndent) {
+    const indent = indentOf(line);
+    // YAML block sequences may be INDENTLESS: items sit at their key's own
+    // indentation rather than deeper. Such an item is still inside the block.
+    // Reading it as a dedent dropped the whole list — silently, since
+    // blocksSeen already held the block and no entry meant no problem either.
+    const indentlessItem = active.list && /^[ \t]*-[ \t]/.test(line);
+    if (indent < headerIndent || (indent === headerIndent && !indentlessItem)) {
       // Dedent on a real key: the block is genuinely over. Any comments picked
       // up on the way out belonged to whatever follows, so endBlock drops them.
       endBlock();

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -134,12 +134,17 @@ function readAnnotation(text) {
  * Every bypass entry in the file, each with the annotation found in the comment
  * block immediately above it.
  *
- * A comment block is the run of consecutive `#` lines ending at the entry. A
- * blank line breaks the association deliberately: a comment separated from the
- * entry by whitespace is prose about the section, not that entry's annotation.
- * Entries sharing one comment block (the four brace-expansion majors) each
- * inherit it, which is why the annotation is read per entry rather than
- * consumed by the first one.
+ * A comment block is the run of consecutive `#` lines ending at the entry, and
+ * it belongs to exactly ONE entry: the block is consumed when its entry is
+ * read, so a second entry sitting directly beneath inherits nothing. Sharing
+ * one marker across a group would fail open — appending a bypass under an
+ * annotated neighbour, with no comment of its own, would silently borrow that
+ * neighbour's date. It is also wrong on the merits: `brace-expansion@1` can
+ * become droppable while `@5` is still load-bearing, so each line is its own
+ * decision and carries its own date.
+ *
+ * A blank line breaks the association too: a comment separated from the entry
+ * by whitespace is prose about the section, not that entry's annotation.
  *
  * A block ends only at a real dedent — a non-blank line indented no further
  * than its header. Ending it at the first line the entry pattern does not
@@ -159,12 +164,10 @@ export function parseBypassEntries(yaml) {
   let active = null;
   let headerIndent = 0;
   let comments = [];
-  let afterEntry = false;
 
   const endBlock = () => {
     active = null;
     comments = [];
-    afterEntry = false;
   };
 
   for (const [i, line] of lines.entries()) {
@@ -173,7 +176,6 @@ export function parseBypassEntries(yaml) {
       active = header;
       headerIndent = indentOf(line);
       comments = [];
-      afterEntry = false;
       continue;
     }
     if (!active) continue;
@@ -190,12 +192,7 @@ export function parseBypassEntries(yaml) {
       continue;
     }
     if (line.trimStart().startsWith('#')) {
-      // A comment that follows an entry opens a new block rather than
-      // extending the previous one. Without this, an unannotated entry would
-      // inherit the date of whichever annotated entry happened to precede it.
-      if (afterEntry) comments = [];
       comments.push(line);
-      afterEntry = false;
       continue;
     }
 
@@ -219,9 +216,9 @@ export function parseBypassEntries(yaml) {
       line: i + 1,
       ...readAnnotation(comments.join('\n')),
     });
-    // Consecutive entries with no comment between them share one block (the
-    // four brace-expansion majors, js-yaml 3 and 4).
-    afterEntry = true;
+    // Consume the block: it annotated this entry and nothing else. The next
+    // entry needs its own marker or it is unannotated.
+    comments = [];
   }
 
   return { entries, problems };


### PR DESCRIPTION
Implements **D + E** from #391.

## The problem

`pnpm audit --audit-level=high` is a blocking gate; `minimumReleaseAge: 4320` refuses anything published in the last 72 hours. When an advisory's only patch is younger than that, the two rules demand opposite things and every open PR goes red over a transitive dependency nobody touched. The escape hatch (force the version in `overrides`, waive the cooldown for it) worked but was undocumented and **permanent by default** — nothing made the expiry observable, so entries outlived their own stated reason.

## D — the runbook

`CONTRIBUTING.md` gains the actual procedure: force the patched version scoped to its major, add the cooldown exclusion if the patch is still inside 72h, annotate both with a review date, confirm the audit is clean, commit the lockfile. It also says plainly that a red gate from this cause is not your PR's fault, and that `pnpm all` does not run the conformance checks (CI does). `pnpm-workspace.yaml` states the contract at the top, where someone editing it will see it, and `CLAUDE.md` carries the rule so other sessions inherit it.

## E — the gate

New `bypass-expiry` conformance check. Every entry in `overrides`, `minimumReleaseAgeExclude` and `auditConfig.ignoreGhsas` must carry one of:

```yaml
# bestax:review 2026-11-13 — drop once the ajv chain resolves to >=3.1.5 itself
# bestax:permanent — why this is standing policy, not debt
```

It fails on a missing annotation *and* once a review date arrives. The missing-annotation half is what gives it teeth — without it a new bypass just omits the marker and the check is decorative.

Two scope decisions worth flagging for review:

- **All three lists, not just cooldown exclusions** as #391 scoped it. That list holds exactly one entry today (`prettier`, permanent); `overrides` holds fourteen. Policing only the former would have shipped a check that guards an empty surface.
- **Hand-rolled line scan** (`scripts/lib/bypass-annotations.mjs`), mirroring the existing `parseWorkspacePackages`. The repo declares no YAML parser anywhere, and adding one to police the cooldown would itself be subject to the cooldown.

Existing entries are dated **2026-11-13** — all reviewed today, one quarterly sweep rather than invented staggered dates. Expired entries in a list report as one grouped violation, so a batch coming due is a single chore.

## Honest limits

- **This does not stop the red gate.** A fresh advisory still reds every open PR; D makes the fix predictable and E makes the cleanup non-optional. Only option C (audit warns on PRs, blocks on a schedule) removes the unrelated-PR breakage, and that is deliberately deferred.
- **E is mildly self-undermining**: a date-triggered check fails on a schedule, on PRs unrelated to the diff, which is the same class of problem #391 is about. The issue concedes this in its Risks section. Mitigation is entirely in the message quality and the grouped reporting.
- No `.github/` changes — `check:conformance` already runs in the required `Build and Test` job.

## Testing

Ran against the real file, not just unit tests:

- `--only=bypass-expiry` clean on the annotated file (18 entries parsed: 16 dated, 2 permanent).
- Back-dated one override → exit 1, message names the entry, line, date and the prune loop. Back-dated a second → confirmed the two report as **one** grouped violation.
- Stripped an annotation → correct missing-annotation message. This case also proves the comment-association fix: `fast-uri@3` did not inherit the preceding block's date.
- `prettier` never trips in any state.
- Full `pnpm check:conformance` green (14/14, no regression), `pnpm lint` clean, `node --test "scripts/*.test.mjs"` 42/42.
- `pnpm install --frozen-lockfile` clean and `pnpm audit --audit-level=high` still exits 0 — annotations are comments, so the lockfile must not move, and it doesn't.

Closes #391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added required review or permanent-exception annotations for dependency bypasses.
  * Added quarterly review metadata to existing dependency exceptions.
  * Added conformance checks to detect missing, malformed, or expired annotations.

* **Documentation**
  * Expanded contributor guidance for handling security advisories, cooldown exclusions, version overrides, and verification steps.

* **Tests**
  * Added comprehensive validation for annotation parsing, expiry handling, error detection, and dependency configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->