### PR TITLE
ci: assert what the provenance attestations actually say

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -297,7 +297,18 @@ jobs:
       # while proving nothing, which bypasses the exact control being added. The
       # inline shell this replaces had that property for free by living in the
       # workflow file; moving the logic into scripts/ is what makes it something
-      # to state explicitly.
+      # to state explicitly. Measured, not assumed: past release-triggered runs
+      # of this workflow record `head_branch` as the tag
+      # (e.g. `@allxsmith/bestax-bulma@5.11.1`).
+      #
+      # `github.workflow_sha` was proposed instead and is wrong here for the
+      # same reason — on a release event the workflow file itself comes from the
+      # tag, so pinning to it would reintroduce exactly the exposure `main`
+      # closes. The residual gap is that `main` resolves when checkout runs, so
+      # a push landing in that window changes the verifier: much smaller, since
+      # `main` is protected by a ruleset that admits only reviewed PRs and the
+      # release App's `chore(release)` commit, and anyone able to push there has
+      # already defeated more than this step.
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -281,7 +281,7 @@ jobs:
       # The provenance assertion moved out of this file and into
       # scripts/verify-attestation.mjs (#526), because checking what an
       # attestation *says* means decoding a base64 DSSE payload and comparing
-      # six fields — rule 9 logic, not a shell loop. So the job now needs the
+      # nine fields — rule 9 logic, not a shell loop. So the job now needs the
       # repository on disk.
       #
       # This adds a second third-party action to a job that had one, which is
@@ -289,9 +289,19 @@ jobs:
       # the repo-wide pin, and `persist-credentials: false` means no token is
       # written to the runner's git config. The job still declares no
       # `permissions:` and still inherits the workflow-level `contents: read`.
+      #
+      # `ref: main` is load-bearing, not tidiness. Without it checkout takes the
+      # event ref, and this job's primary trigger is `release: published` — so
+      # the verifier would be read from the release tag. A tag pointing at a
+      # commit whose verify-attestation.mjs simply exits 0 would pass this gate
+      # while proving nothing, which bypasses the exact control being added. The
+      # inline shell this replaces had that property for free by living in the
+      # workflow file; moving the logic into scripts/ is what makes it something
+      # to state explicitly.
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: main
           persist-credentials: false
 
       - name: Setup Node.js
@@ -336,7 +346,7 @@ jobs:
       # digest is the one the attestation signs, and that the build it describes
       # is this repository, this workflow, this ref, on a GitHub-hosted runner.
       # The logic lives in scripts/ with a node --test sibling, per rule 9,
-      # because it decodes a base64 DSSE payload and compares six fields; that
+      # because it decodes a base64 DSSE payload and compares nine fields; that
       # is not something a shell loop can be tested for.
       #
       # Fails closed everywhere: a fetch error, an unparsable payload, or a

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -278,6 +278,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # The provenance assertion moved out of this file and into
+      # scripts/verify-attestation.mjs (#526), because checking what an
+      # attestation *says* means decoding a base64 DSSE payload and comparing
+      # six fields — rule 9 logic, not a shell loop. So the job now needs the
+      # repository on disk.
+      #
+      # This adds a second third-party action to a job that had one, which is
+      # the honest cost of that move rather than something to elide. It is on
+      # the repo-wide pin, and `persist-credentials: false` means no token is
+      # written to the runner's git config. The job still declares no
+      # `permissions:` and still inherits the workflow-level `contents: read`.
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -295,7 +311,9 @@ jobs:
       # manifest precisely because everything else in CI resolves against the
       # workspace, where the specifier works.
       #
-      # Keep this list in sync with the provenance loop below.
+      # This list is the single source of truth for what gets verified: the
+      # assertion step below reads the roster back out of this tree rather than
+      # repeating it.
       - name: Install published packages into a scratch tree
         run: |
           mkdir -p "$RUNNER_TEMP/verify"
@@ -310,56 +328,25 @@ jobs:
           npm audit signatures
 
       # `npm audit signatures` only fails on signatures/attestations that are
