### PR TITLE
ci: verify every published package installs and carries provenance

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -302,7 +302,7 @@ jobs:
           cd "$RUNNER_TEMP/verify"
           npm init -y > /dev/null
           npm install --ignore-scripts \
-            @allxsmith/bestax-bulma create-bestax bestax-migrate
+            @allxsmith/bestax-bulma create-bestax bestax-migrate bestax-mcp
 
       - name: Audit registry signatures and provenance attestations
         run: |
@@ -318,7 +318,7 @@ jobs:
         run: |
           fail=0
           cd "$RUNNER_TEMP/verify"
-          for pkg in @allxsmith/bestax-bulma create-bestax bestax-migrate; do
+          for pkg in @allxsmith/bestax-bulma create-bestax bestax-migrate bestax-mcp; do
             # Pin to the version that was actually installed and audited above.
             # A bare `npm view "$pkg"` re-resolves the `latest` dist-tag, which
             # is mutable, so a publish landing between the install step and this

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -317,7 +317,27 @@ jobs:
       - name: Assert our packages actually carry provenance
         run: |
           fail=0
+          cd "$RUNNER_TEMP/verify"
           for pkg in @allxsmith/bestax-bulma create-bestax bestax-migrate; do
+            # Pin to the version that was actually installed and audited above.
+            # A bare `npm view "$pkg"` re-resolves the `latest` dist-tag, which
+            # is mutable, so a publish landing between the install step and this
+            # one would have this step vouch for a version the job never
+            # installed. Reading the version back out of the tree keeps all
+            # three steps talking about the same artifacts. Local read, no
+            # network, so it belongs outside the retry loop below.
+            #
+            # Absent from the tree is its own failure, reported as such rather
+            # than folded into the "no provenance" message below — a missing
+            # install and a dropped attestation want different investigations.
+            version=$(npm ls "$pkg" --depth=0 --json 2>/dev/null \
+              | jq -r --arg pkg "$pkg" '.dependencies[$pkg].version // empty' 2>/dev/null || true)
+            if [ -z "$version" ]; then
+              echo "::error::$pkg is not in the installed tree; cannot verify its provenance"
+              fail=1
+              continue
+            fi
+
             # --json + a type guard so only a real string counts as present:
             # null, undefined, [] and non-strings all collapse to empty. The
             # array branch covers npm aggregating a bare spec into one element.
@@ -330,16 +350,16 @@ jobs:
             # spend three attempts before believing provenance is really gone.
             predicate=""
             for attempt in 1 2 3; do
