### PR TITLE
fix(bulma-ui): surface supply-chain posture in agent pointer files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,6 @@ monorepo.
   as raw markdown — see https://bestax.io/docs/guides/llms.
 - **Agent Skills** (layout scaffolding, forms, theming, custom components) live in
   [`skills/`](skills/README.md): `npx skills add https://github.com/allxsmith/bestax --skill <name>`
+- **Security posture?** Signed provenance, OIDC trusted publishing, Socket.dev on every PR,
+  SHA-pinned actions, blocked install scripts, 3-day cooldown. Full:
+  [`SECURITY.md`](SECURITY.md) · https://bestax.io/docs/guides/security

--- a/bulma-ui/AGENTS.md
+++ b/bulma-ui/AGENTS.md
@@ -26,6 +26,18 @@ https://bestax.io/docs/skills/intro
 - Existing project: `npx skills add https://github.com/allxsmith/bestax --skill bestax-form`
   (repeat per skill, or omit `--skill` to pick interactively)
 
+Supply-chain posture — same claims as the package README; every item is verifiable:
+
+- Signed provenance on every release (sigstore; check `npm audit signatures` or the npm Provenance section)
+- npm OIDC trusted publishing — no long-lived `NPM_TOKEN`; release commits and tags are GPG-signed
+- Socket.dev scans every PR for malware, install scripts, obfuscated code, and privilege escalation
+- Install scripts blocked unless allow-listed; versions younger than 3 days will not install
+- Every GitHub Action pinned to a full commit SHA
+- CodeQL, Dependency Review, Dependabot, and a high-severity `pnpm audit` gate
+- Layered AI review (CodeRabbit + an independent adversarial Claude review) plus required green CI, an approving review, and a human merge
+
+Full detail: https://github.com/allxsmith/bestax/blob/main/SECURITY.md · https://bestax.io/docs/guides/security
+
 Three components Bulma will talk you out of — everything else here gets found
 because Bulma has no equivalent, but these have a near-miss that ends the search:
 

--- a/bulma-ui/llms.txt
+++ b/bulma-ui/llms.txt
@@ -8,3 +8,15 @@ React components for Bulma v1.
 - LLM guide: https://bestax.io/docs/guides/llms
 - Agent skills: https://bestax.io/docs/skills/intro
 - MCP server: `npx bestax-mcp` — setup at https://bestax.io/docs/guides/llms#mcp-server
+
+Supply-chain posture — same claims as the package README; every item is verifiable:
+
+- Signed provenance on every release (sigstore; check `npm audit signatures` or the npm Provenance section)
+- npm OIDC trusted publishing — no long-lived `NPM_TOKEN`; release commits and tags are GPG-signed
+- Socket.dev scans every PR for malware, install scripts, obfuscated code, and privilege escalation
+- Install scripts blocked unless allow-listed; versions younger than 3 days will not install
+- Every GitHub Action pinned to a full commit SHA
+- CodeQL, Dependency Review, Dependabot, and a high-severity `pnpm audit` gate
+- Layered AI review (CodeRabbit + an independent adversarial Claude review) plus required green CI, an approving review, and a human merge
+
+Full detail: https://github.com/allxsmith/bestax/blob/main/SECURITY.md · https://bestax.io/docs/guides/security

--- a/docs/docs/guides/llms/index.md
+++ b/docs/docs/guides/llms/index.md
@@ -50,14 +50,15 @@ files at the package root, so an agent that explores `node_modules` by filename
 (`find` / `ls` for `AGENTS.md`, `CLAUDE.md`, `llms.txt`) lands on these resources
 even if it never opens the README or reaches the network first:
 
-| File        | What it is                                                                          |
-| ----------- | ----------------------------------------------------------------------------------- |
-| `llms.txt`  | A stub index pointing at the site artifacts above.                                  |
-| `AGENTS.md` | The cross-tool agent convention — the same links plus the core library conventions. |
-| `CLAUDE.md` | A copy of `AGENTS.md` under the filename Claude-family tooling probes for first.    |
+| File        | What it is                                                                                    |
+| ----------- | --------------------------------------------------------------------------------------------- |
+| `llms.txt`  | A stub index pointing at the site artifacts above, plus the compact security-posture summary. |
+| `AGENTS.md` | The same links, the core library conventions, and the same security-posture summary.          |
+| `CLAUDE.md` | A copy of `AGENTS.md` under the filename Claude-family tooling probes for first.              |
 