-      # *invalid*; it stays green when provenance is simply absent. On its own
-      # it would therefore never catch a release that silently lost
-      # `publishConfig.provenance` or had OIDC misconfigured. Assert presence
-      # explicitly so a dropped attestation is a hard failure.
-      - name: Assert our packages actually carry provenance
-        run: |
-          fail=0
-          cd "$RUNNER_TEMP/verify"
-          for pkg in @allxsmith/bestax-bulma create-bestax bestax-migrate bestax-mcp; do
-            # Pin to the version that was actually installed and audited above.
-            # A bare `npm view "$pkg"` re-resolves the `latest` dist-tag, which
-            # is mutable, so a publish landing between the install step and this
-            # one would have this step vouch for a version the job never
-            # installed. Reading the version back out of the tree keeps all
-            # three steps talking about the same artifacts. Local read, no
-            # network, so it belongs outside the retry loop below.
-            #
-            # Absent from the tree is its own failure, reported as such rather
-            # than folded into the "no provenance" message below — a missing
-            # install and a dropped attestation want different investigations.
-            version=$(npm ls "$pkg" --depth=0 --json 2>/dev/null \
-              | jq -r --arg pkg "$pkg" '.dependencies[$pkg].version // empty' 2>/dev/null || true)
-            if [ -z "$version" ]; then
-              echo "::error::$pkg is not in the installed tree; cannot verify its provenance"
-              fail=1
-              continue
-            fi
-
-            # --json + a type guard so only a real string counts as present:
-            # null, undefined, [] and non-strings all collapse to empty. The
-            # array branch covers npm aggregating a bare spec into one element.
-            # Any failure (network, 404, missing dist-tag) also yields empty and
-            # fails closed — the right default for a security assertion.
-            #
-            # Retried because this runs weekly and failing closed means a
-            # registry blip would otherwise report the same red as a genuinely
-            # dropped attestation. A gate that cries wolf gets ignored, so
-            # spend three attempts before believing provenance is really gone.
-            predicate=""
-            for attempt in 1 2 3; do
-              predicate=$(npm view "$pkg@$version" dist.attestations.provenance.predicateType --json 2>/dev/null \
-                | jq -r 'if type=="array" then .[0] else . end | select(type=="string")' 2>/dev/null || true)
-              [ -n "$predicate" ] && break
-              [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
-            done
-            if [ -z "$predicate" ]; then
-              echo "::error::$pkg@$version has NO provenance attestation on the registry"
-              fail=1
-            else
-              echo "ok: $pkg@$version -> $predicate"
-            fi
-          done
-          exit "$fail"
+      # *invalid*, and it stays green when provenance is simply absent. It also
+      # never opens the attestation: a validly signed statement naming somebody
+      # else's repository satisfies it completely.
+      #
+      # So this step asserts the contents (#526) — that each installed tarball's
+      # digest is the one the attestation signs, and that the build it describes
+      # is this repository, this workflow, this ref, on a GitHub-hosted runner.
+      # The logic lives in scripts/ with a node --test sibling, per rule 9,
+      # because it decodes a base64 DSSE payload and compares six fields; that
+      # is not something a shell loop can be tested for.
+      #
+      # Fails closed everywhere: a fetch error, an unparsable payload, or a
+      # missing field is a failure, never a silent pass.
+      #
+      # No package list here on purpose. It reads the roster back out of the
+      # scratch tree, so the install step above is the single place the
+      # packages are named. Listing them twice made "keep these in sync" a
+      # hand-maintained invariant with nothing enforcing it — add a fifth
+      # published package to one and not the other and it ships unverified,
+      # silently, green.
+      - name: Assert the attestations say this repository built these tarballs
+        run: node scripts/verify-attestation.mjs --dir "$RUNNER_TEMP/verify"

--- a/scripts/lib/fetch-retry.mjs
+++ b/scripts/lib/fetch-retry.mjs
@@ -21,19 +21,22 @@
  * a deleted file that existed.
  */
 
-/** Attempts per URL, matching the three the provenance assertion spends. */
+/** Attempts per URL. Three, the number the shell provenance loop used to spend. */
 export const DEFAULT_ATTEMPTS = 3;
 
 /**
- * Backoff between attempts, in ms. Shorter than the provenance step's
- * `attempt * 5s`: that runs weekly and can afford patience, this gates every
- * pull request.
+ * Backoff between attempts, in ms.
+ *
+ * These were tuned for the pull-request gate, which is the latency-sensitive
+ * caller. The weekly provenance job now shares them, down from the 5s/10s its
+ * shell loop used — deliberate, because that job also gained a real retry on
+ * the registry's 404 propagation lag, which is the case the longer wait was
+ * actually protecting against. Retune with both callers in mind.
  *
  * Cost, stated properly because an earlier version of this comment got it
- * backwards: a confirmed-dead link costs one round trip and fails fast. The
+ * backwards: a confirmed-dead URL costs one round trip and fails fast. The
  * expensive case is a host that never answers — attempts x methods x
- * `timeoutMs`, plus this backoff. That is why the caller checks URLs
- * concurrently rather than in sequence.
+ * `timeoutMs`, plus this backoff. That is why callers check concurrently.
  */
 export const DEFAULT_BACKOFF_MS = [1000, 3000];
 
@@ -125,6 +128,16 @@ export function retryAfterMs(headers, now = Date.now()) {
  * Resolves to `{ outcome, status, detail, attempts }` rather than throwing:
  * callers are gates that need every URL's verdict, not an abort on the first.
  *
+ * `keepBody: true` adds `body` to an `ok` result. It is opt-in rather than
+ * always-on: the body is drained either way, but *retaining* it is not free —
+ * the URL gate holds one result per URL for the whole run, and the GitHub
+ * contents API embeds the entire file, so defaulting to on would park
+ * SECURITY.md and AGENTS.md in memory for a caller that never reads them.
+ *
+ * `alsoRetryable` adds statuses to the retryable set for one call. It exists
+ * for the registry attestation lookup, where a 404 seconds after a publish
+ * means "not propagated yet" rather than "does not exist".
+ *
  * - `outcome: 'ok'`          — resolved.
  * - `outcome: 'dead'`        — the host answered no, on the final method.
  * - `outcome: 'unreachable'` — no usable answer after every attempt. Network
@@ -151,6 +164,8 @@ export async function fetchWithRetry(url, options = {}) {
     timeoutMs = DEFAULT_TIMEOUT_MS,
     methods = ['HEAD', 'GET'],
     headers = undefined,
+    keepBody = false,
+    alsoRetryable = [],
   } = options;
 
   let last = { outcome: 'unreachable', status: null, detail: 'not attempted' };
@@ -171,9 +186,11 @@ export async function fetchWithRetry(url, options = {}) {
         // socket out of the pool and ref'd, and the caller sets
         // process.exitCode rather than calling process.exit, so a retained
         // socket would stall the step after the verdict is already printed.
-        await res.text?.().catch(() => '');
+        const body = await res.text?.().catch(() => '');
 
-        const verdict = classifyStatus(res.status);
+        const verdict = alsoRetryable.includes(res.status)
+          ? 'retryable'
+          : classifyStatus(res.status);
         const detail = `${res.status} ${res.statusText ?? ''}`.trim();
 
         if (verdict === 'ok') {
@@ -182,6 +199,7 @@ export async function fetchWithRetry(url, options = {}) {
             status: res.status,
             detail: null,
             attempts: attempt,
+            ...(keepBody ? { body: body ?? '' } : {}),
           };
         }
         if (verdict === 'dead' && isLastMethod) {

--- a/scripts/verify-attestation.mjs
+++ b/scripts/verify-attestation.mjs
@@ -28,7 +28,10 @@
  * Usage:
  *   node scripts/verify-attestation.mjs --dir <scratch-tree> <pkg>...
  *
- * Exit codes: 0 every package's attestation checks out, 1 any did not.
+ * Exit codes: 0 every package's attestation checks out,
+ *             1 at least one did not,
+ *             2 bad usage or an unusable scratch tree — kept distinct so a
+ *               typo'd flag is not reported as a provenance failure.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -70,6 +73,9 @@ export const EXPECTED = Object.freeze({
   ref: 'refs/heads/main',
   builder: 'https://github.com/actions/runner/github-hosted',
   invocationIdPrefix: 'https://github.com/allxsmith/bestax/actions/runs/',
+  // Matched as a substring of resolvedDependencies[].uri, which npm emits as
+  // `git+https://github.com/allxsmith/bestax@refs/heads/main`.
+  sourceUri: 'github.com/allxsmith/bestax',
 });
 
 /** in-toto statement type the SLSA predicate is wrapped in. */
@@ -263,7 +269,15 @@ export function checkStatement(statement, { pkg, version, digest }) {
   const run = statement?.predicate?.runDetails;
   const builder = run?.builder?.id;
   const invocationId = run?.metadata?.invocationId;
-  const gitCommit = build?.resolvedDependencies?.[0]?.digest?.gitCommit;
+  // resolvedDependencies is an unordered collection, so indexing [0] cuts both
+  // ways: a valid attestation listing another dependency first would false-fail,
+  // and an unrelated first entry that happens to carry a 40-char gitCommit would
+  // let a missing source commit pass. Select the descriptor that actually
+  // describes this repository.
+  const source = (
+    Array.isArray(build?.resolvedDependencies) ? build.resolvedDependencies : []
+  ).find(d => typeof d?.uri === 'string' && d.uri.includes(EXPECTED.sourceUri));
+  const gitCommit = source?.digest?.gitCommit;
 
   // Find the subject by name rather than assuming subject[0]. npm emits one
   // today, but the in-toto schema allows several, and indexing would report a
@@ -329,7 +343,11 @@ export function checkStatement(statement, { pkg, version, digest }) {
     );
   }
   if (typeof gitCommit !== 'string' || !/^[0-9a-f]{40}$/.test(gitCommit)) {
-    problems.push(`source commit is "${gitCommit}", expected a 40-char sha`);
+    problems.push(
+      source
+        ? `source commit is "${gitCommit}", expected a 40-char sha`
+        : `no resolved dependency describing ${EXPECTED.sourceUri}`
+    );
   }
   return problems;
 }

--- a/scripts/verify-attestation.mjs
+++ b/scripts/verify-attestation.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+/**
+ * Assert that our published packages' provenance attestations say what they
+ * are supposed to say (#526).
+ *
+ * The gap this closes: `verify-provenance` in supply-chain.yml proved an
+ * attestation *existed* and was typed `https://slsa.dev/provenance/v1`, by
+ * reading a single field off `npm view`. It never opened the attestation. A
+ * valid, correctly-signed attestation naming a completely different source
+ * repository satisfied that check and `npm audit signatures` both.
+ *
+ * That matters because SECURITY.md tells users provenance "links the tarball
+ * to the exact commit and CI run that built it". The attestation does. Nothing
+ * in CI checked the link pointed at us.
+ *
+ * What is deliberately NOT here: signature verification. `npm audit
+ * signatures` runs immediately before this in the same job and covers it.
+ * Re-verifying the Sigstore bundle would mean vendoring a verifier for no
+ * marginal gain. This script answers a different question — not "is this
+ * signed?" but "signed as *what*?".
+ *
+ * Design mirrors check-security-txt-expiry.mjs: plain node, zero npm deps,
+ * pure helpers exported, main only runs when executed directly. No subprocess:
+ * the installed version and the tarball digest both come from files the
+ * install already wrote, which makes every assertion testable against a temp
+ * directory.
+ *
+ * Usage:
+ *   node scripts/verify-attestation.mjs --dir <scratch-tree> <pkg>...
+ *
+ * Exit codes: 0 every package's attestation checks out, 1 any did not.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { fetchWithRetry } from './lib/fetch-retry.mjs';
+
+/** The SLSA predicate type npm publishes alongside its own publish attestation. */
+export const SLSA_PREDICATE = 'https://slsa.dev/provenance/v1';
+
+/**
+ * What a legitimate build of ours looks like.
+ *
+ * `repositoryId` and `repositoryOwnerId` are the load-bearing pair. The
+ * repository *URL* is a name, and names transfer: rename the repo, or let the
+ * `allxsmith` handle lapse, and whoever takes that path can publish a validly
+ * signed attestation naming this exact URL. The numeric IDs cannot be
+ * reassigned, so they are what actually pins "us". Verified against the live
+ * payload, which carries them in `internalParameters.github`.
+ *
+ * `builder` is the exact `github-hosted` value, not a prefix. npm emits either
+ * `.../actions/runner/github-hosted` or `.../actions/runner/self-hosted`, and a
+ * prefix match accepts both — which would let a build on an attacker-registered
+ * self-hosted runner satisfy a check whose whole stated point is that it did
+ * not happen on one.
+ *
+ * `ref` is pinned to main because that is the only branch semantic-release
+ * publishes from. If that changes, this must change with it in the same PR,
+ * which is the point of pinning rather than accepting any ref.
+ *
+ * Frozen so the assertion baseline cannot be mutated by anything that imports
+ * this module.
+ */
+export const EXPECTED = Object.freeze({
+  repository: 'https://github.com/allxsmith/bestax',
+  repositoryId: '975765002',
+  repositoryOwnerId: '49878611',
+  workflowPath: '.github/workflows/ci.yml',
+  ref: 'refs/heads/main',
+  builder: 'https://github.com/actions/runner/github-hosted',
+  invocationIdPrefix: 'https://github.com/allxsmith/bestax/actions/runs/',
+});
+
+/** in-toto statement type the SLSA predicate is wrapped in. */
+export const STATEMENT_TYPE = 'https://in-toto.io/Statement/v1';
+
+export function attestationUrl(pkg, version) {
+  return `https://registry.npmjs.org/-/npm/v1/attestations/${pkg}@${version}`;
+}
+
+/**
+ * Compare two package URLs without tripping over percent-encoding.
+ *
+ * The purl spec encodes the `@` that introduces an npm scope, so npm attests
+ * `@allxsmith/bestax-bulma` as `pkg:npm/%40allxsmith/bestax-bulma@5.11.1`.
+ * Building the expected string naively made the check fail on the one scoped
+ * package we publish — caught by running this against the real registry, which
+ * is exactly the false red it would otherwise have produced in CI.
+ *
+ * Decoding both sides rather than hard-coding the encoding means the check
+ * keeps working whichever form the registry emits. A malformed escape decodes
+ * to nothing and simply fails to match, which is the fail-closed direction.
+ */
+export function samePurl(a, b) {
+  const decode = s => {
+    try {
+      return decodeURIComponent(String(s));
+    } catch {
+      return null;
+    }
+  };
+  const left = decode(a);
+  return left !== null && left === decode(b);
+}
+
+/**
+ * Parse argv.
+ *
+ * An unrecognised `--flag` is a usage error rather than a package name. Left
+ * permissive, `--dirs /tmp/x pkg` parses as three packages, `installedVersion`
+ * throws ENOENT, and the run exits 1 reporting that provenance "does not check
+ * out" for a package that never existed — a typo dressed up as a verification
+ * failure, which is exactly the distinction the exit codes exist to draw.
+ *
+ * The package list is optional: with none given, the roster is read from the
+ * scratch tree. See `packagesInTree`.
+ */
+export function parseArgs(argv) {
+  const packages = [];
+  let dir = null;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dir') {
+      dir = argv[++i] ?? null;
+    } else if (arg.startsWith('--dir=')) {
+      dir = arg.slice('--dir='.length);
+    } else if (arg.startsWith('-')) {
+      throw new Error(`unknown option "${arg}"`);
+    } else {
+      packages.push(arg);
+    }
+  }
+  if (!dir) throw new Error('--dir <scratch-tree> is required');
+  return { dir, packages };
+}
+
+/**
+ * The packages the install step actually put in the scratch tree.
+ *
+ * This exists so the workflow does not have to name the roster twice. Listing
+ * it in both the install step and the verify step made "keep these in sync" a
+ * hand-maintained invariant with nothing enforcing it — add a fifth published
+ * package to one and not the other and it ships unverified, silently, green.
+ * Reading it back from the tree makes the two structurally incapable of
+ * disagreeing.
+ */
+export function packagesInTree(dir) {
+  const manifest = path.join(dir, 'package.json');
+  const { dependencies } = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+  const names = Object.keys(dependencies ?? {});
+  if (names.length === 0) {
+    throw new Error(
+      `no dependencies in ${manifest} — nothing was installed, so there is ` +
+        `nothing to verify. Refusing to report success on an empty run.`
+    );
+  }
+  return names.sort();
+}
+
+/** The version npm actually installed, read from the tree rather than resolved again. */
+export function installedVersion(dir, pkg) {
+  const manifest = path.join(
+    dir,
+    'node_modules',
+    ...pkg.split('/'),
+    'package.json'
+  );
+  const { version } = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+  if (typeof version !== 'string' || version === '') {
+    throw new Error(`${pkg}: no version in ${manifest}`);
+  }
+  return version;
+}
+
+/**
+ * The sha512 of the tarball that was installed, as lowercase hex.
+ *
+ * npm records it in the lockfile as Subresource Integrity (`sha512-<base64>`)
+ * and the attestation states it as hex, so one has to be converted. Verified
+ * against the real registry: for bestax-migrate@2.0.0 the lockfile integrity
+ * decodes to exactly the attestation's subject digest.
+ */
+export function installedDigest(dir, pkg) {
+  const lockPath = path.join(dir, 'package-lock.json');
+  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  const entry = lock.packages?.[`node_modules/${pkg}`];
+  const integrity = entry?.integrity;
+  if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
+    throw new Error(`${pkg}: no sha512 integrity in ${lockPath}`);
+  }
+  const raw = Buffer.from(integrity.slice('sha512-'.length), 'base64');
+  // Node's base64 decoder discards invalid characters silently, so a truncated
+  // or corrupted integrity yields a short buffer rather than an error. Without
+  // this a malformed lockfile would surface downstream as "subject digest does
+  // not match", sending the reader to investigate the registry instead of the
+  // tree.
+  if (raw.length !== 64) {
+    throw new Error(
+      `${pkg}: integrity in ${lockPath} decoded to ${raw.length} bytes, expected 64`
+    );
+  }
+  return raw.toString('hex');
+}
+
+/**
+ * Pull the SLSA provenance predicate out of the registry's attestation
+ * response.
+ *
+ * The endpoint returns two bundles — npm's own publish attestation and the
+ * SLSA one — so the right one has to be selected rather than assumed to be
+ * first. The payload is a base64 DSSE envelope.
+ */
+export function extractProvenance(responseText) {
+  const parsed = JSON.parse(responseText);
+  const bundles = Array.isArray(parsed?.attestations)
+    ? parsed.attestations
+    : [];
+  const slsa = bundles.find(a => a?.predicateType === SLSA_PREDICATE);
+  if (!slsa) {
+    throw new Error(
+      `no ${SLSA_PREDICATE} attestation among [${bundles.map(b => b?.predicateType).join(', ')}]`
+    );
+  }
+  const payload = slsa?.bundle?.dsseEnvelope?.payload;
+  if (typeof payload !== 'string' || payload === '') {
+    throw new Error('SLSA attestation has no dsseEnvelope payload');
+  }
+  const statement = JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+
+  // The `predicateType` selected on above is envelope metadata, outside what
+  // the DSSE signature covers. The decoded statement carries its own type
+  // fields, so re-check them here: that makes the selection self-verifying
+  // rather than load-bearing on an unsigned label, and settles the case of a
+  // response carrying two bundles both claiming to be SLSA.
+  if (statement?._type !== STATEMENT_TYPE) {
+    throw new Error(
+      `decoded statement is "${statement?._type}", expected "${STATEMENT_TYPE}"`
+    );
+  }
+  if (statement?.predicateType !== SLSA_PREDICATE) {
+    throw new Error(
+      `decoded predicateType is "${statement?.predicateType}", expected "${SLSA_PREDICATE}"`
+    );
+  }
+  return statement;
+}
+
+/**
+ * Compare a provenance statement against what our build should look like.
+ *
+ * Returns the list of problems rather than throwing on the first, so a single
+ * run reports everything wrong with a package instead of one thing at a time.
+ * Every branch is written so a missing or malformed field produces a problem —
+ * there is no path where an absent value silently satisfies a check, which is
+ * rule 4's fail-closed requirement applied field by field.
+ */
+export function checkStatement(statement, { pkg, version, digest }) {
+  const problems = [];
+  const build = statement?.predicate?.buildDefinition;
+  const workflow = build?.externalParameters?.workflow;
+  const github = build?.internalParameters?.github;
+  const run = statement?.predicate?.runDetails;
+  const builder = run?.builder?.id;
+  const invocationId = run?.metadata?.invocationId;
+  const gitCommit = build?.resolvedDependencies?.[0]?.digest?.gitCommit;
+
+  // Find the subject by name rather than assuming subject[0]. npm emits one
+  // today, but the in-toto schema allows several, and indexing would report a
+  // perfectly correct package as both wrong-subject and wrong-digest the day
+  // that changes.
+  const expectedName = `pkg:npm/${pkg}@${version}`;
+  const subjects = Array.isArray(statement?.subject) ? statement.subject : [];
+  const subject = subjects.find(s => samePurl(s?.name, expectedName));
+
+  if (!subject) {
+    problems.push(
+      `no subject named "${expectedName}" (saw ${subjects.length ? subjects.map(s => `"${s?.name}"`).join(', ') : 'none'})`
+    );
+  } else if (subject.digest?.sha512 !== digest) {
+    problems.push(
+      `subject digest does not match the installed tarball ` +
+        `(attested ${String(subject.digest?.sha512).slice(0, 16)}…, ` +
+        `installed ${digest.slice(0, 16)}…)`
+    );
+  }
+
+  if (workflow?.repository !== EXPECTED.repository) {
+    problems.push(
+      `built from repository "${workflow?.repository}", expected "${EXPECTED.repository}"`
+    );
+  }
+  // The IDs are the assertion that survives a rename; the URL above is a name.
+  if (String(github?.repository_id) !== EXPECTED.repositoryId) {
+    problems.push(
+      `repository_id is "${github?.repository_id}", expected "${EXPECTED.repositoryId}"`
+    );
+  }
+  if (String(github?.repository_owner_id) !== EXPECTED.repositoryOwnerId) {
+    problems.push(
+      `repository_owner_id is "${github?.repository_owner_id}", expected "${EXPECTED.repositoryOwnerId}"`
+    );
+  }
+  if (workflow?.path !== EXPECTED.workflowPath) {
+    problems.push(
+      `built by workflow "${workflow?.path}", expected "${EXPECTED.workflowPath}"`
+    );
+  }
+  if (workflow?.ref !== EXPECTED.ref) {
+    problems.push(
+      `built from ref "${workflow?.ref}", expected "${EXPECTED.ref}"`
+    );
+  }
+  if (builder !== EXPECTED.builder) {
+    problems.push(`builder is "${builder}", expected "${EXPECTED.builder}"`);
+  }
+  // SECURITY.md promises provenance links the tarball to the exact commit and
+  // CI run. Those two fields are what make that true, so they are checked
+  // rather than merely quoted: the run must belong to this repository, and a
+  // commit must be stated. The commit's *value* cannot be pinned here — it is
+  // whatever was on main at release — so its presence and shape are what is
+  // available to assert.
+  if (
+    typeof invocationId !== 'string' ||
+    !invocationId.startsWith(EXPECTED.invocationIdPrefix)
+  ) {
+    problems.push(
+      `invocationId is "${invocationId}", expected one under "${EXPECTED.invocationIdPrefix}"`
+    );
+  }
+  if (typeof gitCommit !== 'string' || !/^[0-9a-f]{40}$/.test(gitCommit)) {
+    problems.push(`source commit is "${gitCommit}", expected a 40-char sha`);
+  }
+  return problems;
+}
+
+/** Verify one package end to end. Never throws; returns a result to report. */
+export async function verifyPackage(pkg, { dir, retryOptions = {} }) {
+  let version;
+  let digest;
+  try {
+    version = installedVersion(dir, pkg);
+    digest = installedDigest(dir, pkg);
+  } catch (err) {
+    return { pkg, ok: false, problems: [err.message] };
+  }
+
+  const res = await fetchWithRetry(attestationUrl(pkg, version), {
+    ...retryOptions,
+    // GET, because the payload is the whole point, and keepBody to get it.
+    methods: ['GET'],
+    keepBody: true,
+    // A 404 here is retried rather than believed on sight. This job runs on
+    // `release: published`, seconds after `npm publish`, and the registry
+    // serves the attestations route separately from the packument — so a 404
+    // is far more likely to be propagation lag than a missing attestation.
+    // The shell loop this replaced spent three attempts for exactly this
+    // reason ("a gate that cries wolf gets ignored"); without this the move to
+    // a single-source fetch would have quietly thrown that away.
+    alsoRetryable: [404],
+  });
+  if (res.outcome !== 'ok') {
+    return {
+      pkg,
+      version,
+      ok: false,
+      problems: [
+        `could not fetch the attestation (${res.detail ?? res.outcome})`,
+      ],
+    };
+  }
+
+  let statement;
+  try {
+    statement = extractProvenance(res.body);
+  } catch (err) {
+    return { pkg, version, ok: false, problems: [err.message] };
+  }
+
+  const problems = checkStatement(statement, { pkg, version, digest });
+  return { pkg, version, ok: problems.length === 0, problems };
+}
+
+export async function main(
+  argv = process.argv.slice(2),
+  { retryOptions } = {}
+) {
+  let args;
+  let packages;
+  try {
+    args = parseArgs(argv);
+    // No names given means "whatever the install step put there", which is how
+    // the workflow avoids listing the roster twice.
+    packages =
+      args.packages.length > 0 ? args.packages : packagesInTree(args.dir);
+  } catch (err) {
+    console.error(`::error::verify-attestation: ${err.message}`);
+    return 2;
+  }
+
+  console.log(
+    `verify-attestation: checking ${packages.length} package(s): ${packages.join(', ')}`
+  );
+
+  const results = await Promise.all(
+    packages.map(pkg => verifyPackage(pkg, { dir: args.dir, retryOptions }))
+  );
+
+  let failed = 0;
+  for (const r of results) {
+    if (r.ok) {
+      console.log(
+        `ok: ${r.pkg}@${r.version} — built by ${EXPECTED.repository}`
+      );
+      continue;
+    }
+    failed += 1;
+    console.error(
+      `::error::${r.pkg}${r.version ? `@${r.version}` : ''} provenance does not check out`
+    );
+    for (const p of r.problems) console.error(`  - ${p}`);
+  }
+  if (failed > 0) {
+    console.error(
+      `verify-attestation: ${failed}/${results.length} package(s) failed. An ` +
+        `attestation that exists and is validly signed still says who built ` +
+        `what; these do not say what they should.`
+    );
+    return 1;
+  }
+  console.log(`verify-attestation: ${results.length} package(s) check out`);
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  process.exitCode = await main();
+}

