### PR TITLE
ci: restamp the MCP index in the release job so main stops going stale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,13 @@ jobs:
         id: restamp
         run: |
           pnpm gen:mcp
+          # --intent-to-add mirrors gen:mcp:check exactly. The output is a
+          # directory, and `git diff` cannot see a newly added file that git
+          # has never been told about, so without this a release that somehow
+          # added a file under data/ would read as "no change" here and still
+          # fail the gate on every branch. Today only the version field moves,
+          # but a guard should match the check it exists to satisfy.
+          git add --intent-to-add --all bestax-mcp/data
           if git diff --quiet -- bestax-mcp/data; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "MCP index already matches the released version; nothing to do."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,12 +378,20 @@ jobs:
           # is correct by construction, and letting it trigger the publish job
           # again would re-run the whole release pipeline to do nothing.
           #
-          # --no-verify because `pnpm install` above installed husky's hooks
-          # into .git/hooks, and those are repo-owned code. Without it, a commit
-          # hook would execute in the one step that holds the bypass token,
-          # which is the thing this split exists to prevent. The message is
-          # machine-generated and already conventional, so nothing is lost.
-          git commit -S --no-verify -m "chore(bestax-mcp): restamp index after release [skip ci]"
+          # `pnpm install` above put husky's hooks in .git/hooks, and those are
+          # repo-owned code. Running one here would execute it in the single
+          # step holding the bypass token, which is the thing this split exists
+          # to prevent.
+          #
+          # core.hooksPath rather than --no-verify: that flag suppresses only
+          # pre-commit and commit-msg, so it would silently stop covering this
+          # the day someone adds a prepare-commit-msg, post-commit or
+          # post-rewrite hook. Pointing hooksPath at a non-directory makes git
+          # find no hook of any name, which is the property actually wanted
+          # here — "no repo code runs in this step", not "these two hooks are
+          # skipped". Only commit-msg exists today; the point is that this
+          # keeps holding when that changes.
+          git -c core.hooksPath=/dev/null commit -S -m "chore(bestax-mcp): restamp index after release [skip ci]"
           if ! git push "https://x-access-token:${RESTAMP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main; then
             echo "::error::Packages published, but pushing the MCP index restamp to main failed. Run 'pnpm gen:mcp' on main and commit, or every new branch will fail gen:mcp:check."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,3 +304,55 @@ jobs:
         run: |
           git log -1 --show-signature
           pnpm exec semantic-release
+
+      # A bulma-ui release bumps bulma-ui/package.json, and gen-mcp-index.mjs
+      # stamps that version into the COMMITTED bestax-mcp/data/catalog.json
+      # (`generatedFrom.version`). Nothing above regenerates it, so main was
+      # left carrying an index stamped with the previous version — and because
+      # the release commit skips CI, no run on main ever evaluated
+      # `gen:mcp:check` to notice. The damage landed on everyone else: every
+      # branch cut from main afterwards regenerates, sees the drift, and fails
+      # a check on a file it never touched (#518, #520).
+      #
+      # Why a separate step rather than @semantic-release/exec plus a git
+      # asset, which is the obvious shape: @semantic-release/git selects assets
+      # by running `git ls-files -m -o` and micromatching the result, and each
+      # release above runs with `working-directory` set to its own package. Run
+      # from bulma-ui/, `git ls-files` lists only files under bulma-ui/, so
+      # bestax-mcp/data/catalog.json can never appear in that list no matter
+      # how the asset path is written. It would silently commit nothing, which
+      # is the worst outcome available: a fix that looks applied and is not.
+      # (Same reason the `pnpm-lock.yaml` asset in bulma-ui/release.config.js
+      # has never matched — the root lockfile is outside that cwd too.)
+      #
+      # Runs last on purpose: after every publish has already succeeded, so a
+      # failure here can never cost a release. If the push fails the job goes
+      # red with the packages already published, which is the correct signal —
+      # main needs a manual restamp — rather than a silent revert to the old
+      # broken behaviour.
+      #
+      # No-ops when nothing released: with no version change the generator's
+      # output is byte-identical and the guard exits early.
+      - name: Restamp the MCP index after a release
+        env:
+          # The checkout ran with persist-credentials:false, so there is no
+          # pushable credential in .git/config. Authenticate the same way
+          # semantic-release does above: the App token in the remote URL. It is
+          # a registered bypass actor on main's ruleset; GITHUB_TOKEN is not.
+          RESTAMP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          pnpm gen:mcp
+          if git diff --quiet -- bestax-mcp/data; then
+            echo "MCP index already matches the released version; nothing to do."
+            exit 0
+          fi
+          git add bestax-mcp/data
+          # Signed and attributed by the GPG config imported above, matching the
+          # release commits. Skips CI for the same reason they do: this commit
+          # is correct by construction, and letting it trigger the publish job
+          # again would re-run the whole release pipeline to do nothing.
+          git commit -S -m "chore(bestax-mcp): restamp index after release [skip ci]"
+          if ! git push "https://x-access-token:${RESTAMP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main; then
+            echo "::error::Packages published, but pushing the MCP index restamp to main failed. Run 'pnpm gen:mcp' on main and commit, or every new branch will fail gen:mcp:check."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,25 +333,50 @@ jobs:
       #
       # No-ops when nothing released: with no version change the generator's
       # output is byte-identical and the guard exits early.
