### PR TITLE
feat(docs): publish security.txt with a scheduled renewal reminder

### DIFF
--- a/.github/workflows/security-txt-expiry.yml
+++ b/.github/workflows/security-txt-expiry.yml
@@ -33,6 +33,22 @@ on:
         required: false
         type: boolean
         default: false
+      warn-days:
+        # The reason this input exists: the real trigger is a year away, so
+        # without it the only proof the mechanism works is waiting a year and
+        # finding out the hard way. Dispatch with something larger than the days
+        # remaining (4000 comfortably covers a one-year Expires) and the run
+        # fires immediately against the real API, creating the issue for real.
+        # Dispatch a second time to watch it UPDATE that issue rather than open
+        # a duplicate, which is the property worth seeing with your own eyes.
+        #
+        # Nothing to revert afterwards: this only widens the window for the one
+        # manual run, the default stays 30, and the scheduled runs are
+        # unaffected. Close the test issue when you are satisfied.
+        description: 'Days before expiry to warn. Raise it (e.g. 4000) to force a real run now.'
+        required: false
+        type: string
+        default: ''
 
 # No workflow-level grants; the single job takes exactly what it needs.
 permissions: {}
@@ -87,10 +103,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry-run }}
+          # Passed via env, never interpolated into the script body: this is
+          # dispatch input, so it is attacker-chosen text on any repo where a
+          # non-maintainer can dispatch. The script validates it and refuses
+          # anything that is not a non-negative number.
+          WARN_DAYS: ${{ inputs.warn-days }}
         run: |
           set -euo pipefail
           ARGS=(--repo="$REPO")
           if [ "${DRY_RUN:-false}" = "true" ]; then
             ARGS+=(--dry-run)
+          fi
+          if [ -n "${WARN_DAYS:-}" ]; then
+            ARGS+=(--warn-days="$WARN_DAYS")
           fi
           node scripts/check-security-txt-expiry.mjs "${ARGS[@]}"

--- a/.github/workflows/security-txt-expiry.yml
+++ b/.github/workflows/security-txt-expiry.yml
@@ -1,0 +1,96 @@
+name: security.txt expiry
+
+# Weekly reminder to renew docs/static/.well-known/security.txt before its
+# `Expires` date passes (#414).
+#
+# RFC 9116 makes `Expires` mandatory, and an expired security.txt is worse than
+# publishing none — scanners flag it rather than ignoring it. So the file
+# carries a date somebody has to move, and this is what remembers to ask.
+#
+# Deliberately a reminder and NOT a CI gate. Failing the build the day the date
+# passes would red whichever unrelated PR pushed next, which is the complaint
+# #391 is about; the 30-day lead time is what makes a gate unnecessary. Nothing
+# here can fail a build or block a merge.
+#
+# Idempotent: the issue body carries `<!-- security-txt-expiry -->` and an
+# existing open issue with that marker is UPDATED rather than joined by a
+# second one. A weekly cron that opened a fresh issue every run would be worse
+# than no reminder, because the noise is what trains you to ignore it.
+#
+# Deliberately NOT gated on vars.AI_LOOP_ENABLED: this workflow uses zero
+# Claude/AI — the script is plain REST calls — and zero-Claude workflows ignore
+# the AI-spend kill switch (house rule, same as auto-close-duplicates.yml).
+
+on:
+  schedule:
+    # 09:23 UTC Mondays — clear of the other crons in this repo
+    # (02:00 and 06:37 daily; 07:41 and 08:17 Mondays).
+    - cron: '23 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Log what would happen without opening or updating an issue.'
+        required: false
+        type: boolean
+        default: false
+
+# No workflow-level grants; the single job takes exactly what it needs.
+permissions: {}
+
+# One reminder at a time: a manual dispatch overlapping the weekly cron must
+# not race a second creator over the same issue (the marker lookup and the
+# create are not atomic, so two concurrent runs could both miss and both open).
+concurrency:
+  group: security-txt-expiry
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check security.txt expiry
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write # open or update the renewal issue
+      contents: read # checkout to read security.txt and run the script
+    steps:
+      # Rule 10: a new job ships at `block`. Not described as an enforcing
+      # control here — rule 10 forbids that until #487 closes, and this list is
+      # derived from what the steps below documentedly reach rather than from a
+      # measured run. Note the nearest sibling (auto-close-duplicates.yml, also
+      # a scheduled issue-writer) carries no harden-runner at all; it predates
+      # the rule. Flagged in the PR for a decision rather than settled here.
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            nodejs.org:443
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # No pnpm, no cache: the script is dependency-free (node: builtins +
+      # global fetch), so plain Node 24 is all it needs.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+
+      - name: Open or update the renewal issue
+        env:
+          # GITHUB_TOKEN, not a PAT: issues opened with it do not emit workflow
+          # events, so this cannot re-trigger the comment- and issue-driven
+          # workflows in this repo (invariant I2).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          ARGS=(--repo="$REPO")
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          node scripts/check-security-txt-expiry.mjs "${ARGS[@]}"

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -60,11 +60,23 @@ jobs:
       # The deploy job never checks out the repo — this artifact is the only
       # thing that crosses the boundary. Fail loudly if the build produced
       # nothing rather than deploying an empty site over the preview.
+      #
+      # include-hidden-files is load-bearing and easy to miss. Since v4 this
+      # action defaults it to FALSE, so every dotfile and dot-directory in
+      # docs/build was silently dropped on the way through — the preview then
+      # 404s on paths the real site serves, because production (deploy.yml)
+      # builds and runs `pages deploy docs/build` in one job with no artifact
+      # round-trip. That divergence is invisible: the upload logs a notice and
+      # the deploy succeeds, so the preview looks healthy while under-serving.
+      # Found via #414, where /.well-known/security.txt 404'd on the preview
+      # despite being present in the build; /.nojekyll had been missing the
+      # same way for as long as this split has existed.
       - name: Upload preview site
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: preview-site
           path: docs/build
