### PR TITLE
ci: skip the preview deploy on fork PRs too

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -93,10 +93,11 @@ jobs:
     # it a fork PR reproduces the failure this job was guarded against: the
     # deploy on an empty token, and then Comment Preview URL, whose write
     # permission GitHub downgrades to read on a fork run whatever the
-    # `permissions:` block below says. Same idiom as ai-scan.yml,
-    # ai-triage.yml, claude-review.yml and story-screenshots.yml; they carry an
-    # extra `pull_request == null` branch only because they also run on issues.
-    # Both clauses narrow what runs — the trigger above is unchanged.
+    # `permissions:` block below says. Same bare idiom as claude-review.yml
+    # and story-screenshots.yml; ai-scan.yml and ai-triage.yml wrap it in a
+    # `pull_request == null` branch only because they also run on issues,
+    # which this workflow does not. Both clauses narrow what runs — the
+    # trigger above is unchanged.
     #
     # Only this job is guarded. `build` still runs on dependency PRs, so a bump
     # that breaks the Docusaurus or Storybook build is still caught.

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -86,6 +86,18 @@ jobs:
     # becomes the actor and does get the Actions secrets, so the preview still
     # deploys in exactly the cases where it can.
     #
+    # Fork PRs lose the secrets the same way, and deliberately — this workflow
+    # is plain `pull_request`, so a fork head never sees them (rule 7). The
+    # actor there is the contributor rather than dependabot, so the actor test
+    # alone does not cover them and the head-repo guard is what does. Without
+    # it a fork PR reproduces the failure this job was guarded against: the
+    # deploy on an empty token, and then Comment Preview URL, whose write
+    # permission GitHub downgrades to read on a fork run whatever the
+    # `permissions:` block below says. Same idiom as ai-scan.yml,
+    # ai-triage.yml, claude-review.yml and story-screenshots.yml; they carry an
+    # extra `pull_request == null` branch only because they also run on issues.
+    # Both clauses narrow what runs — the trigger above is unchanged.
+    #
     # Only this job is guarded. `build` still runs on dependency PRs, so a bump
     # that breaks the Docusaurus or Storybook build is still caught.
     #
@@ -99,7 +111,9 @@ jobs:
     # live deploy token to auto-generated PRs that pull in unreviewed
     # transitive dependencies — the exact exposure the build/deploy split above
     # exists to prevent.
-    if: github.actor != 'dependabot[bot]'
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write # comment the preview URL
     steps:


### PR DESCRIPTION
## What #398 asked for, and what is left of it

#398 reported that **Test and Preview Deployment** went red on every dependabot PR: those runs are scoped to the Dependabot secrets store, so `secrets.CLOUDFLARE_API_TOKEN` interpolates empty and `wrangler-action` aborts. The build passed first, so the red X was pure noise that reads as a merge blocker while triaging.

**That symptom already shipped fixed**, by a different mechanism than the issue proposed:

- 4a273b8 split build from deploy so build-time code cannot reach the Cloudflare credentials.
- 6f1351c guarded the deploy job on `github.actor != 'dependabot[bot]'`.

Confirmed live on the three dependabot PRs opened since — #511, #510, #469: `Build preview site` passes, `Test and Preview Deployment` reports *skipping*, and each run concludes success. The job comment notes the skipped-not-green tradeoff is fine while the check is not required; still true, the `main` ruleset requires only Build and Test, React 18 compatibility, React 19 compatibility, and Dependency Review.

## The case the actor test does not reach

Fork PRs arrive with no secrets too, for the same reason and by design — this workflow is plain `pull_request`, so a fork head never sees them. But the actor on a fork run is the contributor rather than dependabot, so the job starts and reproduces #398's failure exactly: wrangler on an empty token, then `Comment Preview URL`, whose write permission GitHub downgrades to read on a fork run whatever the `permissions:` block asks for.

This PR adds the head-repo guard the other same-repo-only workflows already use (`ai-scan.yml`, `ai-triage.yml`, `claude-review.yml`, `story-screenshots.yml`). Theirs carry an extra `pull_request == null` branch only because they also run on `issues` events; this one runs on `pull_request` alone, so the PR object is always present.

## Security notes

- **No trigger change.** Still plain `pull_request` on `main`, no `pull_request_target`. Rule 7 in `.github/CLAUDE.md` is what makes the fork run secret-less in the first place, and this preserves that rather than working around it.
- **Strictly subtractive.** Both clauses only ever cause the job to skip. A fork run gains nothing it does not have today; it just stops starting a deploy it cannot finish.
- No `permissions:` change, no allowlist change, no action SHA change, no new repository variable, no verdict or budget path.
- Adding the Cloudflare credentials to the Dependabot secrets store would also turn the check green and is still deliberately not done, for the reason the job comment already gives.

## Verification

- The run on this PR is the regression test for the path that matters: same-repo branch, human actor, so both clauses are true and **Test and Preview Deployment must still run and post a preview URL**. If it skips, the condition is wrong.
- `pnpm exec prettier --check` passes on the file, which parses the YAML as a side effect. The repo has no actionlint.
- The fork path itself stays unvalidated until an outside PR arrives — the same caveat #398 carried, since a secret-less run cannot be simulated from a same-repo branch.

Closes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deployment attempts for forked and automated dependency-update pull requests when required credentials are unavailable.
  * Improved deployment workflow handling for pull requests from external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->