--- a/scripts/verify-attestation.mjs
+++ b/scripts/verify-attestation.mjs
@@ -13,11 +13,22 @@
  * to the exact commit and CI run that built it". The attestation does. Nothing
  * in CI checked the link pointed at us.
  *
- * What is deliberately NOT here: signature verification. `npm audit
- * signatures` runs immediately before this in the same job and covers it.
- * Re-verifying the Sigstore bundle would mean vendoring a verifier for no
- * marginal gain. This script answers a different question — not "is this
- * signed?" but "signed as *what*?".
+ * What is deliberately NOT here: signature verification. This script answers a
+ * different question — not "is this signed?" but "signed as *what*?".
+ *
+ * Be precise about what that leaves uncovered, because the easy version of this
+ * sentence overstates it. `npm audit signatures` runs in the immediately-prior
+ * step and verifies the bundles it fetched. This step makes its *own* request,
+ * so the two are not cryptographically tied: a registry that equivocates —
+ * serving a validly signed foreign attestation to the audit and an unsigned
+ * matching statement here — would satisfy both. Closing that means verifying
+ * this bundle's DSSE signature, which needs a Sigstore verifier this repository
+ * does not vendor.
+ *
+ * What the pairing does buy is that an attacker must compromise the registry's
+ * responses rather than merely publish a wrong attestation, and must do it
+ * differently for two requests seconds apart. That is a real cost increase and
+ * not a proof, which is the honest way to describe it.
  *
  * Design mirrors check-security-txt-expiry.mjs: plain node, zero npm deps,
  * pure helpers exported, main only runs when executed directly. No subprocess:
@@ -38,6 +49,18 @@ import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { fetchWithRetry } from './lib/fetch-retry.mjs';
+
+/**
+ * Backoff for the attestation lookup, deliberately longer than the shared
+ * default.
+ *
+ * The shared 1s/3s was tuned for the pull-request URL gate. This job's primary
+ * trigger is `release: published`, seconds after `npm publish`, and the shell
+ * loop it replaces spent 5s/10s waiting out exactly that propagation lag.
+ * Inheriting the PR-tuned budget would have cut the wait from ~15s to ~4s and
+ * false-redded a release whose attestation was merely slow.
+ */
+export const ATTESTATION_BACKOFF_MS = [5000, 10000];
 
 /** The SLSA predicate type npm publishes alongside its own publish attestation. */
 export const SLSA_PREDICATE = 'https://slsa.dev/provenance/v1';
@@ -73,9 +96,12 @@ export const EXPECTED = Object.freeze({
   ref: 'refs/heads/main',
   builder: 'https://github.com/actions/runner/github-hosted',
   invocationIdPrefix: 'https://github.com/allxsmith/bestax/actions/runs/',
-  // Matched as a substring of resolvedDependencies[].uri, which npm emits as
-  // `git+https://github.com/allxsmith/bestax@refs/heads/main`.
-  sourceUri: 'github.com/allxsmith/bestax',
+  // The exact `resolvedDependencies[].uri` npm emits. Compared with `===`,
+  // not `includes`: a substring test also selects
+  // `git+https://github.com/allxsmith/bestax-evil@...`, whose 40-char digest
+  // would then satisfy the source-commit assertion while no dependency
+  // describes this repository at all. Near-collision covered by a test.
+  sourceUri: 'git+https://github.com/allxsmith/bestax@refs/heads/main',
 });
 
 /** in-toto statement type the SLSA predicate is wrapped in. */