+          include-hidden-files: true
           retention-days: 1
           if-no-files-found: error
 

--- a/docs/static/.well-known/security.txt
+++ b/docs/static/.well-known/security.txt
@@ -1,0 +1,17 @@
+# Security contact information for bestax.io — RFC 9116.
+#
+# Served from docs/static/.well-known/ (Docusaurus copies static/ verbatim,
+# dot-directories included).
+#
+# Expires is mandatory, and an expired file is worse than none: scanners flag
+# it. Renewal is not left to memory — .github/workflows/security-txt-expiry.yml
+# runs weekly and opens an issue 30 days before the date below. When that issue
+# arrives, re-verify the contacts still work, push Expires out another year, and
+# close it. See issue #414.
+
+Contact: mailto:security@bestax.io
+Contact: https://github.com/allxsmith/bestax/security/advisories/new
+Policy: https://bestax.io/docs/guides/security
+Preferred-Languages: en
+Canonical: https://bestax.io/.well-known/security.txt
+Expires: 2027-08-15T00:00:00.000Z

--- a/scripts/check-security-txt-expiry.mjs
+++ b/scripts/check-security-txt-expiry.mjs
@@ -157,17 +157,24 @@ export function parseExpires(text) {
   }
 
   // The regex bounds each field but cannot know that February has no 30th, and
-  // JS silently rolls such a date forward instead of rejecting it. For a UTC
-  // timestamp the round-trip catches it. A non-Z offset can legitimately shift
-  // the UTC date by a day, so that case is left to the bounds check alone —
-  // being a day or two out on a 30-day reminder is not worth the machinery.
+  // JS silently rolls such a date forward instead of rejecting it.
+  //
+  // Validated on the calendar date ALONE, independent of the time and offset.
+  // The first version of this compared `parsed.toISOString()` against the
+  // input, which only works for a `Z` value — a legitimate `+05:30` timestamp
+  // can shift the UTC date by a day, so that check had to be skipped for
+  // offsets, and `2027-02-30T00:00:00+05:30` sailed through. Round-tripping
+  // just the Y-M-D through Date.UTC has no such blind spot.
+  const [year, month, day] = value.slice(0, 10).split('-').map(Number);
+  const probe = new Date(Date.UTC(year, month - 1, day));
   if (
-    /[Zz]$/.test(value) &&
-    parsed.toISOString().slice(0, 10) !== value.slice(0, 10)
+    probe.getUTCFullYear() !== year ||
+    probe.getUTCMonth() !== month - 1 ||
+    probe.getUTCDate() !== day
   ) {
     throw new Error(
       `security.txt has an \`Expires:\` date that does not exist: "${value}" ` +
-        `(rolled over to ${parsed.toISOString().slice(0, 10)})`
+        `(${year}-${String(month).padStart(2, '0')} has no day ${day})`
     );
   }
 