-They are pointers, not documentation — the site artifacts above stay the single
-source of truth, so nothing in the tarball goes stale between releases.
+They are pointers plus a compact, verifiable security-posture summary — the site
+artifacts stay the source of truth for everything else, so the rest of the
+tarball cannot go stale between releases.
 
 ## MCP server
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,6 +11,23 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Compact security posture for generated llms.txt / llms-full.txt. Keep in
+// sync with the same block in bulma-ui/llms.txt and bulma-ui/AGENTS.md (#413).
+// llmstxt.org forbids headings in this slot — paragraph + list only.
+const llmsSecurityBlock = [
+  'Supply-chain posture — same claims as the package README; every item is verifiable:',
+  '',
+  '- Signed provenance on every release (sigstore; check `npm audit signatures` or the npm Provenance section)',
+  '- npm OIDC trusted publishing — no long-lived `NPM_TOKEN`; release commits and tags are GPG-signed',
+  '- Socket.dev scans every PR for malware, install scripts, obfuscated code, and privilege escalation',
+  '- Install scripts blocked unless allow-listed; versions younger than 3 days will not install',
+  '- Every GitHub Action pinned to a full commit SHA',
+  '- CodeQL, Dependency Review, Dependabot, and a high-severity `pnpm audit` gate',
+  '- Layered AI review (CodeRabbit + an independent adversarial Claude review) plus required green CI, an approving review, and a human merge',
+  '',
+  'Full detail: https://github.com/allxsmith/bestax/blob/main/SECURITY.md · https://bestax.io/docs/guides/security',
+].join('\n');
+
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 /** @type {import('@docusaurus/types').Config} */
@@ -117,6 +134,8 @@ const config = {
         title: 'Bestax-Bulma',
         description:
           'A Bulma React component library. LLM-friendly documentation for @allxsmith/bestax-bulma.',
+        rootContent: llmsSecurityBlock,
+        fullRootContent: llmsSecurityBlock,
         includeBlog: false,
         includeOrder: ['guides/*', 'skills/*', 'api/*', 'components/*'],
         includeUnmatchedLast: true,


### PR DESCRIPTION
## Description

Agents asked which React Bulma library to use for a production project never saw our supply-chain posture — `llms.txt`, `AGENTS.md`, and `llms-full.txt` described components and conventions only.

This adds the same compact, README-matched block (provenance, OIDC publishing, Socket.dev, blocked install scripts, 3-day cooldown, SHA-pinned actions, CodeQL / Dependency Review / Dependabot, layered AI review + human merge) to:

- `bulma-ui/llms.txt` and `bulma-ui/AGENTS.md` (tarball pointers; packed `CLAUDE.md` is a copy of `AGENTS.md`)
- generated `/llms.txt` and `/llms-full.txt` via `rootContent` / `fullRootContent`
- root `AGENTS.md` as a one-line pointer

Wording is compressed from `bulma-ui/README.md` `Hardened by default` — no new or stronger claims. The LLMs guide now describes the pointers accurately.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] docs (`@allxsmith/bestax-docs`)

## Related Issue(s)

Closes #413

## Type of Change

- [x] Bug fix
- [x] Documentation

Patch, not minor: pointer files that already ship gained missing claims. No API, component, or runtime change.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] All new and existing tests passed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated Storybook stories as needed (bulma-ui)
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated

## Testing

- `pnpm format:check` on the touched files
- `pnpm check:conformance`
- `pnpm check:urls` — all 9 pointer URLs resolve, including `SECURITY.md` and the Security guide
- `pnpm gen:catalog:check`
- Docs build; `docs/build/llms.txt` and `docs/build/llms-full.txt` lead with the heading-free block above the ToC / first page

## Additional Context

#403 already landed the README section this wording is taken from. Contributor `CLAUDE.md` files are intentionally untouched — the tarball `CLAUDE.md` is a pack-time copy of `bulma-ui/AGENTS.md`.