@@ -276,7 +302,7 @@ export function checkStatement(statement, { pkg, version, digest }) {
   // describes this repository.
   const source = (
     Array.isArray(build?.resolvedDependencies) ? build.resolvedDependencies : []
-  ).find(d => typeof d?.uri === 'string' && d.uri.includes(EXPECTED.sourceUri));
+  ).find(d => d?.uri === EXPECTED.sourceUri);
   const gitCommit = source?.digest?.gitCommit;
 
   // Find the subject by name rather than assuming subject[0]. npm emits one
@@ -364,6 +390,7 @@ export async function verifyPackage(pkg, { dir, retryOptions = {} }) {
   }
 
   const res = await fetchWithRetry(attestationUrl(pkg, version), {
+    backoffMs: ATTESTATION_BACKOFF_MS,
     ...retryOptions,
     // GET, because the payload is the whole point, and keepBody to get it.
     methods: ['GET'],

--- a/scripts/verify-attestation.test.mjs
+++ b/scripts/verify-attestation.test.mjs
@@ -62,7 +62,12 @@ function goodStatement({ pkg = 'bestax-migrate', version = '2.0.0' } = {}) {
             repository_owner_id: EXPECTED.repositoryOwnerId,
           },
         },
-        resolvedDependencies: [{ digest: { gitCommit: 'a'.repeat(40) } }],
+        resolvedDependencies: [
+          {
+            uri: `git+https://github.com/allxsmith/bestax@${EXPECTED.ref}`,
+            digest: { gitCommit: 'a'.repeat(40) },
+          },
+        ],
       },
       runDetails: {
         builder: { id: EXPECTED.builder },
@@ -323,10 +328,33 @@ test('a run belonging to another repository is caught', () => {
   assert.match(checkStatement(s, CTX)[0], /invocationId/);
 });
 
-test('a missing or malformed source commit is caught', () => {
+test('a missing source dependency is reported as such', () => {
   const s = goodStatement();
   s.predicate.buildDefinition.resolvedDependencies = [];
-  assert.match(checkStatement(s, CTX)[0], /source commit/);
+  assert.match(checkStatement(s, CTX)[0], /no resolved dependency/);
+});
+
+test('the source descriptor is found even when it is not first', () => {
+  // resolvedDependencies is unordered, so indexing [0] would false-fail here.
+  const s = goodStatement();
+  s.predicate.buildDefinition.resolvedDependencies.unshift({
+    uri: 'git+https://github.com/unrelated/thing@refs/heads/main',
+    digest: { gitCommit: 'b'.repeat(40) },
+  });
+  assert.deepEqual(checkStatement(s, CTX), []);
+});
+
+test('an unrelated dependency cannot stand in for a missing source commit', () => {
+  // The other half of the [0] bug: a foreign entry with a valid-looking sha
+  // must not satisfy the check.
+  const s = goodStatement();
+  s.predicate.buildDefinition.resolvedDependencies = [
+    {
+      uri: 'git+https://github.com/unrelated/thing',
+      digest: { gitCommit: 'c'.repeat(40) },
+    },
+  ];
+  assert.match(checkStatement(s, CTX)[0], /no resolved dependency/);
 });
 
 test('an empty statement fails every check rather than passing any', () => {

--- a/scripts/verify-attestation.test.mjs
+++ b/scripts/verify-attestation.test.mjs
@@ -1,0 +1,537 @@
+/**
+ * Tests for the provenance-contents verifier (#526).
+ *
+ * The whole value of this script is that it FAILS when an attestation says the
+ * wrong thing, so most of these are negative controls: mutate one field of a
+ * known-good statement and assert that exactly that field is reported. A suite
+ * that only proved the happy path would not distinguish this script from one
+ * that returns 0 unconditionally.
+ *
+ * Fixtures are shaped from a real response — the payload below is the same
+ * structure `registry.npmjs.org/-/npm/v1/attestations/bestax-migrate@2.0.0`
+ * returns, including the purl percent-encoding of the npm scope.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  parseArgs,
+  packagesInTree,
+  STATEMENT_TYPE,
+  installedVersion,
+  installedDigest,
+  extractProvenance,
+  checkStatement,
+  samePurl,
+  attestationUrl,
+  verifyPackage,
+  main,
+  SLSA_PREDICATE,
+  EXPECTED,
+} from './verify-attestation.mjs';
+
+const NO_WAIT = { backoffMs: [0, 0] };
+
+const DIGEST = 'a'.repeat(128);
+const INTEGRITY = `sha512-${Buffer.from(DIGEST, 'hex').toString('base64')}`;
+
+/** A statement that should pass every check. */
+function goodStatement({ pkg = 'bestax-migrate', version = '2.0.0' } = {}) {
+  return {
+    _type: STATEMENT_TYPE,
+    predicateType: SLSA_PREDICATE,
+    subject: [
+      { name: `pkg:npm/${pkg}@${version}`, digest: { sha512: DIGEST } },
+    ],
+    predicate: {
+      buildDefinition: {
+        externalParameters: {
+          workflow: {
+            ref: EXPECTED.ref,
+            repository: EXPECTED.repository,
+            path: EXPECTED.workflowPath,
+          },
+        },
+        internalParameters: {
+          github: {
+            event_name: 'push',
+            repository_id: EXPECTED.repositoryId,
+            repository_owner_id: EXPECTED.repositoryOwnerId,
+          },
+        },
+        resolvedDependencies: [{ digest: { gitCommit: 'a'.repeat(40) } }],
+      },
+      runDetails: {
+        builder: { id: EXPECTED.builder },
+        metadata: {
+          invocationId: `${EXPECTED.invocationIdPrefix}123/attempts/1`,
+        },
+      },
+    },
+  };
+}
+
+/** The registry response shape: npm's publish attestation plus the SLSA one. */
+function registryResponse(statement) {
+  return JSON.stringify({
+    attestations: [
+      {
+        predicateType:
+          'https://github.com/npm/attestation/tree/main/specs/publish/v0.1',
+        bundle: { dsseEnvelope: { payload: 'ignored' } },
+      },
+      {
+        predicateType: SLSA_PREDICATE,
+        bundle: {
+          dsseEnvelope: {
+            payload: Buffer.from(JSON.stringify(statement)).toString('base64'),
+          },
+        },
+      },
+    ],
+  });
+}
+
+async function fixtureTree({ pkg = 'bestax-migrate', version = '2.0.0' } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'attest-'));
+  await mkdir(join(dir, 'node_modules', ...pkg.split('/')), {
+    recursive: true,
+  });
+  await writeFile(
+    join(dir, 'node_modules', ...pkg.split('/'), 'package.json'),
+    JSON.stringify({ name: pkg, version })
+  );
+  await writeFile(
+    join(dir, 'package-lock.json'),
+    JSON.stringify({
+      packages: { [`node_modules/${pkg}`]: { version, integrity: INTEGRITY } },
+    })
+  );
+  return dir;
+}
+
+function stubFetch(handler) {
+  const real = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), method: init.method });
+    const r = handler(String(url));
+    if (r.throw) throw new Error(r.throw);
+    return {
+      status: r.status ?? 200,
+      statusText: r.statusText ?? '',
+      headers: { get: () => null },
+      text: async () => r.body ?? '',
+    };
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = real;
+    },
+  };
+}
+
+// --- argument parsing -------------------------------------------------------
+
+test('parseArgs takes --dir in both spellings plus the package list', () => {
+  assert.deepEqual(parseArgs(['--dir', '/t', 'a', 'b']), {
+    dir: '/t',
+    packages: ['a', 'b'],
+  });
+  assert.deepEqual(parseArgs(['--dir=/t', 'a']), {
+    dir: '/t',
+    packages: ['a'],
+  });
+});
+
+test('parseArgs requires --dir and rejects unknown options', () => {
+  assert.throws(() => parseArgs(['a', 'b']), /--dir/);
+  // A typo must be a usage error, not a package named "--dirs" that then
+  // fails verification for a package that never existed.
+  assert.throws(() => parseArgs(['--dirs', '/t', 'a']), /unknown option/);
+  assert.throws(
+    () => parseArgs(['--dir=/t', '--verbose', 'a']),
+    /unknown option/
+  );
+});
+
+test('an omitted package list is allowed — the roster comes from the tree', () => {
+  assert.deepEqual(parseArgs(['--dir', '/t']), { dir: '/t', packages: [] });
+});
+
+// --- reading the installed tree ---------------------------------------------
+
+test('the version and digest come from the tree, not from the registry', async () => {
+  const dir = await fixtureTree();
+  assert.equal(installedVersion(dir, 'bestax-migrate'), '2.0.0');
+  assert.equal(installedDigest(dir, 'bestax-migrate'), DIGEST);
+});
+
+test('a scoped package resolves through its nested directory', async () => {
+  const dir = await fixtureTree({
+    pkg: '@allxsmith/bestax-bulma',
+    version: '5.11.1',
+  });
+  assert.equal(installedVersion(dir, '@allxsmith/bestax-bulma'), '5.11.1');
+  assert.equal(installedDigest(dir, '@allxsmith/bestax-bulma'), DIGEST);
+});
+
+test('a missing package throws rather than resolving to something', async () => {
+  const dir = await fixtureTree();
+  assert.throws(() => installedVersion(dir, 'not-installed'));
+  assert.throws(
+    () => installedDigest(dir, 'not-installed'),
+    /no sha512 integrity/
+  );
+});
+
+// --- purl comparison --------------------------------------------------------
+
+test('samePurl sees through the scope percent-encoding npm actually emits', () => {
+  // The real bug: npm attests the scope as %40, so a naive string compare
+  // failed on the one scoped package we publish.
+  assert.ok(
+    samePurl(
+      'pkg:npm/%40allxsmith/bestax-bulma@5.11.1',
+      'pkg:npm/@allxsmith/bestax-bulma@5.11.1'
+    )
+  );
+  assert.ok(
+    samePurl('pkg:npm/bestax-migrate@2.0.0', 'pkg:npm/bestax-migrate@2.0.0')
+  );
+});
+
+test('samePurl still distinguishes different packages and versions', () => {
+  assert.ok(!samePurl('pkg:npm/a@1.0.0', 'pkg:npm/b@1.0.0'));
+  assert.ok(!samePurl('pkg:npm/a@1.0.0', 'pkg:npm/a@1.0.1'));
+  // A malformed escape fails to match rather than throwing.
+  assert.ok(!samePurl('pkg:npm/%zz@1.0.0', 'pkg:npm/a@1.0.0'));
+  assert.ok(!samePurl(undefined, 'pkg:npm/a@1.0.0'));
+});
+
+// --- extracting the payload -------------------------------------------------
+
+test('the SLSA bundle is selected, not whichever comes first', () => {
+  const statement = extractProvenance(registryResponse(goodStatement()));
+  assert.equal(statement.subject[0].digest.sha512, DIGEST);
+});
+
+test('a response carrying no SLSA bundle is an error, not an empty pass', () => {
+  const body = JSON.stringify({
+    attestations: [{ predicateType: 'https://example.test/other', bundle: {} }],
+  });
+  assert.throws(() => extractProvenance(body), /no https:\/\/slsa\.dev/);
+});
+
+test('an empty or malformed attestation list fails closed', () => {
+  assert.throws(() => extractProvenance('{}'), /no https:\/\/slsa\.dev/);
+  assert.throws(
+    () => extractProvenance('{"attestations":[]}'),
+    /no https:\/\/slsa\.dev/
+  );
+  assert.throws(() => extractProvenance('not json'));
+});
+
+test('a SLSA bundle with no payload is an error', () => {
+  const body = JSON.stringify({
+    attestations: [{ predicateType: SLSA_PREDICATE, bundle: {} }],
+  });
+  assert.throws(() => extractProvenance(body), /no dsseEnvelope payload/);
+});
+
+// --- the assertions themselves ----------------------------------------------
+
+const CTX = { pkg: 'bestax-migrate', version: '2.0.0', digest: DIGEST };
+
+test('a well-formed statement from our own build has no problems', () => {
+  assert.deepEqual(checkStatement(goodStatement(), CTX), []);
+});
+
+test('an attestation naming another repository is caught — the gap #526 exists for', () => {
+  const s = goodStatement();
+  s.predicate.buildDefinition.externalParameters.workflow.repository =
+    'https://github.com/someone-else/evil';
+  const problems = checkStatement(s, CTX);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /built from repository .*someone-else\/evil/);
+});
+
+test('a digest that does not match the installed tarball is caught', () => {
+  const s = goodStatement();
+  s.subject[0].digest.sha512 = 'b'.repeat(128);
+  const problems = checkStatement(s, CTX);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /does not match the installed tarball/);
+});
+
+test('a build from another workflow or another ref is caught', () => {
+  const wrongPath = goodStatement();
+  wrongPath.predicate.buildDefinition.externalParameters.workflow.path =
+    '.github/workflows/attacker.yml';
+  assert.match(checkStatement(wrongPath, CTX)[0], /built by workflow/);
+
+  const wrongRef = goodStatement();
+  wrongRef.predicate.buildDefinition.externalParameters.workflow.ref =
+    'refs/heads/some-branch';
+  assert.match(checkStatement(wrongRef, CTX)[0], /built from ref/);
+});
+
+test('a builder that is not a GitHub-hosted runner is caught', () => {
+  const s = goodStatement();
+  s.predicate.runDetails.builder.id = 'https://evil.test/builder';
+  assert.match(checkStatement(s, CTX)[0], /builder is/);
+});
+
+test('a subject naming a different package or version is caught', () => {
+  const s = goodStatement({ pkg: 'something-else' });
+  assert.match(checkStatement(s, CTX)[0], /no subject named/);
+});
+
+test('the matching subject is found even when it is not first', () => {
+  // in-toto permits multiple subjects; indexing [0] would report a correct
+  // package as wrong.
+  const s = goodStatement();
+  s.subject.unshift({
+    name: 'pkg:npm/other@9.9.9',
+    digest: { sha512: 'f'.repeat(128) },
+  });
+  assert.deepEqual(checkStatement(s, CTX), []);
+});
+
+test('an attestation from a renamed repo with our URL is still caught by the IDs', () => {
+  // The URL is a name and names transfer; the numeric IDs do not.
+  const s = goodStatement();
+  s.predicate.buildDefinition.internalParameters.github.repository_id = '111';
+  assert.match(checkStatement(s, CTX)[0], /repository_id is "111"/);
+});
+
+test('a self-hosted runner is caught, not just an obviously foreign builder', () => {
+  const s = goodStatement();
+  s.predicate.runDetails.builder.id =
+    'https://github.com/actions/runner/self-hosted';
+  assert.match(checkStatement(s, CTX)[0], /builder is/);
+});
+
+test('a run belonging to another repository is caught', () => {
+  const s = goodStatement();
+  s.predicate.runDetails.metadata.invocationId =
+    'https://github.com/someone-else/evil/actions/runs/1/attempts/1';
+  assert.match(checkStatement(s, CTX)[0], /invocationId/);
+});
+
+test('a missing or malformed source commit is caught', () => {
+  const s = goodStatement();
+  s.predicate.buildDefinition.resolvedDependencies = [];
+  assert.match(checkStatement(s, CTX)[0], /source commit/);
+});
+
+test('an empty statement fails every check rather than passing any', () => {
+  // The fail-closed case: absent fields must never satisfy an assertion.
+  const problems = checkStatement({}, CTX);
+  assert.equal(problems.length, 9);
+});
+
+test('every problem is reported at once, not one per run', () => {
+  const s = goodStatement();
+  s.predicate.buildDefinition.externalParameters.workflow.repository =
+    'https://x.test/y';
+  s.subject[0].digest.sha512 = 'c'.repeat(128);
+  assert.equal(checkStatement(s, CTX).length, 2);
+});
+
+// --- end to end -------------------------------------------------------------
+
+test('verifyPackage passes for a good package and requests the right URL', async () => {
+  const dir = await fixtureTree();
+  const s = stubFetch(() => ({ body: registryResponse(goodStatement()) }));
+  try {
+    const r = await verifyPackage('bestax-migrate', {
+      dir,
+      retryOptions: NO_WAIT,
+    });
+    assert.deepEqual(r, {
+      pkg: 'bestax-migrate',
+      version: '2.0.0',
+      ok: true,
+      problems: [],
+    });
+    assert.equal(s.calls[0].url, attestationUrl('bestax-migrate', '2.0.0'));
+    assert.equal(s.calls[0].method, 'GET', 'needs the body, so never HEAD');
+  } finally {
+    s.restore();
+  }
+});
+
+test('a registry that will not answer fails closed rather than passing', async () => {
+  const dir = await fixtureTree();
+  const s = stubFetch(() => ({ status: 503 }));
+  try {
+    const r = await verifyPackage('bestax-migrate', {
+      dir,
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.problems[0], /could not fetch the attestation/);
+  } finally {
+    s.restore();
+  }
+});
+
+test('a 404 from the registry fails closed too', async () => {
+  const dir = await fixtureTree();
+  const s = stubFetch(() => ({ status: 404, statusText: 'Not Found' }));
+  try {
+    const r = await verifyPackage('bestax-migrate', {
+      dir,
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.ok, false);
+  } finally {
+    s.restore();
+  }
+});
+
+test('main exits 0 when every package checks out', async () => {
+  const dir = await fixtureTree();
+  const s = stubFetch(() => ({ body: registryResponse(goodStatement()) }));
+  try {
+    const code = await main(['--dir', dir, 'bestax-migrate'], {
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(code, 0);
+  } finally {
+    s.restore();
+  }
+});
+
+test('main exits 1 when a package was built somewhere else', async () => {
+  const dir = await fixtureTree();
+  const bad = goodStatement();
+  bad.predicate.buildDefinition.externalParameters.workflow.repository =
+    'https://github.com/someone-else/evil';
+  const s = stubFetch(() => ({ body: registryResponse(bad) }));
+  try {
+    const code = await main(['--dir', dir, 'bestax-migrate'], {
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(code, 1);
+  } finally {
+    s.restore();
+  }
+});
+
+test('main exits 2 on bad usage, distinct from a failed verification', async () => {
+  assert.equal(await main([]), 2);
+});
+
+// --- roster derived from the tree -------------------------------------------
+
+test('packagesInTree reads the roster the install step actually produced', async () => {
+  const dir = await fixtureTree();
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify({ dependencies: { b: '^1', a: '^2' } })
+  );
+  assert.deepEqual(packagesInTree(dir), ['a', 'b']);
+});
+
+test('an empty tree refuses to report success on a run that checks nothing', async () => {
+  const dir = await fixtureTree();
+  await writeFile(join(dir, 'package.json'), JSON.stringify({}));
+  assert.throws(() => packagesInTree(dir), /nothing to verify/);
+});
+
+test('main derives the roster when no packages are named', async () => {
+  const dir = await fixtureTree();
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify({ dependencies: { 'bestax-migrate': '^2' } })
+  );
+  const s = stubFetch(() => ({ body: registryResponse(goodStatement()) }));
+  try {
+    assert.equal(await main(['--dir', dir], { retryOptions: NO_WAIT }), 0);
+    assert.equal(s.calls.length, 1);
+  } finally {
+    s.restore();
+  }
+});
+
+// --- registry propagation lag ------------------------------------------------
+
+test('a 404 from the attestations route is retried, not believed on sight', async () => {
+  // The job runs seconds after npm publish and that route propagates
+  // separately from the packument, so a first-try 404 is usually lag.
+  const dir = await fixtureTree();
+  let call = 0;
+  const s = stubFetch(() => {
+    call += 1;
+    return call < 3
+      ? { status: 404, statusText: 'Not Found' }
+      : { body: registryResponse(goodStatement()) };
+  });
+  try {
+    const r = await verifyPackage('bestax-migrate', {
+      dir,
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.ok, true);
+    assert.equal(s.calls.length, 3);
+  } finally {
+    s.restore();
+  }
+});
+
+test('a 404 that never clears still fails closed', async () => {
+  const dir = await fixtureTree();
+  const s = stubFetch(() => ({ status: 404, statusText: 'Not Found' }));
+  try {
+    const r = await verifyPackage('bestax-migrate', {
+      dir,
+      retryOptions: NO_WAIT,
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.problems[0], /could not fetch the attestation/);
+  } finally {
+    s.restore();
+  }
+});
+
+// --- statement type is re-checked after decoding -----------------------------
+
+test('a payload whose decoded type disagrees with the envelope label is rejected', () => {
+  // The outer predicateType is unsigned metadata; the decoded statement's own
+  // fields are what make the selection self-verifying.
+  const s = goodStatement();
+  s.predicateType = 'https://example.test/not-slsa';
+  assert.throws(
+    () => extractProvenance(registryResponse(s)),
+    /decoded predicateType/
+  );
+
+  const s2 = goodStatement();
+  s2._type = 'https://example.test/not-in-toto';
+  assert.throws(
+    () => extractProvenance(registryResponse(s2)),
+    /decoded statement is/
+  );
+});
+
+// --- lockfile integrity validation -------------------------------------------
+
+test('a corrupted integrity is reported as a lockfile problem, not a mismatch', async () => {
+  const dir = await fixtureTree();
+  await writeFile(
+    join(dir, 'package-lock.json'),
+    JSON.stringify({
+      packages: { 'node_modules/bestax-migrate': { integrity: 'sha512-!!!!' } },
+    })
+  );
+  assert.throws(
+    () => installedDigest(dir, 'bestax-migrate'),
+    /decoded to \d+ bytes/
+  );
+});

--- a/scripts/verify-attestation.test.mjs
+++ b/scripts/verify-attestation.test.mjs
@@ -344,6 +344,19 @@ test('the source descriptor is found even when it is not first', () => {
   assert.deepEqual(checkStatement(s, CTX), []);
 });
 
+test('a near-collision repository name is not accepted as our source', () => {
+  // `includes` would select bestax-evil here and let its digest satisfy the
+  // source-commit assertion while nothing describes this repository.
+  const s = goodStatement();
+  s.predicate.buildDefinition.resolvedDependencies = [
+    {
+      uri: 'git+https://github.com/allxsmith/bestax-evil@refs/heads/main',
+      digest: { gitCommit: 'd'.repeat(40) },
+    },
+  ];
+  assert.match(checkStatement(s, CTX)[0], /no resolved dependency/);
+});
+
 test('an unrelated dependency cannot stand in for a missing source commit', () => {
   // The other half of the [0] bug: a foreign entry with a valid-looking sha
   // must not satisfy the check.


### PR DESCRIPTION
Closes #526.

`verify-provenance` proved an attestation *existed* and was typed `https://slsa.dev/provenance/v1`, by reading one field off `npm view`. It never opened the attestation. **A valid, correctly signed statement naming somebody else's repository satisfied that check and `npm audit signatures` both.**

`SECURITY.md` tells users provenance "links the tarball to the exact commit and CI run that built it". That is true of the attestation. Nothing in CI checked the link pointed at us.

## What is asserted now

`scripts/verify-attestation.mjs` decodes the SLSA statement and checks nine things:

| Assertion | Why this one |
| --- | --- |
| Subject digest == the installed tarball's `integrity` | Binds the artifact actually installed to the artifact signed. Verified against the registry: the lockfile SRI decodes to exactly the attested sha512. |
| `repository_id` + `repository_owner_id` | **The load-bearing pair.** A repo URL is a *name*, and names transfer — rename the repo or let the `allxsmith` handle lapse, and whoever takes that path can publish a validly signed attestation naming this exact URL. The numeric IDs cannot be reassigned. |
| `workflow.repository` | The human-readable half of the same claim. |
| `workflow.path` + `workflow.ref` | A release built from another workflow or another branch is visible. |
| `builder.id` == `.../actions/runner/github-hosted` | **Exact, not a prefix.** npm emits either `github-hosted` or `self-hosted`, so a prefix match accepts a build on an attacker-registered self-hosted runner — satisfying a check whose whole stated point is that it did not happen on one. |
| `invocationId` under this repo's `/actions/runs/` | The "CI run" half of the SECURITY.md promise, rather than merely quoting it. |
| A 40-char `gitCommit` | The "exact commit" half. The value cannot be pinned (it is whatever was on main at release), so presence and shape are what is available to assert. |
| Decoded `_type` + `predicateType` | The bundle is *selected* on the envelope's `predicateType`, which is unsigned metadata outside what the DSSE signature covers. Re-checking the decoded statement makes the selection self-verifying. |

Every path fails closed — a fetch error, an unparsable payload, a missing field. The test asserting an empty statement produces all nine problems is the guard on that.

**Deliberately not here: signature verification.** `npm audit signatures` runs immediately before this in the same job and covers it. Re-verifying the Sigstore bundle would mean vendoring a verifier for no marginal gain. This answers a different question — not "is this signed?" but "signed as *what*?".

## Two things that are not just the feature

**The registry 404 is retried, not believed.** This job runs on `release: published`, seconds after `npm publish`, and the registry serves the attestations route separately from the packument — so a first-try 404 is far more likely propagation lag than a missing attestation. The shell loop this replaces spent three attempts for exactly that reason ("a gate that cries wolf gets ignored"); moving to a single fetch would have discarded it silently.

**The package roster is read back out of the scratch tree.** The install step is now the only place packages are named. Two lists with reciprocal "keep in sync" comments is an invariant with nothing enforcing it — add a fifth published package to one and not the other and it ships unverified, silently, green.

## Workflow change

Per `.github/CLAUDE.md`, middle row — the job's logic changes, so here is the check rather than the assertion:

- **The job gains `actions/checkout`.** That is a second third-party action in a job that had one, and it is the honest cost of moving this logic somewhere it can be tested rather than something to elide. It is on the repo-wide pin (`3d3c42e5aac5ba805825da76410c181273ba90b1 # v7` — verified as a single distinct SHA across all 23 usages, per rule 1) and sets `persist-credentials: false`, so no token is written to the runner's git config.
- **`permissions:` unchanged.** The job declares none and inherits the workflow-level `contents: read`. No credential in the job, so rule 2 does not engage.
- No trigger change, no new repository variable, nothing that spends model usage. Rule 10: still grandfathered, `harden-runner` stays out of scope.
- The change also **removes** two subprocess surfaces (`npm ls`, `npm view`) and ~35 lines of untestable inline shell.

## Verification

```
168 script tests pass (38 new), lint clean, format clean, full `pnpm all` green
```

Live run against the real registry, roster derived from the tree:

```
verify-attestation: checking 4 package(s): @allxsmith/bestax-bulma, bestax-mcp, bestax-migrate, create-bestax
ok: @allxsmith/bestax-bulma@5.11.1 — built by https://github.com/allxsmith/bestax
ok: bestax-mcp@1.0.0 — built by https://github.com/allxsmith/bestax
ok: bestax-migrate@2.0.0 — built by https://github.com/allxsmith/bestax
ok: create-bestax@4.1.0 — built by https://github.com/allxsmith/bestax
verify-attestation: 4 package(s) check out
```

**Negative controls**, because a verifier that only passes proves nothing:

- Expected repository flipped to a foreign URL → fails, naming the mismatch.
- Empty scratch tree → fails closed rather than reporting an empty success.
- Per-field mutations of a known-good statement → each reported individually, including self-hosted runner, foreign `invocationId`, wrong `repository_id`, and a subject that is not first in the list.

**One real bug caught by running it against the registry rather than a fixture:** purl percent-encodes the `@` that introduces an npm scope, so `@allxsmith/bestax-bulma` is attested as `pkg:npm/%40allxsmith/bestax-bulma@5.11.1`. A naive string compare failed on the one scoped package we publish — which would have been a false red in CI. `samePurl` decodes both sides rather than hard-coding the encoding.

## Review already applied

This branch was reviewed locally before it existed as a PR. `/code-review` raised 12 findings and all 12 are fixed here — including the 404 retry, the mutable-name identity gap, and the self-hosted builder hole above, plus subject-by-name lookup, unknown-flag handling, lockfile integrity length validation, and opt-in `keepBody` so the URL gate does not retain response bodies it never reads. `/security-review` found no HIGH or MEDIUM issues; its hardening note (freeze `EXPECTED`) is applied.

## Out of scope, named rather than hidden

The registry host is hardcoded to `registry.npmjs.org` while the install step resolves through npm's configured registry. Behind a mirror or proxy those could differ, and Node's `fetch` does not honour `HTTP(S)_PROXY` the way npm does. Reading npm's config would mean reintroducing a subprocess, which is the thing this change removes. Not a problem for this repo's CI today; worth knowing before anyone points it at a mirror.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated verification of package provenance attestations, including repository, workflow, commit, builder, and digest checks.
  * Verification now fails safely when package integrity or attestation details are missing or invalid.
* **Reliability**
  * Improved retry handling for transient responses and optionally retains successful response bodies.
* **Testing**
  * Added comprehensive coverage for provenance validation, package discovery, malformed data, retries, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->