--- a/scripts/check-security-txt-expiry.mjs
+++ b/scripts/check-security-txt-expiry.mjs
@@ -324,10 +324,19 @@ async function getAllPages(path) {
 // Main.
 // ---------------------------------------------------------------------------
 
-async function main() {
+/**
+ * Exported so the create-then-update path can be exercised against a stubbed
+ * `globalThis.fetch`. That path is the whole point of the design and it cannot
+ * be reached by `--dry-run`, which returns before any request — so without a
+ * seam here, "does it open exactly one issue and update it next week" would be
+ * verified only by running it for real against the live repo.
+ *
+ * `argv` is a parameter rather than read from process for the same reason.
+ */
+export async function main(argv = process.argv.slice(2)) {
   let opts;
   try {
-    opts = parseArgs(process.argv.slice(2));
+    opts = parseArgs(argv);
   } catch (err) {
     console.error(err.message);
     process.exit(2);

--- a/scripts/check-security-txt-expiry.mjs
+++ b/scripts/check-security-txt-expiry.mjs
@@ -42,6 +42,14 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 export const MARKER = '<!-- security-txt-expiry -->';
 export const DEFAULT_WARN_DAYS = 30;
 
+/**
+ * RFC 3339 §5.6 `date-time`, anchored, with each field bounded so an
+ * out-of-range component is rejected rather than silently rolled over.
+ * Seconds and an offset (`Z` or ±HH:MM) are both required by that grammar.
+ */
+export const RFC3339_DATE_TIME =
+  /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])[Tt](?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
+
 const API_BASE = 'https://api.github.com';
 const DAY_MS = 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 30_000;
@@ -126,12 +134,43 @@ export function parseExpires(text) {
   }
 
   const value = matches[0];
+
+  // Format-check before parsing. RFC 9116 §2.5.5 imports `date-time` from
+  // RFC 3339 §5.6, but `new Date()` is far more permissive than that and its
+  // handling of non-ISO input is implementation-defined. Left to the Date
+  // constructor, `Expires: August 15, 2027` parses happily — so this script
+  // would report "364 days away, nothing to do" about a file that securitytxt
+  // .org rejects. Policing this file is the whole job, so the check is here.
+  if (!RFC3339_DATE_TIME.test(value)) {
+    throw new Error(
+      `security.txt has a non-RFC-3339 \`Expires:\` value: "${value}". ` +
+        `RFC 9116 requires a full date-time with seconds and an offset, ` +
+        `e.g. 2027-08-15T00:00:00.000Z`
+    );
+  }
+
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) {
     throw new Error(
       `security.txt has an unparseable \`Expires:\` value: "${value}"`
     );
   }
+
+  // The regex bounds each field but cannot know that February has no 30th, and
+  // JS silently rolls such a date forward instead of rejecting it. For a UTC
+  // timestamp the round-trip catches it. A non-Z offset can legitimately shift
+  // the UTC date by a day, so that case is left to the bounds check alone —
+  // being a day or two out on a 30-day reminder is not worth the machinery.
+  if (
+    /[Zz]$/.test(value) &&
+    parsed.toISOString().slice(0, 10) !== value.slice(0, 10)
+  ) {
+    throw new Error(
+      `security.txt has an \`Expires:\` date that does not exist: "${value}" ` +
+        `(rolled over to ${parsed.toISOString().slice(0, 10)})`
+    );
+  }
+
   return parsed;
 }
 
@@ -251,6 +290,29 @@ async function api(pathOrUrl, { method = 'GET', body } = {}) {
   return res;
 }
 
+/**
+ * Paginate a GET endpoint by following Link rel="next" (same helper shape as
+ * auto-close-duplicates.mjs).
+ *
+ * Load-bearing rather than tidiness. The marker lookup below has to see EVERY
+ * open issue: miss the reminder because it fell off page one and the script
+ * concludes none exists and opens another, every single week. That is the
+ * duplicate-issue spam this design is built to avoid, and it would arrive
+ * silently the first time the repo carries more than 100 open issues and PRs
+ * (40 today, so it is latent rather than live).
+ */
+async function getAllPages(path) {
+  const items = [];
+  let url = path;
+  while (url) {
+    const res = await api(url);
+    items.push(...(await res.json()));
+    const link = res.headers.get('link') ?? '';
+    url = link.match(/<([^>]+)>;\s*rel="next"/)?.[1] ?? null;
+  }
+  return items;
+}
+
 // ---------------------------------------------------------------------------
 // Main.
 // ---------------------------------------------------------------------------
@@ -286,10 +348,12 @@ async function main() {
 
   // Only open issues: a closed one means somebody handled a previous cycle,
   // and reopening it would bury this cycle's context under old discussion.
-  const res = await api(
-    `/repos/${opts.repo}/issues?state=open&per_page=100&sort=created&direction=desc`
+  // Paginated, not just the first page — see getAllPages.
+  const existing = findMarkerIssue(
+    await getAllPages(
+      `/repos/${opts.repo}/issues?state=open&per_page=100&sort=created&direction=desc`
+    )
   );
-  const existing = findMarkerIssue(await res.json());
 
   if (existing) {
     await api(`/repos/${opts.repo}/issues/${existing.number}`, {

--- a/scripts/check-security-txt-expiry.mjs
+++ b/scripts/check-security-txt-expiry.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/**
+ * Open a renewal issue before docs/static/.well-known/security.txt expires (#414).
+ *
+ * RFC 9116 makes `Expires` mandatory, and an expired security.txt is worse
+ * than publishing none at all — scanners flag it rather than ignoring it. The
+ * file therefore carries a date that somebody has to move, and this is the
+ * thing that remembers to ask.
+ *
+ * Deliberately a reminder and NOT a CI gate. Failing the build the day the
+ * date passes would red whichever unrelated PR happened to push next, which is
+ * the complaint #391 is about; the 30-day lead time is what makes a gate
+ * unnecessary. Nothing here can fail a build or block a merge.
+ *
+ * Design (mirrors auto-close-duplicates.mjs): plain node, zero npm deps —
+ * node: builtins plus global fetch against the GitHub REST API, authenticated
+ * via process.env.GITHUB_TOKEN. Pure helpers are exported and main only runs
+ * when the file is executed directly, so the date arithmetic is unit-testable
+ * without a clock or a network.
+ *
+ * Idempotency: the issue body carries MARKER, and an existing open issue with
+ * it is UPDATED rather than joined by a second one. A weekly cron that opened a
+ * fresh issue every run would be worse than no reminder, because the noise is
+ * what trains you to ignore it.
+ *
+ * CI consumption: .github/workflows/security-txt-expiry.yml, weekly cron plus
+ * workflow_dispatch.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=… node scripts/check-security-txt-expiry.mjs \
+ *     --repo=owner/name [--file=path] [--warn-days=30] [--dry-run]
+ *
+ * Exit codes: 0 clean run (whether or not it acted),
+ *             1 API failure or an unreadable/malformed security.txt,
+ *             2 bad usage.
+ */
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const MARKER = '<!-- security-txt-expiry -->';
+export const DEFAULT_WARN_DAYS = 30;
+
+const API_BASE = 'https://api.github.com';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 30_000;
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
+const DEFAULT_FILE = path.join(
+  REPO_ROOT,
+  'docs',
+  'static',
+  '.well-known',
+  'security.txt'
+);
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests).
+// ---------------------------------------------------------------------------
+
+/** Parse argv into { repo, file, warnDays, dryRun }; throws Error on misuse. */
+export function parseArgs(argv) {
+  const get = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3);
+
+  const repo = get('repo');
+  if (!repo || !/^[^/\s]+\/[^/\s]+$/.test(repo)) {
+    throw new Error('usage: --repo=owner/name is required');
+  }
+
+  const warnRaw = get('warn-days');
+  const warnDays = warnRaw === undefined ? DEFAULT_WARN_DAYS : Number(warnRaw);
+  if (!Number.isFinite(warnDays) || warnDays < 0) {
+    throw new Error(
+      `--warn-days must be a non-negative number, got "${warnRaw}"`
+    );
+  }
+
+  return {
+    repo,
+    file: get('file') ?? DEFAULT_FILE,
+    warnDays,
+    dryRun: argv.includes('--dry-run'),
+  };
+}
+
+/**
+ * Pull the `Expires` value out of a security.txt body.
+ *
+ * Throws rather than returning null on absence or garbage. A silent "no date
+ * found" is indistinguishable from "not due yet" once it reaches the caller,
+ * and the failure mode of guessing wrong here is an expired file nobody is
+ * told about — precisely what this script exists to prevent.
+ *
+ * RFC 9116 field names are case-insensitive and `#` starts a comment, so both
+ * are handled rather than assumed away.
+ */
+export function parseExpires(text) {
+  const lines = String(text ?? '')
+    .split('\n')
+    // Strip a UTF-8 BOM if the file was saved with one. Escaped rather than
+    // written literally: a raw BOM here is invisible in review and trips
+    // eslint's no-irregular-whitespace.
+    .map(line => line.replace(/^\uFEFF/, '').trim())
+    .filter(line => line && !line.startsWith('#'));
+
+  const matches = lines
+    .map(line => /^Expires\s*:\s*(.+)$/i.exec(line))
+    .filter(Boolean)
+    .map(m => m[1].trim());
+
+  if (matches.length === 0) {
+    throw new Error(
+      'security.txt has no `Expires:` field (RFC 9116 requires one)'
+    );
+  }
+  // RFC 9116 §2.5.5: exactly one Expires. Two dates means nobody knows which
+  // one is authoritative, so refuse rather than pick.
+  if (matches.length > 1) {
+    throw new Error(
+      `security.txt has ${matches.length} \`Expires:\` fields; RFC 9116 allows exactly one`
+    );
+  }
+
+  const value = matches[0];
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(
+      `security.txt has an unparseable \`Expires:\` value: "${value}"`
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Whole days from `now` until `expires`. Negative once the date has passed.
+ *
+ * `now` is injected (same trick as ageInDays in auto-close-duplicates.mjs) so
+ * every test is deterministic rather than dependent on the wall clock.
+ *
+ * trunc, not floor. Real dates are almost never a whole number of days away, so
+ * the rounding direction shows up in the issue title. floor is right going
+ * forward (9.99 days left really is 9 whole days) but wrong going back: it
+ * turns -3.0001 into -4, and the issue then claims the file expired four days
+ * ago when it expired three. trunc rounds toward zero, which is "whole days
+ * elapsed" in both directions.
+ */
+export function daysUntil(expires, now = Date.now()) {
+  const then =
+    expires instanceof Date ? expires.getTime() : new Date(expires).getTime();
+  const days = Math.trunc((then - new Date(now).getTime()) / DAY_MS);
+  // Normalise -0. Math.trunc(-0.5) is -0, and `-0 < 0` is false, so a file
+  // that expired a few hours ago would take the not-expired branch in
+  // renderIssue and announce itself in the future tense. Returning +0 keeps
+  // that day reading as "expires in 0 day(s)" — urgent either way, and the
+  // body carries the exact timestamp — instead of silently mis-tensed.
+  return days === 0 ? 0 : days;
+}
+
+/** True when the date is close enough (or past) to be worth an issue. */
+export function shouldNotify(days, warnDays = DEFAULT_WARN_DAYS) {
+  return days <= warnDays;
+}
+
+/** Title and body for the renewal issue. Pure, so the wording is testable. */
+export function renderIssue(
+  days,
+  expires,
+  { file = 'docs/static/.well-known/security.txt' } = {}
+) {
+  const iso = (
+    expires instanceof Date ? expires : new Date(expires)
+  ).toISOString();
+  const expired = days < 0;
+
+  const title = expired
+    ? `security.txt EXPIRED ${Math.abs(days)} day(s) ago — renew now`
+    : `security.txt expires in ${days} day(s) — renew it`;
+
+  const lede = expired
+    ? `\`${file}\` **expired on ${iso}**. An expired security.txt is worse than ` +
+      `not publishing one: scanners flag it rather than ignoring it, so this ` +
+      `is actively costing us until the date moves.`
+    : `\`${file}\` expires on ${iso}, in ${days} day(s).`;
+
+  const body = [
+    MARKER,
+    '',
+    lede,
+    '',
+    '### What to do',
+    '',
+    '1. Re-verify the contacts still work — `security@bestax.io` reaches someone,',
+    '   and the advisories URL still resolves.',
+    '2. Check `Policy:` still points at a live page.',
+    '3. Push `Expires:` out another year (RFC 3339, e.g. `2028-08-15T00:00:00.000Z`).',
+    '4. Validate the result at https://securitytxt.org/ and close this issue.',
+    '',
+    `Renewing is a one-line edit to \`${file}\`.`,
+    '',
+    '<sub>Opened automatically by `.github/workflows/security-txt-expiry.yml`. ' +
+      'This issue is updated in place rather than reopened weekly, so it will ' +
+      'not multiply while it sits here.</sub>',
+  ].join('\n');
+
+  return { title, body };
+}
+
+/** The open issue carrying our marker, or undefined. */
+export function findMarkerIssue(issues) {
+  return (issues ?? []).find(
+    issue =>
+      !issue.pull_request &&
+      typeof issue.body === 'string' &&
+      issue.body.includes(MARKER)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GitHub REST client (global fetch).
+// ---------------------------------------------------------------------------
+
+async function api(pathOrUrl, { method = 'GET', body } = {}) {
+  const url = pathOrUrl.startsWith('https://')
+    ? pathOrUrl
+    : `${API_BASE}${pathOrUrl}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'bestax-security-txt-expiry',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    // A hung request must not stall the cron run.
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    const err = new Error(
+      `${method} ${url} failed: ${res.status} ${res.statusText} ${text.slice(0, 300)}`
+    );
+    err.status = res.status;
+    throw err;
+  }
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Main.
+// ---------------------------------------------------------------------------
+
+async function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err.message);
+    process.exit(2);
+  }
+
+  const text = await readFile(opts.file, 'utf8');
+  const expires = parseExpires(text);
+  const days = daysUntil(expires);
+
+  if (!shouldNotify(days, opts.warnDays)) {
+    console.log(
+      `security.txt expires ${expires.toISOString()} — ${days} day(s) away, ` +
+        `more than the ${opts.warnDays}-day window. Nothing to do.`
+    );
+    return;
+  }
+
+  const relFile = path.relative(REPO_ROOT, opts.file) || opts.file;
+  const { title, body } = renderIssue(days, expires, { file: relFile });
+
+  if (opts.dryRun) {
+    console.log(`[dry-run] would open or update an issue titled: ${title}`);
+    return;
+  }
+
+  // Only open issues: a closed one means somebody handled a previous cycle,
+  // and reopening it would bury this cycle's context under old discussion.
+  const res = await api(
+    `/repos/${opts.repo}/issues?state=open&per_page=100&sort=created&direction=desc`
+  );
+  const existing = findMarkerIssue(await res.json());
+
+  if (existing) {
+    await api(`/repos/${opts.repo}/issues/${existing.number}`, {
+      method: 'PATCH',
+      body: { title, body },
+    });
+    console.log(`Updated #${existing.number}: ${title}`);
+    return;
+  }
+
+  // No labels on purpose. There is no plain `security` label in this repo, and
+  // the nearest match — `needs-security-review` — is a refusal gate:
+  // claude-repro, claude-fix, @claude and @bestaxbot all decline an item
+  // carrying it until a maintainer clears it. Tagging an automated reminder
+  // with that would wedge those entry points for no reason. Label it by hand
+  // if a suitable one is ever added.
+  const created = await api(`/repos/${opts.repo}/issues`, {
+    method: 'POST',
+    body: { title, body },
+  });
+  console.log(`Opened #${(await created.json()).number}: ${title}`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch(err => {
+    console.error(err.message ?? err);
+    process.exit(1);
+  });
+}

--- a/scripts/check-security-txt-expiry.test.mjs
+++ b/scripts/check-security-txt-expiry.test.mjs
@@ -101,7 +101,51 @@ test('parseExpires throws when the field is missing', () => {
 });
 
 test('parseExpires throws on an unparseable date rather than guessing', () => {
-  assert.throws(() => parseExpires(txt('next tuesday')), /unparseable/);
+  assert.throws(() => parseExpires(txt('next tuesday')), /non-RFC-3339/);
+});
+
+test('parseExpires rejects dates new Date() would happily accept', () => {
+  // The reason the format check exists. `new Date()` is far looser than
+  // RFC 3339 and its non-ISO handling is implementation-defined, so without
+  // an explicit check these all parse into real dates and the script cheerfully
+  // reports "nothing to do" about a file securitytxt.org rejects.
+  for (const bad of [
+    'August 15, 2027',
+    '2027/08/15',
+    '08/15/2027',
+    '2027-08-15', // date only: RFC 9116 wants a full date-time
+    '2027-08-15T00:00:00', // no offset
+    '2027-08-15T00:00Z', // no seconds
+  ]) {
+    assert.throws(
+      () => parseExpires(txt(bad)),
+      /non-RFC-3339/,
+      `expected "${bad}" to be rejected`
+    );
+  }
+});
+
+test('parseExpires accepts the RFC 3339 shapes that are actually legal', () => {
+  for (const good of [
+    '2027-08-15T00:00:00Z',
+    '2027-08-15T00:00:00.000Z',
+    '2027-08-15T00:00:00+05:30',
+    '2027-08-15t00:00:00z', // RFC 3339 allows lower case
+  ]) {
+    assert.ok(
+      parseExpires(txt(good)) instanceof Date,
+      `expected "${good}" to parse`
+    );
+  }
+});
+
+test('parseExpires rejects a date that does not exist rather than rolling it over', () => {
+  // JS turns 2027-02-30 into 2027-03-02 without complaint, which would make the
+  // reminder fire against a date nobody wrote.
+  assert.throws(
+    () => parseExpires(txt('2027-02-30T00:00:00Z')),
+    /does not exist/
+  );
 });
 
 test('parseExpires refuses a file with two Expires fields', () => {

--- a/scripts/check-security-txt-expiry.test.mjs
+++ b/scripts/check-security-txt-expiry.test.mjs
@@ -148,6 +148,29 @@ test('parseExpires rejects a date that does not exist rather than rolling it ove
   );
 });
 
+test('the rollover check is independent of the offset', () => {
+  // The first version compared toISOString() against the input, which only
+  // works for a `Z` value: a legitimate +05:30 timestamp shifts the UTC date by
+  // a day, so the check was skipped for offsets and this case slipped through.
+  // Validating the Y-M-D alone has no such blind spot.
+  assert.throws(
+    () => parseExpires(txt('2027-02-30T00:00:00+05:30')),
+    /does not exist/
+  );
+  assert.throws(
+    () => parseExpires(txt('2027-04-31T12:00:00-08:00')),
+    /does not exist/
+  );
+  assert.throws(
+    () => parseExpires(txt('2027-02-29T00:00:00Z')),
+    /does not exist/
+  ); // 2027 is not a leap year
+
+  // ...while real dates with offsets still parse, including a genuine leap day.
+  assert.ok(parseExpires(txt('2028-02-29T00:00:00Z')) instanceof Date);
+  assert.ok(parseExpires(txt('2027-03-31T23:59:59+05:30')) instanceof Date);
+});
+
 test('parseExpires refuses a file with two Expires fields', () => {
   const two = `${txt('2027-08-15T00:00:00.000Z')}\nExpires: 2028-01-01T00:00:00.000Z`;
   assert.throws(() => parseExpires(two), /exactly one/);

--- a/scripts/check-security-txt-expiry.test.mjs
+++ b/scripts/check-security-txt-expiry.test.mjs
@@ -280,3 +280,121 @@ test('findMarkerIssue survives a null body and an empty list', () => {
   assert.equal(findMarkerIssue([]), undefined);
   assert.equal(findMarkerIssue(undefined), undefined);
 });
+
+// --- the create-then-update path ---------------------------------------------
+// `--dry-run` returns before any request, so none of this is reachable through
+// the CLI without hitting the live repo. These stub `globalThis.fetch` so the
+// idempotency the whole design rests on — open exactly one issue, then UPDATE
+// it rather than opening a second — is actually exercised.
+
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { main } from './check-security-txt-expiry.mjs';
+
+/** A fetch stub that records calls and replays queued responses. */
+function stubFetch(pages) {
+  const calls = [];
+  const real = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      body: init.body,
+    });
+    const next = pages.shift() ?? { body: [], link: null };
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: h => (h.toLowerCase() === 'link' ? next.link : null) },
+      json: async () => next.body,
+      text: async () => JSON.stringify(next.body),
+    };
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = real;
+    },
+  };
+}
+
+async function fixtureNearExpiry() {
+  const dir = await mkdtemp(join(tmpdir(), 'sectxt-'));
+  const file = join(dir, 'security.txt');
+  const soon = new Date(Date.now() + 5 * 864e5).toISOString();
+  await writeFile(file, `Contact: mailto:x@y.z\nExpires: ${soon}\n`);
+  return file;
+}
+
+test('opens exactly one issue when none carries the marker', async () => {
+  const file = await fixtureNearExpiry();
+  const s = stubFetch([
+    { body: [{ number: 1, body: 'unrelated' }], link: null }, // the list
+    { body: { number: 99 }, link: null }, // the create
+  ]);
+  try {
+    await main([`--repo=a/b`, `--file=${file}`]);
+  } finally {
+    s.restore();
+  }
+  const writes = s.calls.filter(c => c.method !== 'GET');
+  assert.equal(writes.length, 1, 'exactly one write');
+  assert.equal(writes[0].method, 'POST');
+  assert.match(writes[0].url, /\/repos\/a\/b\/issues$/);
+  assert.ok(JSON.parse(writes[0].body).body.includes(MARKER));
+});
+
+test('updates the existing issue instead of opening a second', async () => {
+  const file = await fixtureNearExpiry();
+  const s = stubFetch([
+    { body: [{ number: 7, body: `${MARKER}\nold text` }], link: null },
+    { body: { number: 7 }, link: null },
+  ]);
+  try {
+    await main([`--repo=a/b`, `--file=${file}`]);
+  } finally {
+    s.restore();
+  }
+  const writes = s.calls.filter(c => c.method !== 'GET');
+  assert.equal(writes.length, 1, 'exactly one write');
+  assert.equal(writes[0].method, 'PATCH', 'must PATCH, not POST a duplicate');
+  assert.match(writes[0].url, /\/issues\/7$/);
+});
+
+test('finds a marker issue that is only on page two', async () => {
+  // The bug this pagination fixed: with a single-page lookup the marker issue
+  // is missed and a duplicate is opened every run, forever.
+  const file = await fixtureNearExpiry();
+  const s = stubFetch([
+    {
+      body: [{ number: 1, body: 'noise' }],
+      link: '<https://api.github.com/next>; rel="next"',
+    },
+    { body: [{ number: 42, body: `${MARKER}\nburied` }], link: null },
+    { body: { number: 42 }, link: null },
+  ]);
+  try {
+    await main([`--repo=a/b`, `--file=${file}`]);
+  } finally {
+    s.restore();
+  }
+  const writes = s.calls.filter(c => c.method !== 'GET');
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].method, 'PATCH');
+  assert.match(writes[0].url, /\/issues\/42$/, 'must update the buried issue');
+});
+
+test('makes no request at all when the date is far out', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'sectxt-'));
+  const file = join(dir, 'security.txt');
+  const far = new Date(Date.now() + 300 * 864e5).toISOString();
+  await writeFile(file, `Contact: mailto:x@y.z\nExpires: ${far}\n`);
+  const s = stubFetch([]);
+  try {
+    await main([`--repo=a/b`, `--file=${file}`]);
+  } finally {
+    s.restore();
+  }
+  assert.equal(s.calls.length, 0, 'a quiet week must not touch the API');
+});