-      - name: Restamp the MCP index after a release
+      # Split across two steps for the same reason the App token is minted after
+      # install and build rather than before: a bypass-capable credential must
+      # not be in the environment while repo-owned code executes. `pnpm gen:mcp`
+      # runs scripts/gen-mcp-index.mjs and whatever it imports, so it gets no
+      # token. Only the commit-and-push step, which runs nothing from this
+      # repository, sees one.
+      - name: Regenerate the MCP index
+        id: restamp
+        run: |
+          pnpm gen:mcp
+          if git diff --quiet -- bestax-mcp/data; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "MCP index already matches the released version; nothing to do."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push the MCP index restamp
+        if: steps.restamp.outputs.changed == 'true'
         env:
           # The checkout ran with persist-credentials:false, so there is no
           # pushable credential in .git/config. Authenticate the same way
           # semantic-release does above: the App token in the remote URL. It is
           # a registered bypass actor on main's ruleset; GITHUB_TOKEN is not.
+          #
+          # Passed through `env:` deliberately, NOT interpolated as `${{ }}`
+          # inside `run:`. Expression interpolation is textual substitution into
+          # the script before the shell parses it, which is the pattern GitHub's
+          # hardening guidance tells you to avoid; `env:` keeps the value out of
+          # the rendered script body.
           RESTAMP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          pnpm gen:mcp
-          if git diff --quiet -- bestax-mcp/data; then
-            echo "MCP index already matches the released version; nothing to do."
-            exit 0
-          fi
           git add bestax-mcp/data
           # Signed and attributed by the GPG config imported above, matching the
           # release commits. Skips CI for the same reason they do: this commit
           # is correct by construction, and letting it trigger the publish job
           # again would re-run the whole release pipeline to do nothing.
-          git commit -S -m "chore(bestax-mcp): restamp index after release [skip ci]"
+          #
+          # --no-verify because `pnpm install` above installed husky's hooks
+          # into .git/hooks, and those are repo-owned code. Without it, a commit
+          # hook would execute in the one step that holds the bypass token,
+          # which is the thing this split exists to prevent. The message is
+          # machine-generated and already conventional, so nothing is lost.
+          git commit -S --no-verify -m "chore(bestax-mcp): restamp index after release [skip ci]"
           if ! git push "https://x-access-token:${RESTAMP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main; then
             echo "::error::Packages published, but pushing the MCP index restamp to main failed. Run 'pnpm gen:mcp' on main and commit, or every new branch will fail gen:mcp:check."
             exit 1

--- a/bestax-mcp/data/catalog.json
+++ b/bestax-mcp/data/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generatedFrom": {
     "package": "@allxsmith/bestax-bulma",
