### PR TITLE
ci: verify pointer URLs against the API, and warn when a host won't answer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,18 @@ jobs:
       - name: Format Check
         run: pnpm run format:check
 
+      # github.com URLs are verified through the REST API rather than the web
+      # UI (#525): during the 2026-08-17 incident the API answered 200 for the
+      # same file whose blob page was 404ing, and this failed every open PR.
+      # The token is the job's own read-only GITHUB_TOKEN — it buys the
+      # authenticated rate limit, so a shared runner IP does not get throttled
+      # into a false "link is gone". The check falls back to unauthenticated
+      # requests when it is unset, which is how it runs on a contributor's
+      # laptop.
       - name: Pointer file URLs resolve
         run: pnpm run check:urls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Audit (high severity)
         run: pnpm audit --audit-level=high

--- a/scripts/check-pointer-urls.mjs
+++ b/scripts/check-pointer-urls.mjs
@@ -1,55 +1,246 @@
 #!/usr/bin/env node
-// Verify that every URL in the agent-discovery pointer files shipped in the
-// bestax-bulma tarball (issue #344) still resolves, so a release can't ship
-// dead links to the docs site.
+/**
+ * Verify that every URL in the agent-discovery pointer files shipped in the
+ * bestax-bulma tarball (issue #344) still resolves, so a release can't ship
+ * dead links to the docs site.
+ *
+ * Runs in ci.yml's `Build and Test` job (`pnpm run check:urls`), a required
+ * check — so this decides whether every open PR is red. #525 is the record of
+ * getting that wrong: during the 2026-08-17 GitHub incident this failed #524
+ * on `blob/main/SECURITY.md` with a 404 while the file was present on `main`
+ * the whole time.
+ *
+ * Two design choices come straight out of that incident, and neither is the
+ * obvious one:
+ *
+ * 1. **github.com URLs are verified through the REST API, not the web UI.**
+ *    Retrying would not have helped — the outage lasted hours. What was
+ *    measurably true at the time is that `/repos/{owner}/{repo}/contents/...`
+ *    answered 200 for the very file whose blob page was 404ing. The API is
+ *    also the authenticated path, so it does not collect the anonymous 403
+ *    rate limits a shared runner IP attracts.
+ *
+ * 2. **"Could not determine" is a warning, not a failure.** This gate exists
+ *    to catch a dead link a PR introduces. If a host will not answer, the gate
+ *    has not found a dead link — it has failed to look, and reding every open
+ *    PR for that is the cry-wolf problem #391 and #525 are both about. A
+ *    confirmed 404 still fails the build.
+ *
+ * Design mirrors check-security-txt-expiry.mjs: plain node, zero npm deps,
+ * pure helpers exported, main only runs when executed directly.
+ *
+ * Exit codes: 0 every URL resolved or could not be determined,
+ *             1 at least one URL was confirmed dead.
+ */
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fetchWithRetry } from './lib/fetch-retry.mjs';
 
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-const FILES = ['bulma-ui/llms.txt', 'bulma-ui/AGENTS.md'];
 