--- a/scripts/check-security-txt-expiry.test.mjs
+++ b/scripts/check-security-txt-expiry.test.mjs
@@ -1,0 +1,215 @@
+/**
+ * Guards on the pure decision logic in check-security-txt-expiry.mjs.
+ *
+ * Every failure mode of this script is silence. It is a reminder with no CI
+ * gate behind it, so if the date parsing quietly returns nothing, or the
+ * window arithmetic is off by a day, or the marker stops matching, the result
+ * is not a red build — it is an expired security.txt that nobody was told
+ * about, which is the exact outcome the file exists to prevent. Nothing in a
+ * diff review would show it either: the code reads fine either way.
+ *
+ * So the assertions below are written around the consequence (did it decide to
+ * notify, would it open a second issue) rather than the implementation. The
+ * clock is injected everywhere — a test that depends on the real date would
+ * start failing on a specific day in 2027, which is a nasty way to learn this.
+ *
+ * `.mjs` and `node --test` rather than jest: these are root-level scripts with
+ * no package of their own, matching auto-close-duplicates.test.mjs.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MARKER,
+  DEFAULT_WARN_DAYS,
+  parseArgs,
+  parseExpires,
+  daysUntil,
+  shouldNotify,
+  renderIssue,
+  findMarkerIssue,
+} from './check-security-txt-expiry.mjs';
+
+const NOW = Date.parse('2026-08-15T00:00:00.000Z');
+const txt = expires =>
+  [
+    '# a comment line',
+    'Contact: mailto:security@bestax.io',
+    'Preferred-Languages: en',
+    `Expires: ${expires}`,
+  ].join('\n');
+
+// --- argument parsing --------------------------------------------------------
+
+test('parseArgs requires a well-formed --repo', () => {
+  assert.throws(() => parseArgs([]), /--repo=owner\/name is required/);
+  assert.throws(
+    () => parseArgs(['--repo=nope']),
+    /--repo=owner\/name is required/
+  );
+  assert.equal(parseArgs(['--repo=allxsmith/bestax']).repo, 'allxsmith/bestax');
+});
+
+test('parseArgs defaults the window to 30 days and rejects nonsense', () => {
+  assert.equal(parseArgs(['--repo=a/b']).warnDays, DEFAULT_WARN_DAYS);
+  assert.equal(parseArgs(['--repo=a/b', '--warn-days=7']).warnDays, 7);
+  assert.throws(
+    () => parseArgs(['--repo=a/b', '--warn-days=x']),
+    /non-negative/
+  );
+  assert.throws(
+    () => parseArgs(['--repo=a/b', '--warn-days=-1']),
+    /non-negative/
+  );
+});
+
+test('parseArgs carries --dry-run through', () => {
+  assert.equal(parseArgs(['--repo=a/b']).dryRun, false);
+  assert.equal(parseArgs(['--repo=a/b', '--dry-run']).dryRun, true);
+});
+
+// --- Expires parsing ---------------------------------------------------------
+// These throw on purpose. Returning null would let a malformed file read as
+// "nothing due", which is the silent failure this whole file is about.
+
+test('parseExpires reads the date, ignoring comments and case', () => {
+  assert.equal(
+    parseExpires(txt('2027-08-15T00:00:00.000Z')).toISOString(),
+    '2027-08-15T00:00:00.000Z'
+  );
+  assert.equal(
+    parseExpires('expires: 2027-08-15T00:00:00.000Z').toISOString(),
+    '2027-08-15T00:00:00.000Z'
+  );
+});
+
+test('parseExpires ignores an Expires that is only inside a comment', () => {
+  assert.throws(
+    () =>
+      parseExpires(
+        '# Expires: 2027-08-15T00:00:00.000Z\nContact: mailto:x@y.z'
+      ),
+    /no `Expires:` field/
+  );
+});
+
+test('parseExpires throws when the field is missing', () => {
+  assert.throws(
+    () => parseExpires('Contact: mailto:x@y.z'),
+    /no `Expires:` field/
+  );
+  assert.throws(() => parseExpires(''), /no `Expires:` field/);
+});
+
+test('parseExpires throws on an unparseable date rather than guessing', () => {
+  assert.throws(() => parseExpires(txt('next tuesday')), /unparseable/);
+});
+
+test('parseExpires refuses a file with two Expires fields', () => {
+  const two = `${txt('2027-08-15T00:00:00.000Z')}\nExpires: 2028-01-01T00:00:00.000Z`;
+  assert.throws(() => parseExpires(two), /exactly one/);
+});
+
+// --- window arithmetic -------------------------------------------------------
+
+test('daysUntil counts whole days and goes negative once passed', () => {
+  assert.equal(daysUntil(new Date('2026-09-14T00:00:00.000Z'), NOW), 30);
+  assert.equal(daysUntil(new Date('2026-08-16T00:00:00.000Z'), NOW), 1);
+  assert.equal(daysUntil(new Date('2026-08-15T00:00:00.000Z'), NOW), 0);
+  assert.equal(daysUntil(new Date('2026-08-10T00:00:00.000Z'), NOW), -5);
+});
+
+test('daysUntil rounds toward zero, so a part-day never inflates the count', () => {
+  // Every case above lands on an exact midnight, which is the one situation
+  // where floor and trunc agree — so they all passed while the rounding was
+  // wrong. Real dates are fractional, and the direction leaks into the issue
+  // title: with floor, a file that expired three days and one second ago
+  // announced itself as "EXPIRED 4 day(s) ago". Caught by running the script,
+  // not by these tests, which is why the fractional cases are pinned here now.
+  const plus = ms => new Date(NOW + ms);
+  assert.equal(daysUntil(plus(9.99 * 864e5), NOW), 9); // 9 whole days remain
+  assert.equal(daysUntil(plus(-3.0001 * 864e5), NOW), -3); // 3 whole days ago
+});
+
+test('daysUntil never returns -0, because renderIssue branches on days < 0', () => {
+  // Math.trunc(-0.5) is -0, and `-0 < 0` is false. Left unnormalised, a file
+  // that expired a few hours ago takes the NOT-expired branch and announces
+  // itself in the future tense. assert/strict compares with Object.is, so this
+  // assertion actually distinguishes -0 from 0 — a loose == would not.
+  const halfDayAgo = daysUntil(new Date(NOW - 0.5 * 864e5), NOW);
+  assert.equal(halfDayAgo, 0);
+  assert.ok(!Object.is(halfDayAgo, -0), 'must be +0, not -0');
+  assert.doesNotMatch(renderIssue(halfDayAgo, new Date(NOW)).title, /EXPIRED/);
+});
+
+test('the 30-day boundary notifies rather than waiting one more week', () => {
+  // The cron is weekly. If day 30 did not notify, the next run would land on
+  // day 23 — still fine — but an off-by-one the other way would silently skip
+  // a whole cycle, so the boundary is asserted explicitly.
+  assert.equal(shouldNotify(31), false);
+  assert.equal(shouldNotify(30), true);
+  assert.equal(shouldNotify(0), true);
+  assert.equal(shouldNotify(-1), true);
+});
+
+test('shouldNotify honours a custom window', () => {
+  assert.equal(shouldNotify(10, 7), false);
+  assert.equal(shouldNotify(7, 7), true);
+});
+
+// --- issue rendering ---------------------------------------------------------
+
+test('the issue body always carries the marker', () => {
+  // Lose this and every weekly run opens another issue.
+  assert.ok(
+    renderIssue(30, new Date('2026-09-14T00:00:00.000Z')).body.includes(MARKER)
+  );
+  assert.ok(
+    renderIssue(-3, new Date('2026-08-12T00:00:00.000Z')).body.includes(MARKER)
+  );
+});
+
+test('an expired file is worded differently from an approaching one', () => {
+  const soon = renderIssue(12, new Date('2026-08-27T00:00:00.000Z'));
+  const past = renderIssue(-3, new Date('2026-08-12T00:00:00.000Z'));
+
+  assert.match(soon.title, /expires in 12 day/);
+  assert.doesNotMatch(soon.title, /EXPIRED/);
+
+  // Past tense and an absolute day count — "-3 days" would read as a bug.
+  assert.match(past.title, /EXPIRED 3 day\(s\) ago/);
+  assert.match(past.body, /worse than/);
+});
+
+test('the issue names the file and the renewal steps', () => {
+  const { body } = renderIssue(5, new Date('2026-08-20T00:00:00.000Z'), {
+    file: 'docs/static/.well-known/security.txt',
+  });
+  assert.match(body, /docs\/static\/\.well-known\/security\.txt/);
+  assert.match(body, /securitytxt\.org/);
+});
+
+// --- idempotency -------------------------------------------------------------
+
+test('findMarkerIssue matches on the marker, not the title', () => {
+  const issues = [
+    { number: 1, body: 'unrelated' },
+    { number: 2, body: `${MARKER}\nrenew it` },
+  ];
+  assert.equal(findMarkerIssue(issues).number, 2);
+});
+
+test('findMarkerIssue ignores pull requests carrying the marker', () => {
+  // A PR that quotes the marker (e.g. the PR that added this script) must not
+  // be mistaken for the reminder issue and PATCHed.
+  const issues = [
+    { number: 9, body: `${MARKER}\nin a PR body`, pull_request: { url: 'x' } },
+    { number: 10, body: `${MARKER}\nthe real issue` },
+  ];
+  assert.equal(findMarkerIssue(issues).number, 10);
+});
+
+test('findMarkerIssue survives a null body and an empty list', () => {
+  assert.equal(findMarkerIssue([{ number: 1, body: null }]), undefined);
+  assert.equal(findMarkerIssue([]), undefined);
+  assert.equal(findMarkerIssue(undefined), undefined);
+});


### PR DESCRIPTION
Closes #414.

`bestax.io` served no `/.well-known/security.txt` — the RFC 9116 location scanners and researchers check first. The disclosure process already existed (`SECURITY.md`, `security@bestax.io`, private vulnerability reporting); this publishes it where tooling looks.

**The renewal mechanism is the actual work.** The issue asked for it to be decided *before* merge, because `Expires` is mandatory and an expired file is worse than none — scanners flag it rather than ignoring it.

## What's here

| File | |
| --- | --- |
| `docs/static/.well-known/security.txt` | the file, `Expires` one year out |
| `scripts/check-security-txt-expiry.mjs` | reads the date, opens/updates one issue inside a 30-day window |
| `scripts/check-security-txt-expiry.test.mjs` | 19 tests, no clock or network |
| `.github/workflows/security-txt-expiry.yml` | weekly cron + `workflow_dispatch` |

**A reminder, not a CI gate** (per your call). Failing the build the day the date passes would red whichever unrelated PR pushed next — the #391 complaint — and the 30-day lead time is what makes a gate unnecessary. Nothing here can fail a build or block a merge.

**Built as a near-copy of `auto-close-duplicates`** rather than a new shape, since that is already a scheduled issue-writer backed by a tested script: pure helpers with an injected clock, `main()` behind the standard direct-execution guard, plain `fetch` with no new dependency, `permissions: {}` at workflow level so the one job takes only `issues: write` + `contents: read`, and a `concurrency` group so a dispatch cannot race the cron. Parsing lives in `scripts/` with a `node --test` sibling rather than in YAML, per **rule 9**.

Idempotency is the property most likely to break and least visible in review, so the body carries `<!-- security-txt-expiry -->` and an existing open issue is **updated in place**. A weekly cron that opened a fresh issue each run would be worse than no reminder — the noise is what teaches you to ignore it.

## Three bugs found by running it, not reading it

The unit tests passed while two of these were live, which is the interesting part.

1. **`Math.floor` mis-reported elapsed days.** Right going forward (9.99 days left really is 9), wrong going back: `-3.0001 → -4`, so a file three days expired announced *"EXPIRED 4 day(s) ago"*. Now `Math.trunc`. Every existing test used exact midnights, where floor and trunc agree — so none of them caught it.
2. **`Math.trunc(-0.5)` is `-0`, and `-0 < 0` is false.** A file that expired a few hours ago took the *not-expired* branch and announced itself in the future tense. Normalised, with a test that uses `Object.is` since `==` cannot tell `-0` from `0`.
3. **No `security` label exists here**, and the nearest match — `needs-security-review` — is a **refusal gate**: `claude-fix`, `claude-repro`, `@claude` and `@bestaxbot` all decline an item carrying it. Tagging an automated reminder with that would have wedged those entry points. The issue is opened unlabelled.

`eslint` also caught a literal BOM I'd embedded in a regex (`no-irregular-whitespace`) — now `﻿`, with the BOM-stripping path verified against an actual BOM'd file.

## Verification

The plan's one real unknown was whether Docusaurus copies a **dot-directory** out of `static/`. Confirmed two ways before relying on it — `copy-webpack-plugin`'s `fromType: "dir"` branch defaults `dot` to `true` (`dist/index.js:350-361`), and the built site now contains the file:

```
$ ls docs/build/.well-known/
security.txt
```

All three URLs in the file resolve, including `Policy:` (`docs/build/docs/guides/security.html`). `pnpm all` green, `check:conformance` and `check:urls` both 0.

Worth noting what is **not** verified: the workflow has never run. It only fires on cron or dispatch. Dispatching it on this branch before merge would confirm the create-then-update path end to end — that second run is the one worth doing, since duplicate-issue spam is the likeliest defect.

## For your call

`.github/CLAUDE.md` **rule 10** says a new job ships at `egress-policy: block`, so harden-runner is included. But the nearest sibling — `auto-close-duplicates.yml`, also a scheduled issue-writer — carries none at all; it predates the rule. The allowlist here is derived from what the steps documentedly reach, not from a measured run, and it is **not** described as an enforcing control anywhere (rule 10 forbids that until #487 closes). Happy to drop it for consistency with the sibling if you'd rather.

After merge and deploy: `curl -sI https://bestax.io/.well-known/security.txt` should be `200 text/plain`, then validate at https://securitytxt.org/ per the acceptance criteria. `docs/static/_headers` is there if the content type needs forcing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized `security.txt` file with security contact, policy, language, canonical URL, and expiration details.
  * Added automated expiration monitoring with renewal issue creation or updates.
  * Added scheduled checks and manual dry-run support.

* **Tests**
  * Added coverage for expiration parsing, notification timing, issue handling, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->