-    "version": "5.11.0"
+    "version": "5.11.1"
   },
   "docsBase": "https://bestax.io/docs",
   "categories": [


### PR DESCRIPTION
Fixes the version-stamp race that went red on #518 and #520 today, on work unrelated to bestax-mcp in both cases.

## The bug

`scripts/gen-mcp-index.mjs:542` reads `bulma-ui/package.json`'s version and writes it into the **committed** `bestax-mcp/data/catalog.json` as `generatedFrom.version`. CI gates that with `gen:mcp:check` (regenerate → `git add --intent-to-add` → `git diff --exit-code`).

A release breaks the invariant and nothing repairs it:

1. semantic-release pushes `chore(release): 5.11.1` bumping `bulma-ui/package.json`.
2. Nothing in the release job regenerates `catalog.json`.
3. That commit skips CI, so **no run on main ever evaluates `gen:mcp:check`**.
4. Main now carries an index stamped `5.11.0`. Every branch — existing *or newly cut* — regenerates to `5.11.1`, diffs, and fails.

Two properties make it expensive out of proportion to its size. The failure lands on a file the PR never touched, so it reads as "my change broke something." And the one branch where the staleness lives is the one branch never checked, so main looks permanently green while being the source.

Worth correcting a common description of this: it is **not** a rebase problem. #520 was cut fresh from main after the release and still failed. Rebasing cannot help when main is where the stale file is.

## The fix

A final step in the publish job that regenerates the index and commits any change back to main.

**Why not `@semantic-release/exec` + a git asset**, which is the shape this obviously wants: `@semantic-release/git` selects assets by running `git ls-files -m -o` and micromatching the output, and each release runs with `working-directory` set to its own package. Run from `bulma-ui/`, `git ls-files` lists only files under `bulma-ui/`, so `bestax-mcp/data/catalog.json` can never appear in that list whatever the asset path says. I probed this rather than trusting the docs:

```
$ cd bulma-ui && git ls-files -m -o | grep -c bestax-mcp
0
```

It would have committed nothing while looking correct — a fix that appears applied and is not, which is the worst outcome on offer.

**That probe also found a pre-existing bug**, left alone here but worth its own issue: `bulma-ui/release.config.js` lists `pnpm-lock.yaml` as a git asset, and the root lockfile is outside that cwd too, so **that asset has never matched anything**. Release commits silently never include lockfile changes.

### Safety properties

- **Runs last**, after every publish has succeeded, so it cannot cost a release.
- **Fails loudly.** If the push fails the job goes red with packages already published — deliberately. That is the signal main needs a manual restamp, rather than a quiet return to the broken behaviour, and the `::error::` says exactly what to run.
- **No-ops when nothing released.** With no version change the generator's output is byte-identical and the guard exits early.
- **`permissions:` unchanged** (`contents: read`, `id-token: write`). The step authenticates with the App token in the remote URL — the same mechanism semantic-release uses, and necessary because the checkout runs `persist-credentials: false`, so there is no pushable credential in `.git/config`. `GITHUB_TOKEN` is not a ruleset bypass actor; the App is.
- **No new actions, no SHA changes, no allowlist growth.**

### Verification

Both guard paths exercised on this branch:

| state | guard | behaviour |
| --- | --- | --- |
| against main's current stale index | diff detected | would `git add` + commit |
| after restamping | no diff | exits 0 early |

The first row is not hypothetical — main is stale right now, so the drift branch ran against real conditions.

Full gate green (19/19, lint/format/storybook 0). Run with `--concurrency=1` because this branch does not carry #520's sync-skills race fix; that flake is unrelated and tracked there.

## Also included

One commit restamping the index for 5.11.1, repairing main's current state. #518 and #520 carry identical copies; whichever lands first makes the others no-ops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated post-release refreshes keep the MCP catalog current when updates are detected.
  * Release processing now clearly reports update failures and provides guidance for completing them manually.
  * Catalog changes are committed automatically after successful package publishing.

* **Documentation**
  * Updated the catalog to reflect `@allxsmith/bestax-bulma` version `5.11.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->