-const urls = new Set();
-for (const rel of FILES) {
-  const text = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+export const FILES = ['bulma-ui/llms.txt', 'bulma-ui/AGENTS.md'];
+
+/**
+ * Fail if the pointer files yield fewer URLs than this. Without a floor, a
+ * restructured pointer file or an edit to the extraction regex turns the gate
+ * into a no-op that reports "all 0 URLs resolve" and goes green having checked
+ * nothing. The number is a floor, not the current count, so adding or removing
+ * a link does not require touching it.
+ */
+export const MIN_EXPECTED_URLS = 5;
+
+/**
+ * Pull https:// URLs out of a pointer file. The trailing `[.,]` trim keeps a
+ * URL that ends a sentence from carrying the punctuation into the request.
+ */
+export function extractUrls(text) {
+  const found = [];
   for (const match of text.matchAll(/https:\/\/[^\s)`]+/g)) {
-    urls.add(match[0].replace(/[.,]$/, ''));
+    found.push(match[0].replace(/[.,]$/, ''));
   }
+  return found;
 }
 
-async function check(url) {
-  for (const method of ['HEAD', 'GET']) {
+export function collectUrls(root = repoRoot, files = FILES) {
+  const urls = new Set();
+  for (const rel of files) {
+    const text = fs.readFileSync(path.join(root, rel), 'utf8');
+    for (const url of extractUrls(text)) urls.add(url);
+  }
+  return [...urls].sort();
+}
+
+/**
+ * Map a github.com web URL to the REST endpoint that answers the same
+ * question. Returns null for shapes we have no mapping for, which fall back to
+ * fetching the page directly.
+ *
+ *   /{owner}/{repo}                     -> /repos/{owner}/{repo}
+ *   /{owner}/{repo}/blob/{ref}/{path}   -> /repos/{owner}/{repo}/contents/{path}?ref={ref}
+ *   /{owner}/{repo}/tree/{ref}/{path}   -> same contents endpoint
+ */
+export function githubApiUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.hostname !== 'github.com') return null;
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  const [owner, repo, kind, ref, ...rest] = segments;
+  if (!owner || !repo) return null;
+
+  if (segments.length === 2) {
+    return `https://api.github.com/repos/${owner}/${repo}`;
+  }
+  if ((kind === 'blob' || kind === 'tree') && ref && rest.length > 0) {
+    const filePath = rest.map(encodeURIComponent).join('/');
+    return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${encodeURIComponent(ref)}`;
+  }
+  return null;
+}
+
+/**
+ * Check one URL, preferring the authoritative endpoint where one exists.
+ *
+ * The token is optional on purpose: a contributor running `pnpm check:urls`
+ * locally has none, and the check must still work for them. Unauthenticated
+ * API requests are rate-limited but not forbidden, and a throttle now
+ * classifies as retryable rather than dead.
+ */
+export async function checkUrl(url, { token, retryOptions = {} } = {}) {
+  const apiUrl = githubApiUrl(url);
+  if (!apiUrl) return fetchWithRetry(url, retryOptions);
+
+  const result = await fetchWithRetry(apiUrl, {
+    ...retryOptions,
+    // GET only. The API answers HEAD fine (measured: 200 on the contents
+    // route), but HEAD and GET each cost one request against the rate limit,
+    // so trying HEAD first can only ever spend two where one would do.
+    methods: ['GET'],
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'bestax-check-pointer-urls',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  return { ...result, via: apiUrl };
+}
+
+/** The distinct hosts present in a set of results, for the operator's benefit. */
+export function hostsOf(entries) {
+  const hosts = new Set();
+  for (const { url } of entries) {
     try {
-      const res = await fetch(url, {
-        method,
-        redirect: 'follow',
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (res.ok) return null;
-      if (method === 'GET') return `${res.status} ${res.statusText}`;
-    } catch (err) {
-      if (method === 'GET') return err.cause?.message ?? err.message;
+      hosts.add(new URL(url).hostname);
+    } catch {
+      /* a URL we could not parse cannot name a host */
     }
   }
-  return 'unreachable';
+  return [...hosts].sort();
 }
 
-const failures = [];
-for (const url of [...urls].sort()) {
-  const problem = await check(url);
-  if (problem) {
-    failures.push(`  ${url} — ${problem}`);
-    console.error(`[check-pointer-urls] FAIL ${url} (${problem})`);
-  } else {
-    console.log(`[check-pointer-urls] ok   ${url}`);
+/**
+ * Render the undetermined URLs as a warning.
+ *
+ * Naming the hosts actually in the failing set matters: seven of the nine URLs
+ * live on bestax.io, so a message that only ever points at githubstatus.com
+ * sends the reader somewhere all-green during a Cloudflare incident — the same
+ * misdirection, one host over.
+ */
+export function formatUndetermined(entries, total) {
+  const hosts = hostsOf(entries);
+  const scope =
+    entries.length === total
+      ? `none of the ${total} URLs could be checked`
+      : `${entries.length} of ${total} URLs could not be checked`;
+  return [
+    `[check-pointer-urls] ${scope}. This is not a dead-link report — the hosts`,
+    `did not give a usable answer, so the check could not look. Affected`,
+    `host(s): ${hosts.join(', ') || 'unknown'}.`,
+    ...entries.map(e => `  ${e.url} — ${e.detail}`),
+  ].join('\n');
+}
+
+/** Render the confirmed dead links — the failures that red the build. */
+export function formatDead(entries, files = FILES) {
+  return [
+    `[check-pointer-urls] ${entries.length} URL(s) in ${files.join(', ')} are gone:`,
+    ...entries.map(e => `  ${e.url} — ${e.detail}`),
+  ].join('\n');
+}
+
+export async function main({
+  root = repoRoot,
+  files = FILES,
+  token = process.env.GITHUB_TOKEN,
+  // Forwarded to fetchWithRetry so the tests can zero the backoff; without it
+  // the suite would really sleep through every retry it exercises.
+  retryOptions = {},
+  minUrls = MIN_EXPECTED_URLS,
+} = {}) {
+  const urls = collectUrls(root, files);
+
+  if (urls.length < minUrls) {
+    console.error(
+      `[check-pointer-urls] found only ${urls.length} URL(s) in ${files.join(', ')}, ` +
+        `expected at least ${minUrls}. Refusing to report success on a check that ` +
+        `verified almost nothing — the pointer files or the extraction changed.`
+    );
+    return 1;
   }
+
+  // Concurrent, because the expensive case is a host that never answers: a
+  // sequential sweep multiplies every timeout by the number of URLs.
+  const results = await Promise.all(
+    urls.map(async url => ({
+      url,
+      ...(await checkUrl(url, { token, retryOptions })),
+    }))
+  );
+
+  const dead = [];
+  const undetermined = [];
+  for (const r of results) {
+    if (r.outcome === 'ok') {
+      console.log(
+        `[check-pointer-urls] ok   ${r.url}${r.via ? ` (via API)` : ''}`
+      );
+    } else if (r.outcome === 'dead') {
+      dead.push(r);
+      console.error(`[check-pointer-urls] DEAD ${r.url} (${r.detail})`);
+    } else {
+      undetermined.push(r);
+      console.error(`[check-pointer-urls] ????  ${r.url} (${r.detail})`);
+    }
+  }
+
+  if (undetermined.length > 0) {
+    const body = formatUndetermined(undetermined, urls.length);
+    // A GitHub Actions workflow command when running in CI, an ordinary line
+    // otherwise. Either way it does not fail the job.
+    console.error(`::warning::${body.split('\n')[0]}`);
+    console.error(body);
+  }
+
+  if (dead.length > 0) {
+    console.error(formatDead(dead, files));
+    return 1;
+  }
+
+  const checked = urls.length - undetermined.length;
+  console.log(
+    `[check-pointer-urls] ${checked}/${urls.length} URLs resolve` +
+      (undetermined.length ? ` (${undetermined.length} undetermined)` : '')
+  );
+  return 0;
 }
 
-if (failures.length > 0) {
-  console.error(
-    `[check-pointer-urls] ${failures.length} URL(s) in ${FILES.join(', ')} did not resolve:\n` +
-      failures.join('\n')
-  );
-  process.exit(1);
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  process.exitCode = await main();
 }
-console.log(`[check-pointer-urls] all ${urls.size} URLs resolve`);

--- a/scripts/check-pointer-urls.mjs
+++ b/scripts/check-pointer-urls.mjs
@@ -105,31 +105,78 @@ export function githubApiUrl(rawUrl) {
 }
 
 /**
+ * Corroborate a `dead` verdict against a second source before believing it.
+ *
+ * Only a `dead` verdict reds the build, so it is the one that has to be right,
+ * and a single source is not enough to establish it. Two ways that bites:
+ *
+ * - The #525 incident, one host over. The API fallback only covers github.com;
+ *   the other seven URLs are on bestax.io, where a CDN incident serving
+ *   spurious 404s would reproduce exactly the failure this PR removes.
+ * - `githubApiUrl` has to guess where the ref ends and the path begins, so a
+ *   branch with a slash in it (`blob/feature/x/README.md`) mis-maps and the
+ *   API 404s a file that exists.
+ *
+ * The second source differs by what is available. For a github.com URL the
+ * original web page is the corroborator, so the two only agree on "gone" when
+ * both the API and the page say so. For everything else there is no second
+ * view of the same resource, so we ask a weaker but still useful question —
+ * is the host healthy at all? A 404 from a host whose root serves fine is
+ * credible; a 404 from a host that cannot serve its own root is not.
+ *
+ * Disagreement resolves to `unreachable`, which warns and passes. That is the
+ * deliberate direction: a false "gone" reds every open PR, a false
+ * "undetermined" costs one warning and is caught on the next run.
+ */
+async function corroborateDead(url, primary, retryOptions) {
+  const isGithub = githubApiUrl(url) !== null;
+  const second = isGithub ? url : new URL(url).origin;
+
+  const check = await fetchWithRetry(second, retryOptions);
+  if (isGithub ? check.outcome === 'dead' : check.outcome === 'ok') {
+    return primary;
+  }
+  return {
+    ...primary,
+    outcome: 'unreachable',
+    detail:
+      `${primary.detail} (not corroborated: ${second} answered ` +
+      `${check.detail ?? check.status ?? check.outcome})`,
+  };
+}
+
+/**
  * Check one URL, preferring the authoritative endpoint where one exists.
  *
  * The token is optional on purpose: a contributor running `pnpm check:urls`
  * locally has none, and the check must still work for them. Unauthenticated
- * API requests are rate-limited but not forbidden, and a throttle now
- * classifies as retryable rather than dead.
+ * API requests are rate-limited but not forbidden, and a throttle classifies
+ * as retryable rather than dead.
  */
 export async function checkUrl(url, { token, retryOptions = {} } = {}) {
   const apiUrl = githubApiUrl(url);
-  if (!apiUrl) return fetchWithRetry(url, retryOptions);
 
-  const result = await fetchWithRetry(apiUrl, {
-    ...retryOptions,
-    // GET only. The API answers HEAD fine (measured: 200 on the contents
-    // route), but HEAD and GET each cost one request against the rate limit,
-    // so trying HEAD first can only ever spend two where one would do.
-    methods: ['GET'],
-    headers: {
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-      'User-Agent': 'bestax-check-pointer-urls',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-  return { ...result, via: apiUrl };
+  const primary = apiUrl
+    ? {
+        ...(await fetchWithRetry(apiUrl, {
+          ...retryOptions,
+          // GET only. The API answers HEAD fine (measured: 200 on the contents
+          // route), but HEAD and GET each cost one request against the rate
+          // limit, so trying HEAD first can only ever spend two where one does.
+          methods: ['GET'],
+          headers: {
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'bestax-check-pointer-urls',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+        })),
+        via: apiUrl,
+      }
+    : await fetchWithRetry(url, retryOptions);
+
+  if (primary.outcome !== 'dead') return primary;
+  return corroborateDead(url, primary, retryOptions);
 }
 
 /** The distinct hosts present in a set of results, for the operator's benefit. */

--- a/scripts/check-pointer-urls.test.mjs
+++ b/scripts/check-pointer-urls.test.mjs
@@ -128,11 +128,14 @@ test('404 and 410 are dead', () => {
   assert.equal(classifyStatus(410), 'dead');
 });
 
-test('403 is retryable, matching auto-close-duplicates on rate limits', () => {
+test('401/403 are retryable, matching auto-close-duplicates on rate limits', () => {
   // The whole point: anonymous GitHub requests from a shared runner IP get
   // 403-throttled, and calling that a deleted page is the #525 failure mode.
   assert.equal(classifyStatus(403), 'retryable');
   assert.equal(classifyStatus(429), 'retryable');
+  // 401 means our own credential went bad — a problem with the checker, not
+  // with the link. Reding the build for it would blame the wrong thing.
+  assert.equal(classifyStatus(401), 'retryable');
 });
 
 test('5xx is retryable and other 4xx is dead', () => {
@@ -336,6 +339,100 @@ test('a non-github URL is fetched directly and sends no headers', async () => {
   }
 });
 
+// --- corroboration of a dead verdict ----------------------------------------
+
+test('a bestax.io 404 is believed when the host root is healthy', async () => {
+  const s = stubFetchByUrl({
+    'bestax.io/gone': [
+      { status: 404, statusText: 'Not Found' }, // HEAD
+      { status: 404, statusText: 'Not Found' }, // GET
+    ],
+    // Origin root, the corroborator.
+    'https://bestax.io': [{ status: 200 }],
+  });
+  try {
+    const r = await checkUrl('https://bestax.io/gone', {
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.outcome, 'dead');
+  } finally {
+    s.restore();
+  }
+});
+
+test('a bestax.io 404 is NOT believed when the host cannot serve its own root', async () => {
+  // The #525 shape one host over: a CDN incident serving spurious 404s must
+  // not red every open PR.
+  const s = stubFetchByUrl({
+    'bestax.io/gone': [
+      { status: 404, statusText: 'Not Found' },
+      { status: 404, statusText: 'Not Found' },
+    ],
+    'https://bestax.io': all({ status: 503 }),
+  });
+  try {
+    const r = await checkUrl('https://bestax.io/gone', {
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.outcome, 'unreachable');
+    assert.match(r.detail, /not corroborated/);
+  } finally {
+    s.restore();
+  }
+});
+
+test('a github API 404 is believed only when the web page agrees', async () => {
+  const s = stubFetchByUrl({
+    'api.github.com': [{ status: 404, statusText: 'Not Found' }],
+    'https://github.com/allxsmith/bestax/blob': [
+      { status: 404, statusText: 'Not Found' }, // HEAD
+      { status: 404, statusText: 'Not Found' }, // GET
+    ],
+  });
+  try {
+    const r = await checkUrl(
+      'https://github.com/allxsmith/bestax/blob/main/GONE.md',
+      { retryOptions: NO_WAIT }
+    );
+    assert.equal(r.outcome, 'dead');
+  } finally {
+    s.restore();
+  }
+});
+
+test('a slashed branch that mis-maps to a 404 is caught by the web page', async () => {
+  // githubApiUrl has to guess where the ref ends and the path begins, so
+  // blob/feature/x/README.md maps wrong and the API 404s a file that exists.
+  // The page still serves, so the verdict must not be "gone".
+  const s = stubFetchByUrl({
+    'api.github.com': [{ status: 404, statusText: 'Not Found' }],
+    'https://github.com/allxsmith/bestax/blob': [{ status: 200 }],
+  });
+  try {
+    const r = await checkUrl(
+      'https://github.com/allxsmith/bestax/blob/feature/x/README.md',
+      { retryOptions: NO_WAIT }
+    );
+    assert.equal(r.outcome, 'unreachable');
+    assert.match(r.detail, /not corroborated/);
+  } finally {
+    s.restore();
+  }
+});
+
+test('corroboration only runs for a dead verdict, never for a healthy URL', async () => {
+  const s = stubFetchByUrl({ 'bestax.io/fine': [{ status: 200 }] });
+  try {
+    const r = await checkUrl('https://bestax.io/fine', {
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.outcome, 'ok');
+    assert.equal(s.calls.length, 1, 'no second request for a passing URL');
+  } finally {
+    s.restore();
+  }
+});
+
 // --- extractUrls ------------------------------------------------------------
 
 test('extractUrls trims sentence punctuation but keeps the path', () => {
@@ -418,6 +515,9 @@ test('main exits 1 on a confirmed dead link', async () => {
       { status: 404, statusText: 'Not Found' }, // GET
     ],
     ...routeAll([{ status: 200 }]),
+    // The corroborator: a healthy host root makes the 404 believable. Listed
+    // last because it is a substring of every URL above.
+    'https://bestax.io': [{ status: 200 }],
   });
   try {
     assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 1);
@@ -459,6 +559,7 @@ test('a dead link still fails even when another URL is undetermined', async () =
       { status: 404, statusText: 'Not Found' },
     ],
     ...routeAll([{ status: 200 }]),
+    'https://bestax.io': [{ status: 200 }],
   });
   try {
     assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 1);

--- a/scripts/check-pointer-urls.test.mjs
+++ b/scripts/check-pointer-urls.test.mjs
@@ -1,0 +1,475 @@
+/**
+ * Tests for the pointer-URL gate and its retry helper (#525).
+ *
+ * Everything here is about what happens when the network misbehaves, so every
+ * test stubs `globalThis.fetch` (the pattern from
+ * check-security-txt-expiry.test.mjs). Nothing touches the live hosts — that
+ * would reintroduce the flakiness this is meant to remove.
+ *
+ * The stub deliberately THROWS when its queue underflows. An earlier version
+ * returned a free 200, which meant a regression that fetched twice, or retried
+ * something it should not have, still passed every assertion.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  classifyStatus,
+  fetchWithRetry,
+  retryAfterMs,
+  DEFAULT_ATTEMPTS,
+  MAX_RETRY_AFTER_MS,
+} from './lib/fetch-retry.mjs';
+import {
+  extractUrls,
+  githubApiUrl,
+  checkUrl,
+  hostsOf,
+  formatUndetermined,
+  formatDead,
+  main,
+  FILES,
+} from './check-pointer-urls.mjs';
+
+const NO_WAIT = { backoffMs: [0, 0] };
+
+function stubFetch(queue) {
+  const calls = [];
+  const real = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({
+      url: String(url),
+      method: init.method,
+      headers: init.headers,
+    });
+    if (queue.length === 0) {
+      throw new Error(
+        `unexpected request #${calls.length}: ${init.method} ${url}`
+      );
+    }
+    const next = queue.shift();
+    if (next.throw) throw new Error(next.throw);
+    return {
+      status: next.status,
+      statusText: next.statusText ?? '',
+      headers: { get: h => next.headers?.[h.toLowerCase()] ?? null },
+      text: async () => next.body ?? '',
+    };
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = real;
+    },
+  };
+}
+
+/** Enough queue entries for a full HEAD+GET x attempts sweep. */
+const all = entry => Array.from({ length: DEFAULT_ATTEMPTS * 2 }, () => entry);
+
+/**
+ * A stub keyed by URL rather than by call order.
+ *
+ * `main` checks URLs concurrently, so a positional queue would silently encode
+ * the scheduling order of Promise.all — the tests would still pass, but they
+ * would be asserting against an implementation detail rather than behaviour,
+ * and would break confusingly the first time concurrency changed. Routes are
+ * matched by substring, **first match wins in insertion order**, so a specific
+ * override must be listed before the general route it narrows. An unmatched or
+ * exhausted route throws rather than handing back a free 200.
+ */
+function stubFetchByUrl(routes) {
+  const calls = [];
+  const real = globalThis.fetch;
+  const pending = new Map(Object.entries(routes).map(([k, v]) => [k, [...v]]));
+  globalThis.fetch = async (url, init = {}) => {
+    const target = String(url);
+    calls.push({ url: target, method: init.method });
+    const key = [...pending.keys()].find(k => target.includes(k));
+    if (key === undefined) throw new Error(`unrouted request: ${target}`);
+    const queue = pending.get(key);
+    if (queue.length === 0)
+      throw new Error(`route ${key} exhausted by ${target}`);
+    const next = queue.shift();
+    if (next.throw) throw new Error(next.throw);
+    return {
+      status: next.status,
+      statusText: next.statusText ?? '',
+      headers: { get: h => next.headers?.[h.toLowerCase()] ?? null },
+      text: async () => next.body ?? '',
+    };
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = real;
+    },
+  };
+}
+
+// --- classifyStatus ---------------------------------------------------------
+
+test('2xx resolves; 3xx does not, because redirects are followed', () => {
+  for (const s of [200, 204, 299])
+    assert.equal(classifyStatus(s), 'ok', `${s}`);
+  // A 3xx only reaches us when it could not be followed — a broken redirect.
+  for (const s of [301, 302, 304]) {
+    assert.equal(classifyStatus(s), 'retryable', `${s}`);
+  }
+});
+
+test('404 and 410 are dead', () => {
+  assert.equal(classifyStatus(404), 'dead');
+  assert.equal(classifyStatus(410), 'dead');
+});
+
+test('403 is retryable, matching auto-close-duplicates on rate limits', () => {
+  // The whole point: anonymous GitHub requests from a shared runner IP get
+  // 403-throttled, and calling that a deleted page is the #525 failure mode.
+  assert.equal(classifyStatus(403), 'retryable');
+  assert.equal(classifyStatus(429), 'retryable');
+});
+
+test('5xx is retryable and other 4xx is dead', () => {
+  for (const s of [500, 502, 503]) assert.equal(classifyStatus(s), 'retryable');
+  assert.equal(classifyStatus(400), 'dead');
+  assert.equal(classifyStatus(451), 'dead');
+});
+
+// --- retryAfterMs -----------------------------------------------------------
+
+test('Retry-After is honoured when short enough to be worth waiting', () => {
+  assert.equal(retryAfterMs({ get: () => '5' }), 5000);
+  assert.equal(retryAfterMs({ get: () => null }), null);
+  assert.equal(retryAfterMs({ get: () => 'soon' }), null);
+  assert.equal(retryAfterMs({ get: () => '-1' }), null);
+});
+
+test('an unreasonably long Retry-After is ignored rather than stalling the gate', () => {
+  assert.equal(
+    retryAfterMs({ get: () => String(MAX_RETRY_AFTER_MS / 1000 + 1) }),
+    null
+  );
+});
+
+// --- fetchWithRetry ---------------------------------------------------------
+
+test('a 503 that clears resolves', async () => {
+  const s = stubFetch([{ status: 503 }, { status: 503 }, { status: 200 }]);
+  try {
+    const r = await fetchWithRetry('https://example.test/a', NO_WAIT);
+    assert.equal(r.outcome, 'ok');
+  } finally {
+    s.restore();
+  }
+});
+
+test('a non-ok HEAD always falls through to GET, never short-circuits', async () => {
+  // A CDN answering HEAD with 405 for a URL it serves over GET must not red
+  // the build. The implementation this replaced fell through unconditionally.
+  const s = stubFetch([{ status: 405 }, { status: 200 }]);
+  try {
+    const r = await fetchWithRetry('https://example.test/cdn', NO_WAIT);
+    assert.equal(r.outcome, 'ok');
+    assert.deepEqual(
+      s.calls.map(c => c.method),
+      ['HEAD', 'GET']
+    );
+  } finally {
+    s.restore();
+  }
+});
+
+test('a 404 on HEAD still tries GET before declaring the link gone', async () => {
+  const s = stubFetch([
+    { status: 404 },
+    { status: 404, statusText: 'Not Found' },
+  ]);
+  try {
+    const r = await fetchWithRetry('https://example.test/gone', NO_WAIT);
+    assert.equal(r.outcome, 'dead');
+    assert.equal(s.calls.length, 2);
+  } finally {
+    s.restore();
+  }
+});
+
+test('persistent 403 reports unreachable, not gone', async () => {
+  const s = stubFetch(all({ status: 403, statusText: 'rate limited' }));
+  try {
+    const r = await fetchWithRetry('https://example.test/throttled', NO_WAIT);
+    assert.equal(r.outcome, 'unreachable');
+    assert.equal(r.attempts, DEFAULT_ATTEMPTS);
+  } finally {
+    s.restore();
+  }
+});
+
+test('a network error is unreachable with no status', async () => {
+  const s = stubFetch(all({ throw: 'getaddrinfo ENOTFOUND' }));
+  try {
+    const r = await fetchWithRetry('https://example.test/dns', NO_WAIT);
+    assert.equal(r.outcome, 'unreachable');
+    assert.equal(r.status, null);
+  } finally {
+    s.restore();
+  }
+});
+
+test('response bodies are drained so a socket cannot outlive the verdict', async () => {
+  let drained = 0;
+  const real = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    status: 503,
+    statusText: '',
+    headers: { get: () => null },
+    text: async () => {
+      drained += 1;
+      return '';
+    },
+  });
+  try {
+    await fetchWithRetry('https://example.test/body', NO_WAIT);
+    assert.equal(drained, DEFAULT_ATTEMPTS * 2);
+  } finally {
+    globalThis.fetch = real;
+  }
+});
+
+// --- githubApiUrl -----------------------------------------------------------
+
+test('a blob URL maps to the contents endpoint with its ref', () => {
+  assert.equal(
+    githubApiUrl('https://github.com/allxsmith/bestax/blob/main/SECURITY.md'),
+    'https://api.github.com/repos/allxsmith/bestax/contents/SECURITY.md?ref=main'
+  );
+});
+
+test('a nested path keeps its separators', () => {
+  assert.equal(
+    githubApiUrl('https://github.com/o/r/blob/main/a/b/c.md'),
+    'https://api.github.com/repos/o/r/contents/a/b/c.md?ref=main'
+  );
+});
+
+test('a bare repo URL maps to the repo endpoint', () => {
+  assert.equal(
+    githubApiUrl('https://github.com/allxsmith/bestax'),
+    'https://api.github.com/repos/allxsmith/bestax'
+  );
+});
+
+test('non-github and unmapped shapes fall back to a direct fetch', () => {
+  assert.equal(githubApiUrl('https://bestax.io/llms.txt'), null);
+  assert.equal(githubApiUrl('https://github.com/o/r/releases/tag/v1'), null);
+  assert.equal(githubApiUrl('not a url'), null);
+  // Look-alike hosts must not be treated as GitHub.
+  assert.equal(githubApiUrl('https://github.com.evil.test/o/r'), null);
+});
+
+// --- checkUrl ---------------------------------------------------------------
+
+test('a github.com URL is verified through the API, with the token', async () => {
+  const s = stubFetch([{ status: 200 }]);
+  try {
+    const r = await checkUrl(
+      'https://github.com/allxsmith/bestax/blob/main/SECURITY.md',
+      {
+        token: 'ghs_example',
+        retryOptions: NO_WAIT,
+      }
+    );
+    assert.equal(r.outcome, 'ok');
+    assert.equal(s.calls.length, 1);
+    assert.match(s.calls[0].url, /^https:\/\/api\.github\.com\/repos\//);
+    assert.equal(s.calls[0].headers.Authorization, 'Bearer ghs_example');
+  } finally {
+    s.restore();
+  }
+});
+
+test('no token still checks, just unauthenticated', async () => {
+  const s = stubFetch([{ status: 200 }]);
+  try {
+    const r = await checkUrl('https://github.com/allxsmith/bestax', {
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.outcome, 'ok');
+    assert.equal(s.calls[0].headers.Authorization, undefined);
+  } finally {
+    s.restore();
+  }
+});
+
+test('a non-github URL is fetched directly and sends no headers', async () => {
+  const s = stubFetch([{ status: 200 }]);
+  try {
+    await checkUrl('https://bestax.io/llms.txt', {
+      token: 'x',
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(s.calls[0].url, 'https://bestax.io/llms.txt');
+    assert.equal(s.calls[0].headers, undefined);
+  } finally {
+    s.restore();
+  }
+});
+
+// --- extractUrls ------------------------------------------------------------
+
+test('extractUrls trims sentence punctuation but keeps the path', () => {
+  assert.deepEqual(extractUrls('see https://bestax.io/docs/guides/llms.'), [
+    'https://bestax.io/docs/guides/llms',
+  ]);
+  assert.deepEqual(extractUrls('a https://x.test/a, and https://y.test/b'), [
+    'https://x.test/a',
+    'https://y.test/b',
+  ]);
+});
+
+test('extractUrls keeps a fragment and ignores markdown delimiters', () => {
+  assert.deepEqual(
+    extractUrls('[llms](https://bestax.io/docs/guides/llms#mcp-server)'),
+    ['https://bestax.io/docs/guides/llms#mcp-server']
+  );
+});
+
+// --- reporting --------------------------------------------------------------
+
+test('hostsOf names the hosts actually in the failing set', () => {
+  assert.deepEqual(
+    hostsOf([{ url: 'https://bestax.io/a' }, { url: 'https://bestax.io/b' }]),
+    ['bestax.io']
+  );
+});
+
+test('the undetermined message does not claim the links are dead', () => {
+  const msg = formatUndetermined(
+    [{ url: 'https://bestax.io/a', detail: '503' }],
+    9
+  );
+  assert.match(msg, /could not be checked/);
+  assert.match(msg, /not a dead-link report/);
+  assert.match(msg, /bestax\.io/);
+  assert.doesNotMatch(msg, /githubstatus/);
+});
+
+test('the dead message names the pointer files it was given, not the constant', () => {
+  const msg = formatDead(
+    [{ url: 'https://x.test', detail: '404 Not Found' }],
+    ['bulma-ui/llms.txt']
+  );
+  assert.match(msg, /bulma-ui\/llms\.txt/);
+  assert.doesNotMatch(msg, /AGENTS\.md/);
+});
+
+// --- main -------------------------------------------------------------------
+
+async function fixtureRepo(urls) {
+  const root = await mkdtemp(join(tmpdir(), 'pointer-urls-'));
+  await mkdir(join(root, 'bulma-ui'), { recursive: true });
+  await writeFile(join(root, 'bulma-ui/llms.txt'), urls.join('\n') + '\n');
+  await writeFile(join(root, 'bulma-ui/AGENTS.md'), '');
+  return root;
+}
+
+const SIX = Array.from({ length: 6 }, (_, i) => `https://bestax.io/p${i}`);
+
+/** Route every URL in SIX to the same scripted response set. */
+const routeAll = entries => Object.fromEntries(SIX.map(u => [u, entries]));
+
+test('main exits 0 when everything resolves', async () => {
+  const root = await fixtureRepo(SIX);
+  const s = stubFetchByUrl(routeAll([{ status: 200 }]));
+  try {
+    assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 0);
+  } finally {
+    s.restore();
+  }
+});
+
+test('main exits 1 on a confirmed dead link', async () => {
+  const root = await fixtureRepo(SIX);
+  const s = stubFetchByUrl({
+    // Specific route first — first match wins.
+    p5: [
+      { status: 404, statusText: 'Not Found' }, // HEAD
+      { status: 404, statusText: 'Not Found' }, // GET
+    ],
+    ...routeAll([{ status: 200 }]),
+  });
+  try {
+    assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 1);
+  } finally {
+    s.restore();
+  }
+});
+
+test('a total outage warns and PASSES — the gate could not look', async () => {
+  // The #525 case. Every host unreachable must not red every open PR.
+  const root = await fixtureRepo(SIX);
+  const s = stubFetchByUrl(routeAll(all({ status: 503 })));
+  try {
+    assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 0);
+  } finally {
+    s.restore();
+  }
+});
+
+test('one undetermined URL among healthy ones still passes', async () => {
+  const root = await fixtureRepo(SIX);
+  const s = stubFetchByUrl({
+    p3: all({ status: 503 }),
+    ...routeAll([{ status: 200 }]),
+  });
+  try {
+    assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 0);
+  } finally {
+    s.restore();
+  }
+});
+
+test('a dead link still fails even when another URL is undetermined', async () => {
+  const root = await fixtureRepo(SIX);
+  const s = stubFetchByUrl({
+    p2: all({ status: 503 }),
+    p4: [
+      { status: 404, statusText: 'Not Found' },
+      { status: 404, statusText: 'Not Found' },
+    ],
+    ...routeAll([{ status: 200 }]),
+  });
+  try {
+    assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 1);
+  } finally {
+    s.restore();
+  }
+});
+
+test('too few URLs fails rather than reporting a vacuous success', async () => {
+  const root = await fixtureRepo(['https://bestax.io/only-one']);
+  const s = stubFetchByUrl({});
+  try {
+    assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 1);
+    assert.equal(s.calls.length, 0, 'should not even try to fetch');
+  } finally {
+    s.restore();
+  }
+});
+
+test('a URL repeated across both files is requested once', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pointer-urls-'));
+  await mkdir(join(root, 'bulma-ui'), { recursive: true });
+  await writeFile(join(root, 'bulma-ui/llms.txt'), SIX.join('\n'));
+  await writeFile(join(root, 'bulma-ui/AGENTS.md'), SIX.join('\n'));
+  const s = stubFetchByUrl(routeAll([{ status: 200 }]));
+  try {
+    assert.equal(await main({ root, files: FILES, retryOptions: NO_WAIT }), 0);
+    assert.equal(s.calls.length, SIX.length);
+  } finally {
+    s.restore();
+  }
+});

