### PR TITLE
chore: force nanoid 3.3.18 after the advisory range widened

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   yaml@2: '>=2.8.3'
   js-yaml@3: '>=3.15.1 <4'
   js-yaml@4: '>=4.3.1 <5'
-  nanoid@3: '>=3.3.17 <4'
+  nanoid@3: '>=3.3.18 <4'
 
 importers:
 
@@ -7704,8 +7704,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -19625,7 +19625,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -20559,7 +20559,7 @@ snapshots:
 
   postcss@8.5.21:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,12 +104,15 @@ overrides:
   'js-yaml@4': '>=4.3.1 <5'
   # Force patched nanoid under the vite>postcss chain (storybook build
   # tooling) — high advisory GHSA-2v37-7h3g-55p8: custom generators can loop
-  # indefinitely when size is zero. The patched 3.3.17 (2026-08-03) clears the
-  # cooldown and postcss's ^3.3.16 admits it — the lockfile just predates it.
-  # Scoped to the 3.x major (the only copy in the tree; the 4.x/5.x line has
-  # its own patch at 5.1.6 if a consumer ever appears). Prune once the chain
-  # resolves to >=3.3.17 without the force.
-  'nanoid@3': '>=3.3.17 <4'
+  # indefinitely when size is zero. The advisory's affected range was widened
+  # from <3.3.17 to <3.3.18 after 3.3.17 shipped an incomplete fix, so the
+  # earlier force stopped clearing the gate and every open PR went red on it.
+  # 3.3.18 (2026-08-07) is well past the cooldown and postcss's ^3.3.16 admits
+  # it, so no minimumReleaseAgeExclude entry is needed. Scoped to the 3.x major
+  # (the only copy in the tree; the 4.x/5.x line has its own patch at 5.1.6 if
+  # a consumer ever appears). Prune once the chain resolves to >=3.3.18 without
+  # the force.
+  'nanoid@3': '>=3.3.18 <4'
 
 # --- Audit exceptions (no patched release exists) ---
 


### PR DESCRIPTION
## What

One-line override bump: `'nanoid@3': '>=3.3.17 <4'` → `'>=3.3.18 <4'`, plus the lockfile.

## Why this is urgent

GHSA-2v37-7h3g-55p8 was re-scored — 3.3.17 shipped an incomplete fix, so the affected range moved from `<3.3.17` to `<3.3.18`. Our existing override no longer clears `pnpm audit --audit-level=high`, which is a blocking step in the required `Build and Test` job. **`main` and every open PR are red on this**, unrelated to their diffs.

Confirmed on #514: its failing step is `Audit (high severity)`, nothing in its own change.

## Why the override alone

This is the easy case of the fresh-advisory path: 3.3.18 published 2026-08-07, roughly 154 hours ago, so it is well outside the 3-day `minimumReleaseAge` cooldown and no `minimumReleaseAgeExclude` entry is needed. postcss's `^3.3.16` admits it, so the chain resolves without further forcing. Kept scoped to the 3.x major, as before — it is the only copy in the tree.

## Testing

- `pnpm audit --audit-level=high` exits 0 (was 1).
- `pnpm install` lockfile delta is nanoid only: 3.3.17 → 3.3.18, no other package moved.
- Full `pnpm all` green, including the Storybook build — that is the toolchain actually pulling nanoid in via vite>postcss.

## Note

The recurrence of this exact scenario is the argument for #391's deferred option C (audit warns on PRs, blocks on a schedule): a third-party re-score just reddened every open PR in the repo, including the PR implementing #391's own D+E mitigations.