-              predicate=$(npm view "$pkg" dist.attestations.provenance.predicateType --json 2>/dev/null \
+              predicate=$(npm view "$pkg@$version" dist.attestations.provenance.predicateType --json 2>/dev/null \
                 | jq -r 'if type=="array" then .[0] else . end | select(type=="string")' 2>/dev/null || true)
               [ -n "$predicate" ] && break
               [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
             done
             if [ -z "$predicate" ]; then
-              echo "::error::$pkg has NO provenance attestation on the registry"
+              echo "::error::$pkg@$version has NO provenance attestation on the registry"
               fail=1
             else
-              echo "ok: $pkg -> $predicate"
+              echo "ok: $pkg@$version -> $predicate"
             fi
           done
           exit "$fail"

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -287,17 +287,22 @@ jobs:
       # the loop by running it ourselves against the real published tarballs
       # rather than the local workspace. npm (not pnpm) on purpose: the
       # signature audit needs an npm-resolved tree and lockfile.
-      # bestax-migrate is deliberately absent: its published manifest still
-      # carries an unresolved `workspace:^` specifier, so `npm install` of it
-      # fails outright and would mask real signature failures here. Add it back
-      # once that is fixed.
+      #
+      # This step is itself the assertion, not just setup for the audit below:
+      # `npm install` exits non-zero on an uninstallable package, so the job
+      # goes red whether the artifact is unsigned or simply broken. That is the
+      # check #412 did not have — it shipped an uninstallable `workspace:^`
+      # manifest precisely because everything else in CI resolves against the
+      # workspace, where the specifier works.
+      #
+      # Keep this list in sync with the provenance loop below.
       - name: Install published packages into a scratch tree
         run: |
           mkdir -p "$RUNNER_TEMP/verify"
           cd "$RUNNER_TEMP/verify"
           npm init -y > /dev/null
           npm install --ignore-scripts \
-            @allxsmith/bestax-bulma create-bestax
+            @allxsmith/bestax-bulma create-bestax bestax-migrate
 
       - name: Audit registry signatures and provenance attestations
         run: |
@@ -312,7 +317,7 @@ jobs:
       - name: Assert our packages actually carry provenance
         run: |
           fail=0
-          for pkg in @allxsmith/bestax-bulma create-bestax; do
+          for pkg in @allxsmith/bestax-bulma create-bestax bestax-migrate; do
             # --json + a type guard so only a real string counts as present:
             # null, undefined, [] and non-strings all collapse to empty. The
             # array branch covers npm aggregating a bare spec into one element.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,16 +3,17 @@
 ## Supported Versions
 
 Security fixes land on the **latest release line only** — currently
-`@allxsmith/bestax-bulma` 5.x, `create-bestax` 3.x, and `bestax-migrate` 1.x.
-All three packages release automatically from `main` (semantic-release), so the
-latest published version is always the patched one. Older majors may still work
-but receive no security updates; please upgrade.
+`@allxsmith/bestax-bulma` 5.x, `create-bestax` 4.x, `bestax-migrate` 2.x, and
+`bestax-mcp` 1.x. All four packages release automatically from `main`
+(semantic-release), so the latest published version is always the patched one.
+Older majors may still work but receive no security updates; please upgrade.
 
 | Package                   | Supported    | Unsupported |
 | ------------------------- | ------------ | ----------- |
 | `@allxsmith/bestax-bulma` | 5.x (latest) | < 5.0       |
-| `create-bestax`           | 3.x (latest) | < 3.0       |
-| `bestax-migrate`          | 1.x (latest) | —           |
+| `create-bestax`           | 4.x (latest) | < 4.0       |
+| `bestax-migrate`          | 2.x (latest) | < 2.0       |
+| `bestax-mcp`              | 1.x (latest) | —           |
 
 ## Supply-Chain Security
 
@@ -42,7 +43,7 @@ Measures active in this repository and its release pipeline:
   reviewed lockfile resolves. (The React 18/19 compatibility matrix is the
   one deliberate exception: it re-resolves to pin the requested React major
   for testing, and never publishes.)
-- **npm provenance** — all three published packages set
+- **npm provenance** — all four published packages set
   `publishConfig.provenance`, so every release carries a signed attestation
   linking the tarball to the exact commit and CI run that built it.
 - **OIDC trusted publishing** — releases authenticate to npm with

--- a/docs/docs/guides/security.md
+++ b/docs/docs/guides/security.md
@@ -19,9 +19,10 @@ npm via **OIDC trusted publishing** (short-lived, per-run tokens), so there is
 no long-lived npm token that could leak and be used to push a rogue release.
 
 Only the **latest release line** of each package receives security fixes
-(currently bestax-bulma 5.x and create-bestax 3.x). Releases are fully
-automated from `main` via semantic-release, so the newest published version is
-always the patched one — staying current is the supported posture. See
+(currently bestax-bulma 5.x, create-bestax 4.x, bestax-migrate 2.x, and
+bestax-mcp 1.x). Releases are fully automated from `main` via semantic-release,
+so the newest published version is always the patched one — staying current is
+the supported posture. See
 [SECURITY.md](https://github.com/allxsmith/bestax/blob/main/SECURITY.md) for
 the full policy.
 


### PR DESCRIPTION
Closes #416.

`bestax-migrate` was excluded from `verify-provenance` because its published manifest carried an unresolved `workspace:^` specifier — `npm install` of it failed with `EUNSUPPORTEDPROTOCOL` (#412) and would have masked real signature failures. #412 is fixed and released, #411 is merged, so the workaround becomes a permanent regression guard.

While verifying that, two further gaps turned up. The job now covers **all four** published packages, and the user-facing claims about which versions are supported are correct again.

## What changed

**`.github/workflows/supply-chain.yml`** — the `verify-provenance` job:

- The `npm install` list and the `for pkg in …` provenance loop both gain `bestax-migrate` **and** `bestax-mcp`. The issue's diff only named the install list; leaving the assertion loop behind would mean a silently dropped attestation stays green forever, which is the exact hole that step exists to close.
- The assertion pins to the version actually installed (`npm view "$pkg@$version"`) instead of re-resolving the mutable `latest` dist-tag. Install, `npm audit signatures`, and the assertion now provably describe one set of artifacts rather than three independent resolutions. Absent-from-tree gets its own `::error::` — a missing install and a dropped attestation want different investigations. Both paths still fail closed, per rule 4.
- The stale exclusion comment is replaced with one stating what the install step is *for*. It already asserted installability, it just read as setup for the audit.

**`SECURITY.md` and `docs/docs/guides/security.md`** — the supported-versions table had drifted two majors behind on two packages and never gained a row for the fourth: `create-bestax` is 4.x not 3.x, `bestax-migrate` is 2.x not 1.x, and `bestax-mcp` was missing entirely. Both majors were the Node 22 requirement from #447, not an API break. That table is what tells users which line receives security fixes, so being wrong about it is a security-relevant inaccuracy rather than a docs nit. The provenance bullet said "all three published packages" for the same reason, and the docs guide named only two of the four.

## `bestax-mcp` — a correction to this PR's own first draft

I originally excluded `bestax-mcp` here citing #502 ("CI has no `Semantic Release (bestax-mcp)` step, so the package can never publish"). **#502 is stale.** `ci.yml:298` has that step, and `bestax-mcp@1.0.0` is on the registry with a SLSA provenance attestation and clean dependencies. Verified it installs alongside the other three before adding it.

That issue is still open and should probably be closed, but that is a maintainer call rather than something to fold into this PR.

## Security review

Per `.github/CLAUDE.md`, this is a bottom-row change, and here is the check rather than the assertion:

- **No `permissions:` change.** `verify-provenance` declares none and inherits the workflow-level `contents: read`.
- **No credential in the job**, so rule 2 does not apply — there is no allowlist here.
- No trigger change, no action SHA change, no new repository variable, nothing that spends model usage.
- Rule 10: `verify-provenance` is one of the three jobs grandfathered by the "existing live job" clause. Adding `harden-runner` to it is out of scope here.
- I1/I2 untouched — no model session, no comment body, no PAT.

The change widens *what the job installs*, which is the point of the guard. It cannot widen what the job is permitted to do.

**Rejected alternative:** hoisting the package list into a job-level `env:` consumed by both steps. It removes the drift risk the sync comment only warns about, but both call sites would then depend on unquoted shell word-splitting inside a security check — not worth the subtlety for two lists fifteen lines apart.

## Verification

Dispatched on this branch after each commit. Latest — [run 32041442143](https://github.com/allxsmith/bestax/actions/runs/32041442143) — `verify-provenance` green, release-only jobs skipped as expected:

```
added 204 packages, and audited 205 packages in 7s
204 packages have verified registry signatures
58 packages have verified attestations
ok: @allxsmith/bestax-bulma@5.11.1 -> https://slsa.dev/provenance/v1
ok: create-bestax@4.1.0 -> https://slsa.dev/provenance/v1
ok: bestax-migrate@2.0.0 -> https://slsa.dev/provenance/v1
ok: bestax-mcp@1.0.0 -> https://slsa.dev/provenance/v1
```

Both fail-closed branches were also exercised directly: an empty scratch tree produces the not-in-tree error, and `bestax-migrate@0.0.1` (predates provenance) yields an empty predicate.

`bestax-migrate@2.0.0`'s published manifest was checked directly too — all four dependencies are plain semver ranges, no `workspace:`/`catalog:` in any section, and it does not drag in `@allxsmith/bestax-bulma` (the second bug from #417).

## Out of scope

**#437** (nothing installs the packed tarball *pre*-publish) stays open. That check runs `npm pack` and installs the tarball before publishing; this one verifies what is already on the registry.