--- a/scripts/check-pointer-urls.test.mjs
+++ b/scripts/check-pointer-urls.test.mjs
@@ -112,12 +112,14 @@ function stubFetchByUrl(routes) {
 
 // --- classifyStatus ---------------------------------------------------------
 
-test('2xx resolves; 3xx does not, because redirects are followed', () => {
+test('2xx resolves; a 3xx that survived redirect-following is a dead link', () => {
   for (const s of [200, 204, 299])
     assert.equal(classifyStatus(s), 'ok', `${s}`);
-  // A 3xx only reaches us when it could not be followed — a broken redirect.
-  for (const s of [301, 302, 304]) {
-    assert.equal(classifyStatus(s), 'retryable', `${s}`);
+  // Requests set redirect: 'follow', so a 3xx reaching the caller is a
+  // redirect with no Location — broken, and retrying it would downgrade a
+  // real defect into a warning that passes.
+  for (const s of [301, 302, 307, 308]) {
+    assert.equal(classifyStatus(s), 'dead', `${s}`);
   }
 });
 
@@ -141,11 +143,27 @@ test('5xx is retryable and other 4xx is dead', () => {
 
 // --- retryAfterMs -----------------------------------------------------------
 
-test('Retry-After is honoured when short enough to be worth waiting', () => {
+test('Retry-After delay-seconds is honoured when short enough to be worth waiting', () => {
   assert.equal(retryAfterMs({ get: () => '5' }), 5000);
   assert.equal(retryAfterMs({ get: () => null }), null);
   assert.equal(retryAfterMs({ get: () => 'soon' }), null);
   assert.equal(retryAfterMs({ get: () => '-1' }), null);
+  assert.equal(retryAfterMs({ get: () => '1.5' }), null);
+});
+
+test('Retry-After also accepts the HTTP-date form RFC 9110 allows', () => {
+  // Frozen clock, so the date branch is deterministic.
+  const now = Date.parse('2026-08-17T12:00:00Z');
+  const in5s = new Date(now + 5000).toUTCString();
+  assert.equal(retryAfterMs({ get: () => in5s }, now), 5000);
+
+  // A date already in the past means "come back now", not "wait forever".
+  const past = new Date(now - 60_000).toUTCString();
+  assert.equal(retryAfterMs({ get: () => past }, now), null);
+
+  // And a date beyond the ceiling is ignored like a too-large delay-seconds.
+  const far = new Date(now + MAX_RETRY_AFTER_MS + 1000).toUTCString();
+  assert.equal(retryAfterMs({ get: () => far }, now), null);
 });
 
 test('an unreasonably long Retry-After is ignored rather than stalling the gate', () => {

--- a/scripts/lib/fetch-retry.mjs
+++ b/scripts/lib/fetch-retry.mjs
@@ -1,0 +1,183 @@
+/**
+ * Retrying fetch for the checks that probe public URLs (#525).
+ *
+ * The incident this exists for: on 2026-08-17 GitHub served `404` and `503`
+ * interchangeably for anonymous blob requests for about three hours, and
+ * check-pointer-urls failed every open PR with "SECURITY.md did not resolve"
+ * while that file sat on `main` untouched.
+ *
+ * Read that carefully, because the obvious fix does not work. Retrying does
+ * not help against a three-hour outage, and only one of the nine URLs was
+ * failing, so no "everything is down" heuristic would have fired either. What
+ * actually distinguished truth from noise that day was *asking a different
+ * endpoint*: the REST API answered `200` for the same file the web UI was
+ * 404ing. That is why the caller resolves github.com URLs through the API and
+ * this module only handles the transport.
+ *
+ * So retrying here is the cheap half — it covers brief blips, nothing more.
+ * The classification is the load-bearing half: statuses are sorted into "the
+ * host answered no", "the host did not give a usable answer", and "resolved",
+ * because reporting the second as the first is what sent everyone to look for
+ * a deleted file that existed.
+ */
+
+/** Attempts per URL, matching the three the provenance assertion spends. */
+export const DEFAULT_ATTEMPTS = 3;
+
+/**
+ * Backoff between attempts, in ms. Shorter than the provenance step's
+ * `attempt * 5s`: that runs weekly and can afford patience, this gates every
+ * pull request.
+ *
+ * Cost, stated properly because an earlier version of this comment got it
+ * backwards: a confirmed-dead link costs one round trip and fails fast. The
+ * expensive case is a host that never answers — attempts x methods x
+ * `timeoutMs`, plus this backoff. That is why the caller checks URLs
+ * concurrently rather than in sequence.
+ */
+export const DEFAULT_BACKOFF_MS = [1000, 3000];
+
+/** Per-request ceiling, matching check-security-txt-expiry.mjs. */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Longest `Retry-After` we will actually wait. Honouring the header is right
+ * (auto-close-duplicates.mjs does the same), but a gate on every PR cannot sit
+ * out a 300-second throttle — past this we stop waiting and report the URL as
+ * undetermined, which is a warning rather than a failure.
+ */
+export const MAX_RETRY_AFTER_MS = 15_000;
+
+/**
+ * Sort an HTTP status into what it tells us about the URL.
+ *
+ * - `ok`        — 2xx. Matches the `res.ok` test this replaced.
+ * - `dead`      — the host answered no, and asking again cannot change that.
+ * - `retryable` — no usable answer: throttling, or the host's own failure.
+ *
+ * 403 is **retryable**, not dead. It reads like a definite answer about access,
+ * but the requests here are anonymous and made from a shared Actions runner IP,
+ * and that is exactly how GitHub reports abuse and rate limiting.
+ * `auto-close-duplicates.mjs` already reached this conclusion — "403/429 is
+ * (usually) a primary/secondary rate limit" — and disagreeing with it here
+ * would mean this gate calls a throttled request a deleted page.
+ *
+ * 3xx is deliberately NOT ok. Requests are made with `redirect: 'follow'`, so
+ * a 3xx only reaches us when it could not be followed — a redirect with no
+ * `Location`, or a loop. That is a broken link, not a working one.
+ */
+export function classifyStatus(status) {
+  if (status >= 200 && status < 300) return 'ok';
+  if (status === 403 || status === 408 || status === 425 || status === 429) {
+    return 'retryable';
+  }
+  if (status >= 500) return 'retryable';
+  if (status >= 400 && status < 500) return 'dead';
+  // 3xx that survived redirect-following, and anything unrecognised. Erring
+  // toward retryable costs latency; erring the other way costs a false red.
+  return 'retryable';
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/** `Retry-After` in ms if present, sane, and short enough to be worth waiting. */
+export function retryAfterMs(headers) {
+  const raw = headers?.get?.('retry-after');
+  if (raw == null) return null;
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  const ms = seconds * 1000;
+  return ms <= MAX_RETRY_AFTER_MS ? ms : null;
+}
+
+/**
+ * Fetch `url`, retrying only what retrying can fix.
+ *
+ * Resolves to `{ outcome, status, detail, attempts }` rather than throwing:
+ * callers are gates that need every URL's verdict, not an abort on the first.
+ *
+ * - `outcome: 'ok'`          — resolved.
+ * - `outcome: 'dead'`        — the host answered no, on the final method.
+ * - `outcome: 'unreachable'` — no usable answer after every attempt. Network
+ *   errors and timeouts land here too, with `status: null`.
+ *
+ * HEAD is tried before GET because it is cheaper, and a non-ok HEAD **always
+ * falls through to GET** — never short-circuits. Some CDNs answer HEAD with
+ * 405 or 403 for a URL they serve perfectly well over GET, so a HEAD-only
+ * verdict would red the build for a link that works in a browser. The
+ * implementation this replaced fell through unconditionally; keeping that is
+ * deliberate, not incidental.
+ *
+ * `headers` exists for exactly one caller: the GitHub REST lookups, which need
+ * `Authorization`. Two things keep that from leaking. Redirects are followed,
+ * and the fetch spec strips `Authorization` on a cross-origin redirect; and the
+ * caller only ever sets it for api.github.com. Do not widen this to arbitrary
+ * request init — a general seam plus redirect-following is how a credential
+ * reaches a host nobody named.
+ */
+export async function fetchWithRetry(url, options = {}) {
+  const {
+    attempts = DEFAULT_ATTEMPTS,
+    backoffMs = DEFAULT_BACKOFF_MS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    methods = ['HEAD', 'GET'],
+    headers = undefined,
+  } = options;
+
+  let last = { outcome: 'unreachable', status: null, detail: 'not attempted' };
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let waitMs = backoffMs[attempt - 1] ?? backoffMs.at(-1) ?? 0;
+
+    for (const [index, method] of methods.entries()) {
+      const isLastMethod = index === methods.length - 1;
+      try {
+        const res = await fetch(url, {
+          method,
+          headers,
+          redirect: 'follow',
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        // Drain before anything else. An unconsumed undici body keeps its
+        // socket out of the pool and ref'd, and the caller sets
+        // process.exitCode rather than calling process.exit, so a retained
+        // socket would stall the step after the verdict is already printed.
+        await res.text?.().catch(() => '');
+
+        const verdict = classifyStatus(res.status);
+        const detail = `${res.status} ${res.statusText ?? ''}`.trim();
+
+        if (verdict === 'ok') {
+          return {
+            outcome: 'ok',
+            status: res.status,
+            detail: null,
+            attempts: attempt,
+          };
+        }
+        if (verdict === 'dead' && isLastMethod) {
+          return {
+            outcome: 'dead',
+            status: res.status,
+            detail,
+            attempts: attempt,
+          };
+        }
+        last = { outcome: 'unreachable', status: res.status, detail };
+        const after = retryAfterMs(res.headers);
+        if (after !== null) waitMs = after;
+      } catch (err) {
+        // Network refusal, DNS failure, or the AbortSignal timeout. None of
+        // these say anything about whether the URL exists.
+        last = {
+          outcome: 'unreachable',
+          status: null,
+          detail: err?.cause?.message ?? err?.message ?? String(err),
+        };
+      }
+    }
+    if (attempt < attempts) await sleep(waitMs);
+  }
+
+  return { ...last, attempts };
+}

--- a/scripts/lib/fetch-retry.mjs
+++ b/scripts/lib/fetch-retry.mjs
@@ -55,12 +55,14 @@ export const MAX_RETRY_AFTER_MS = 15_000;
  * - `dead`      — the host answered no, and asking again cannot change that.
  * - `retryable` — no usable answer: throttling, or the host's own failure.
  *
- * 403 is **retryable**, not dead. It reads like a definite answer about access,
- * but the requests here are anonymous and made from a shared Actions runner IP,
- * and that is exactly how GitHub reports abuse and rate limiting.
- * `auto-close-duplicates.mjs` already reached this conclusion — "403/429 is
- * (usually) a primary/secondary rate limit" — and disagreeing with it here
- * would mean this gate calls a throttled request a deleted page.
+ * 401 and 403 are **retryable**, not dead. They read like definite answers
+ * about access, but neither says anything about whether the URL exists. 403 is
+ * how GitHub reports abuse and rate limiting to anonymous requests from a
+ * shared Actions runner IP — `auto-close-duplicates.mjs` already concluded
+ * "403/429 is (usually) a primary/secondary rate limit", and disagreeing here
+ * would mean this gate calls a throttled request a deleted page. 401 would
+ * mean our own credential went bad, which is a problem with the checker, not
+ * with the link; reding the build for it would blame the wrong thing.
  *
  * 3xx is `dead`, not ok and not retryable. Requests are made with
  * `redirect: 'follow'`, so a 3xx only reaches us when it could not be
@@ -73,7 +75,13 @@ export const MAX_RETRY_AFTER_MS = 15_000;
 export function classifyStatus(status) {
   if (status >= 200 && status < 300) return 'ok';
   if (status >= 300 && status < 400) return 'dead';
-  if (status === 403 || status === 408 || status === 425 || status === 429) {
+  if (
+    status === 401 ||
+    status === 403 ||
+    status === 408 ||
+    status === 425 ||
+    status === 429
+  ) {
     return 'retryable';
   }
   if (status >= 500) return 'retryable';

--- a/scripts/lib/fetch-retry.mjs
+++ b/scripts/lib/fetch-retry.mjs
@@ -62,31 +62,52 @@ export const MAX_RETRY_AFTER_MS = 15_000;
  * (usually) a primary/secondary rate limit" — and disagreeing with it here
  * would mean this gate calls a throttled request a deleted page.
  *
- * 3xx is deliberately NOT ok. Requests are made with `redirect: 'follow'`, so
- * a 3xx only reaches us when it could not be followed — a redirect with no
- * `Location`, or a loop. That is a broken link, not a working one.
+ * 3xx is `dead`, not ok and not retryable. Requests are made with
+ * `redirect: 'follow'`, so a 3xx only reaches us when it could not be
+ * followed — a redirect with no `Location` header. That is a broken link, and
+ * retrying it would only turn a real defect into a warning that passes.
+ * (A redirect *loop* never lands here: undici throws, which the caller records
+ * as unreachable. And 304 cannot occur because no conditional request headers
+ * are ever sent.)
  */
 export function classifyStatus(status) {
   if (status >= 200 && status < 300) return 'ok';
+  if (status >= 300 && status < 400) return 'dead';
   if (status === 403 || status === 408 || status === 425 || status === 429) {
     return 'retryable';
   }
   if (status >= 500) return 'retryable';
   if (status >= 400 && status < 500) return 'dead';
-  // 3xx that survived redirect-following, and anything unrecognised. Erring
-  // toward retryable costs latency; erring the other way costs a false red.
+  // Anything unrecognised. Erring toward retryable costs latency; erring the
+  // other way costs a false red on someone's PR.
   return 'retryable';
 }
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-/** `Retry-After` in ms if present, sane, and short enough to be worth waiting. */
-export function retryAfterMs(headers) {
+/**
+ * `Retry-After` in ms if present, sane, and short enough to be worth waiting.
+ *
+ * RFC 9110 §10.2.3 defines two forms and hosts use both: `delay-seconds`, and
+ * an absolute HTTP-date. Parsing only the first is not a crash — a date reads
+ * as NaN and we fall back to the fixed backoff — but it silently ignores a
+ * server that told us exactly when to come back.
+ *
+ * `now` is a parameter so the date branch is testable against a frozen clock
+ * rather than a real one.
+ */
+export function retryAfterMs(headers, now = Date.now()) {
   const raw = headers?.get?.('retry-after');
   if (raw == null) return null;
-  const seconds = Number(raw);
-  if (!Number.isFinite(seconds) || seconds <= 0) return null;
-  const ms = seconds * 1000;
+  const trimmed = String(raw).trim();
+
+  // delay-seconds. Matched strictly, so a negative or fractional value falls
+  // through to the date branch and is rejected there rather than sneaking in.
+  const ms = /^\d+$/.test(trimmed)
+    ? Number(trimmed) * 1000
+    : Date.parse(trimmed) - now;
+
+  if (!Number.isFinite(ms) || ms <= 0) return null;
   return ms <= MAX_RETRY_AFTER_MS ? ms : null;
 }
 


### PR DESCRIPTION
Closes #525.

The `Pointer file URLs resolve` step failed #524 on `blob/main/SECURITY.md` with a `404` while that file was present on `main` the whole time, reddening every open PR for about three hours.

## Retrying does not fix this

Worth stating up front, because it was the first thing I built and it was wrong.

- The outage lasted hours. Three attempts over four seconds was never going to clear it.
- Only **one of the nine** URLs failed (the #524 log shows the other eight passing), so an "everything is down, must be an outage" heuristic would not have fired either.
- GitHub was serving `404` — not `503` — for anonymous blob requests. Classifying `404` as definitive, which is the obvious thing to do, reproduces the exact failure.

What *was* measurably true during the incident: `/repos/{owner}/{repo}/contents/SECURITY.md` returned `200` for the very file whose blob page was 404ing.

## What changed

**1. github.com URLs are verified through the REST API, not the web UI.** `githubApiUrl()` maps `/{owner}/{repo}` and `/{owner}/{repo}/blob/{ref}/{path}` to the corresponding endpoints; anything unmapped falls back to fetching the page directly. That path is also the authenticated one, so it does not collect the anonymous `403` rate limits a shared runner IP attracts.

**2. "Could not determine" is a warning, not a failure.** This gate exists to catch a dead link a PR introduces. A host that will not answer has not told us a link is dead — it has stopped us looking, and failing every open PR for that is the cry-wolf problem #391 and #525 are both about. Undetermined URLs emit a `::warning::` and pass. **A confirmed 404 still fails the build.**

**3. Retry and status classification move to `scripts/lib/fetch-retry.mjs`** (rule 9 — logic worth testing does not belong in YAML). The classification, not the retrying, is the load-bearing half:

| Behavior | Why |
| --- | --- |
| `403` is retryable, not dead | `auto-close-duplicates.mjs:167` already concluded "403/429 is (usually) a primary/secondary rate limit". Disagreeing here would mean this gate calls a throttled request a deleted page. |
| A non-ok HEAD **always** falls through to GET | Some CDNs answer HEAD with `405` for a URL they serve fine over GET. The implementation this replaces fell through unconditionally; keeping that is deliberate, not incidental. |
| `Retry-After` honoured, capped at 15s | Matches `auto-close-duplicates.mjs`, but a gate on every PR cannot sit out a 300-second throttle. Past the cap the URL is reported undetermined. |
| Bodies drained | The caller sets `process.exitCode` rather than calling `process.exit`, so an unconsumed undici body could stall the step after the verdict is printed. |
| `ok` is 2xx only | With `redirect: 'follow'`, a 3xx only reaches us when it could not be followed — a broken redirect, not a working link. |

**4. Two hardening changes.** URLs are checked concurrently (the expensive case is a host that never answers, and a sequential sweep multiplies every timeout by nine). And the run fails if the pointer files yield fewer than five URLs, so a restructured file or an edited regex cannot turn the gate into a no-op that reports success having checked nothing.

**5. `ci.yml` passes the job's read-only `GITHUB_TOKEN`** to the step. The check falls back to unauthenticated requests when unset, which is how it runs on a contributor's laptop.

## Workflow change

Per `.github/CLAUDE.md`, the `ci.yml` edit is bottom-row but worth naming precisely:

- The step gains `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. That is the job's own token, already scoped `contents: read` / `metadata: read` in this workflow — no new permission, no PAT, nothing that can write.
- No trigger change, no action SHA change, no allowlist, no new repository variable, nothing that spends model usage.
- The token is only ever attached to `api.github.com` requests. `fetch-retry.mjs` takes a narrow `headers` option rather than an arbitrary request-init passthrough, specifically so a general seam plus redirect-following cannot carry a credential to a host nobody named.

## Verification

```
124 script tests pass (31 new), lint clean, format clean, full `pnpm all` green
```

Live runs against the real hosts, both authenticated and not:

```
[check-pointer-urls] ok   https://github.com/allxsmith/bestax (via API)
[check-pointer-urls] ok   https://github.com/allxsmith/bestax/blob/main/SECURITY.md (via API)
[check-pointer-urls] 9/9 URLs resolve
```

**Negative control**, because "it passes" is not evidence a gate still works — a fixture pointing at a file that does not exist:

```
[check-pointer-urls] DEAD https://github.com/allxsmith/bestax/blob/main/THIS-FILE-DOES-NOT-EXIST.md (404 Not Found)
exit code: 1
```

The tests stub `globalThis.fetch` (the `check-security-txt-expiry.test.mjs` pattern) and the stub **throws on an unrouted or exhausted route** rather than handing back a free 200 — an earlier version did the latter, which meant a regression that fetched twice still passed every assertion.

## The trade-off, stated plainly

The gate no longer fails when a host is unreachable. That is the fix, and it is also a real cost: a genuinely dead link would slip through if its host happened to be 5xx-ing at that moment. A confirmed 404 still reds the build, and the release-time run would catch the straggler later. I think that is the right side of the trade for a check that gates every PR, but it is a policy change and not just a bug fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer URL validation with authenticated GitHub checks.
  * Added retry handling, timeouts, and fallback requests for more reliable link verification.
  * Clearly distinguishes working, broken, and temporarily unreachable links.
  * Prevents transient network issues from incorrectly failing validation.

* **Tests**
  * Added comprehensive coverage for URL extraction, deduplication, retries, authentication, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->