### PR TITLE
docs: give the pnpm-publish rationale one home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ pnpm exec turbo run test --filter=@allxsmith/bestax-bulma   # scope any task to 
 Enforced by CI (`.github/workflows/ci.yml`):
 
 - Coverage thresholds from the jest configs: **bulma-ui 99%** (all metrics);
-  create-bestax, bestax-migrate and bestax-mcp 95% (78% branches).
+  every other jest package 95% (78% branches). `docs` has no jest suite.
 - Stale skill catalog fails (`gen:catalog:check`) and a stale MCP index fails
   (`gen:mcp:check`); build, typecheck, lint, format, audit.
 - House conventions fail via `pnpm check:conformance` (error messages name the file and fix);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,9 @@ semantic-release. Two repo-specific rules:
 
 - Commits of type `feat|fix|perf|refactor|style|revert` **must** use a scope of `bulma-ui`, `docs`,
   `create-bestax`, `bestax-migrate`, or `bestax-mcp` — unscoped release types are rejected
-  (`RELEASE_SCOPES` in `commitlint.config.js` is the source of truth).
+  (`RELEASE_SCOPES` in `commitlint.config.js` is the source of truth). One exception worth
+  knowing: commitlint's default ignores skip git's own `Revert "…"` messages, so the hook cannot
+  reject an unscoped revert in that form — keep reverts conventional and scoped by hand.
 - **Packages release independently, keyed off the scope**: `feat(bulma-ui)` bumps only
   `@allxsmith/bestax-bulma`; `fix(create-bestax)` bumps only `create-bestax`. The
   `releaseRules` in each package's `release.config.js` are the source of truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ pnpm exec turbo run test --filter=@allxsmith/bestax-bulma   # scope any task to 
 
 Enforced by CI (`.github/workflows/ci.yml`):
 
-- Coverage thresholds from the jest configs: **bulma-ui 99%** (all metrics),
-  create-bestax and bestax-mcp 95% (78% branches).
+- Coverage thresholds from the jest configs: **bulma-ui 99%** (all metrics);
+  create-bestax, bestax-migrate and bestax-mcp 95% (78% branches).
 - Stale skill catalog fails (`gen:catalog:check`) and a stale MCP index fails
   (`gen:mcp:check`); build, typecheck, lint, format, audit.
 - House conventions fail via `pnpm check:conformance` (error messages name the file and fix);
@@ -61,7 +61,7 @@ Enforced in review (a green CI does **not** check these):
 Conventional Commits, enforced by commitlint (husky `commit-msg` hook) and consumed by
 semantic-release. Two repo-specific rules:
 
-- Commits of type `feat|fix|perf|refactor|style` **must** use a scope of `bulma-ui`, `docs`,
+- Commits of type `feat|fix|perf|refactor|style|revert` **must** use a scope of `bulma-ui`, `docs`,
   `create-bestax`, `bestax-migrate`, or `bestax-mcp` — unscoped release types are rejected
   (`RELEASE_SCOPES` in `commitlint.config.js` is the source of truth).
 - **Packages release independently, keyed off the scope**: `feat(bulma-ui)` bumps only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,9 @@ Before contributing, your PR **must** satisfy the following:
 
 - **All tests pass** (`pnpm test` & `pnpm test:coverage`)
   - Coverage thresholds are enforced per package by jest: **bulma-ui 99%** on all metrics
-    ([`bulma-ui/jest.config.js`](./bulma-ui/jest.config.js)); **every other package**
-    95% (78% branches), each in its own jest config
+    ([`bulma-ui/jest.config.js`](./bulma-ui/jest.config.js)); **every other jest
+    package** 95% (78% branches), each in its own config. `docs` runs
+    `node --test` and has no coverage threshold
 - **Linting and formatting pass** (`pnpm lint`, `pnpm format:check`)
 - **Type checks pass** (`pnpm typecheck`)
 - **Storybook runs and covers UI changes** (`pnpm storybook`)
@@ -175,7 +176,7 @@ pnpm run all
 pnpm run build          # turbo build all packages
 pnpm run typecheck
 pnpm run test           # jest in every package + the docs and scripts/ node:test suites
-pnpm run test:coverage  # coverage (bulma-ui 99%; every other package 95%, 78% branches)
+pnpm run test:coverage  # coverage (bulma-ui 99%; every other jest package 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
 pnpm run bundle:stats   # writes bulma-ui/dist/stats.html
@@ -281,7 +282,7 @@ no `npm publish`, no tag, no GitHub release.
    pnpm install
    ```
 4. **Make your changes** in the appropriate workspace (`bulma-ui` for components, `docs` for documentation).
-5. **Update/add unit tests** (coverage must stay above each package's jest threshold — 99% for bulma-ui, 95% with 78% branches for every other package).
+5. **Update/add unit tests** (coverage must stay above each package's jest threshold — 99% for bulma-ui, 95% with 78% branches for every other jest package).
 6. **Add or update Storybook stories** for UI-related changes.
 7. **Update documentation** in `/docs` as needed.
 8. **Run all checks**:
@@ -353,7 +354,7 @@ The CI `publish` job grants `id-token: write`. It no longer pins an npm version:
 ## Code Quality Standards
 
 - **Unit tests** required for all new features and bug fixes.
-- **Coverage must not drop below the per-package jest thresholds** (bulma-ui 99%; every other package 95%, 78% branches).
+- **Coverage must not drop below the per-package jest thresholds** (bulma-ui 99%; every other jest package 95%, 78% branches). `docs` has no jest suite and no threshold.
 - **Linting, formatting, and type checks** must all pass.
 - **Storybook stories** required for any visible or interactive UI change.
 - **Documentation** must be updated to reflect your changes (see [Documentation](#documentation)).
@@ -370,10 +371,14 @@ commitlint via the husky `commit-msg` hook ([`commitlint.config.js`](./commitlin
 - **Release types need a scope:** commits of type `feat`, `fix`, `perf`, `refactor`, `style`
   or `revert` **must** use a scope of `bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`
   or `bestax-mcp` (repo-specific commitlint rule — the scope decides which package releases,
-  see [`VERSIONING.md`](./VERSIONING.md)). `revert` is in that list for a reason worth
-  knowing: commit-analyzer ships `{ revert: true, release: 'patch' }`, so an unscoped revert
-  matches no package's negated-scope suppression and would patch-release **all** of them.
-  `RELEASE_TYPES` and `RELEASE_SCOPES` in `commitlint.config.js` are the source of truth.
+  see [`VERSIONING.md`](./VERSIONING.md)). `revert` is in that list because
+  commit-analyzer ships `{ revert: true, release: 'patch' }`, so an unscoped revert would
+  match no package's negated-scope suppression and patch-release **all** of them. Note the
+  residual, which `commitlint.config.js` records: that rule fires on the parser's
+  `revertPattern` — git's own `Revert "…"` form — and commitlint's default `ignores` skip
+  those messages entirely, so scoping is a convention here rather than something the hook
+  can enforce. Keep reverts conventional and scoped. `RELEASE_TYPES` and `RELEASE_SCOPES`
+  in `commitlint.config.js` are the source of truth.
 - **Breaking changes** need a `BREAKING CHANGE:` footer in the body — a `!` after the type is
   **not** picked up by our release tooling.
 - Non-releasing types (`docs`, `chore`, `ci`, `test`, `build`) may omit the scope.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ pnpm run all
 ```bash
 pnpm run build          # turbo build all packages
 pnpm run typecheck
-pnpm run test           # jest (all four packages) + the scripts/ node:test suite
+pnpm run test           # jest (all four packages) + the docs and scripts/ node:test suites
 pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ pnpm run all
 pnpm run build          # turbo build all packages
 pnpm run typecheck
 pnpm run test           # jest (bulma-ui + create-bestax)
-pnpm run test:coverage  # coverage (bulma-ui: 99%; create-bestax: 95%, 78% branches)
+pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
 pnpm run bundle:stats   # writes bulma-ui/dist/stats.html
@@ -246,8 +246,9 @@ Runs the real commit analysis + next-version calc, but publishes nothing:
 
 ```bash
 export GITHUB_TOKEN=<a token with repo read>   # the github plugin needs it even in dry-run
-cd bulma-ui      && pnpm exec semantic-release --dry-run --no-ci ; cd ..
-cd create-bestax && pnpm exec semantic-release --dry-run --no-ci ; cd ..
+for pkg in bulma-ui create-bestax bestax-migrate bestax-mcp; do
+  ( cd "$pkg" && pnpm exec semantic-release --dry-run --no-ci )
+done
 ```
 
 It prints "The next release version is X.Y.Z" per package (or "no release") from your local commits —
@@ -255,14 +256,16 @@ no `npm publish`, no tag, no GitHub release.
 
 > **Safe to run; never publishes:** everything above. The only things that actually publish are
 > `pnpm exec semantic-release` **without** `--dry-run` (CI-only, on merge to `main`) and a manual
-> `pnpm publish --provenance --embed-readme --access public` — neither of which is in this
-> list. Those flags are not optional: pnpm defaults `embed-readme` to false and ignores
-> `publishConfig.provenance`, which no package carries, so a bare `pnpm publish` ships
-> unattested and loses the npm page's README. Every package publishes with `pnpm publish`,
-> and each one's `prepack` and `prepublishOnly` hooks refuse the publishers they recognise as not
-> being pnpm, so a stray `npm publish` or `npm pack` exits with an explanation rather than
-> shipping an unresolved specifier (#412). Both hooks are skipped by `--ignore-scripts`, and
-> neither travels with a tarball that was packed elsewhere.
+> `pnpm publish --provenance --embed-readme --access public` — neither of which is in this list.
+> Those flags are not optional, and a bare `pnpm publish` ships unattested and loses the npm
+> page's README.
+>
+> You are unlikely to need a manual publish at all. Every package's `prepack` and
+> `prepublishOnly` hooks refuse publishers they recognise as not being pnpm, so a stray
+> `npm publish` or `npm pack` exits with an explanation rather than shipping an unresolved
+> specifier (#412) — though `--ignore-scripts` skips both, and neither travels with a tarball
+> packed elsewhere. Why each flag matters and what the guard does and does not cover:
+> [`VERSIONING.md`](./VERSIONING.md#release-process) and `scripts/require-pnpm-publish.mjs`.
 
 ---
 
@@ -338,12 +341,12 @@ Publishing authenticates with npm via [OIDC trusted publishing](https://docs.npm
 
 For this to work, each published package must have a trusted publisher configured **once** on npmjs.com (Package → Settings → Trusted Publisher):
 
-- Packages: `@allxsmith/bestax-bulma` and `create-bestax`
+- Packages: `@allxsmith/bestax-bulma`, `create-bestax`, `bestax-migrate` and `bestax-mcp` — all four, and a missing entry fails the publish _after_ the release commit and tag are pushed
 - Provider: **GitHub Actions**
 - Repository: `allxsmith/bestax`
 - Workflow: `ci.yml`
 
-The CI `publish` job grants `id-token: write` and upgrades npm to a version that supports OIDC.
+The CI `publish` job grants `id-token: write`. It no longer pins an npm version: that pin existed because `npm publish` needed npm >= 11.5.1 for OIDC, and since #532 every package publishes with `pnpm publish`, which carries its own OIDC exchange.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,9 @@ Before contributing, your PR **must** satisfy the following:
 
 - **All tests pass** (`pnpm test` & `pnpm test:coverage`)
   - Coverage thresholds are enforced per package by jest: **bulma-ui 99%** on all metrics
-    ([`bulma-ui/jest.config.js`](./bulma-ui/jest.config.js)), **create-bestax 95%**
-    (78% branches, [`create-bestax/jest.config.mjs`](./create-bestax/jest.config.mjs))
+    ([`bulma-ui/jest.config.js`](./bulma-ui/jest.config.js)); **create-bestax**,
+    **bestax-migrate** and **bestax-mcp** 95% (78% branches), each in that package's
+    own jest config
 - **Linting and formatting pass** (`pnpm lint`, `pnpm format:check`)
 - **Type checks pass** (`pnpm typecheck`)
 - **Storybook runs and covers UI changes** (`pnpm storybook`)
@@ -174,7 +175,7 @@ pnpm run all
 ```bash
 pnpm run build          # turbo build all packages
 pnpm run typecheck
-pnpm run test           # jest (bulma-ui + create-bestax)
+pnpm run test           # jest (all four packages) + the scripts/ node:test suite
 pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
@@ -353,7 +354,7 @@ The CI `publish` job grants `id-token: write`. It no longer pins an npm version:
 ## Code Quality Standards
 
 - **Unit tests** required for all new features and bug fixes.
-- **Coverage must not drop below the per-package jest thresholds** (bulma-ui 99%, create-bestax 95%).
+- **Coverage must not drop below the per-package jest thresholds** (bulma-ui 99%; create-bestax, bestax-migrate and bestax-mcp 95%, 78% branches).
 - **Linting, formatting, and type checks** must all pass.
 - **Storybook stories** required for any visible or interactive UI change.
 - **Documentation** must be updated to reflect your changes (see [Documentation](#documentation)).
@@ -367,9 +368,13 @@ commitlint via the husky `commit-msg` hook ([`commitlint.config.js`](./commitlin
 
 - **Format:** `<type>(<scope>): <subject>` — imperative subject, blank line, then an optional
   body with bullet points and context.
-- **Release types need a scope:** commits of type `feat`, `fix`, `perf`, `refactor`, or `style`
-  **must** use a scope of `bulma-ui`, `docs`, or `create-bestax` (repo-specific commitlint
-  rule — the scope decides which package releases, see [`VERSIONING.md`](./VERSIONING.md)).
+- **Release types need a scope:** commits of type `feat`, `fix`, `perf`, `refactor`, `style`
+  or `revert` **must** use a scope of `bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`
+  or `bestax-mcp` (repo-specific commitlint rule — the scope decides which package releases,
+  see [`VERSIONING.md`](./VERSIONING.md)). `revert` is in that list for a reason worth
+  knowing: commit-analyzer ships `{ revert: true, release: 'patch' }`, so an unscoped revert
+  matches no package's negated-scope suppression and would patch-release **all** of them.
+  `RELEASE_TYPES` and `RELEASE_SCOPES` in `commitlint.config.js` are the source of truth.
 - **Breaking changes** need a `BREAKING CHANGE:` footer in the body — a `!` after the type is
   **not** picked up by our release tooling.
 - Non-releasing types (`docs`, `chore`, `ci`, `test`, `build`) may omit the scope.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,8 @@ Before contributing, your PR **must** satisfy the following:
 
 - **All tests pass** (`pnpm test` & `pnpm test:coverage`)
   - Coverage thresholds are enforced per package by jest: **bulma-ui 99%** on all metrics
-    ([`bulma-ui/jest.config.js`](./bulma-ui/jest.config.js)); **create-bestax**,
-    **bestax-migrate** and **bestax-mcp** 95% (78% branches), each in that package's
-    own jest config
+    ([`bulma-ui/jest.config.js`](./bulma-ui/jest.config.js)); **every other package**
+    95% (78% branches), each in its own jest config
 - **Linting and formatting pass** (`pnpm lint`, `pnpm format:check`)
 - **Type checks pass** (`pnpm typecheck`)
 - **Storybook runs and covers UI changes** (`pnpm storybook`)
@@ -175,8 +174,8 @@ pnpm run all
 ```bash
 pnpm run build          # turbo build all packages
 pnpm run typecheck
-pnpm run test           # jest (all four packages) + the docs and scripts/ node:test suites
-pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
+pnpm run test           # jest in every package + the docs and scripts/ node:test suites
+pnpm run test:coverage  # coverage (bulma-ui 99%; every other package 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
 pnpm run bundle:stats   # writes bulma-ui/dist/stats.html
@@ -282,7 +281,7 @@ no `npm publish`, no tag, no GitHub release.
    pnpm install
    ```
 4. **Make your changes** in the appropriate workspace (`bulma-ui` for components, `docs` for documentation).
-5. **Update/add unit tests** (coverage must stay above each package's jest threshold — 99% for bulma-ui, 95% for create-bestax).
+5. **Update/add unit tests** (coverage must stay above each package's jest threshold — 99% for bulma-ui, 95% with 78% branches for every other package).
 6. **Add or update Storybook stories** for UI-related changes.
 7. **Update documentation** in `/docs` as needed.
 8. **Run all checks**:
@@ -330,7 +329,7 @@ The short version for contributors:
 
 ## Semantic Release & Publishing
 
-We use [Semantic Release](https://semantic-release.gitbook.io/) to automate publishing of both packages to npm: `bulma-ui` as [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) and [`create-bestax`](https://www.npmjs.com/package/create-bestax).
+We use [Semantic Release](https://semantic-release.gitbook.io/) to automate publishing of every package to npm: `bulma-ui` as [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma), plus [`create-bestax`](https://www.npmjs.com/package/create-bestax), [`bestax-migrate`](https://www.npmjs.com/package/bestax-migrate) and [`bestax-mcp`](https://www.npmjs.com/package/bestax-mcp).
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) to trigger releases — see [Commit Message Guidelines](#commit-message-guidelines).
 - **Packages version and release independently, keyed off the commit scope** — `feat(bulma-ui)` releases only bestax-bulma. See [`VERSIONING.md`](./VERSIONING.md).
@@ -342,7 +341,7 @@ Publishing authenticates with npm via [OIDC trusted publishing](https://docs.npm
 
 For this to work, each published package must have a trusted publisher configured **once** on npmjs.com (Package → Settings → Trusted Publisher):
 
-- Packages: `@allxsmith/bestax-bulma`, `create-bestax`, `bestax-migrate` and `bestax-mcp` — all four, and a missing entry fails the publish _after_ the release commit and tag are pushed
+- Packages: `@allxsmith/bestax-bulma`, `create-bestax`, `bestax-migrate` and `bestax-mcp` — every publishable package, and a missing entry fails the publish _after_ the release commit and tag are pushed
 - Provider: **GitHub Actions**
 - Repository: `allxsmith/bestax`
 - Workflow: `ci.yml`
@@ -354,7 +353,7 @@ The CI `publish` job grants `id-token: write`. It no longer pins an npm version:
 ## Code Quality Standards
 
 - **Unit tests** required for all new features and bug fixes.
-- **Coverage must not drop below the per-package jest thresholds** (bulma-ui 99%; create-bestax, bestax-migrate and bestax-mcp 95%, 78% branches).
+- **Coverage must not drop below the per-package jest thresholds** (bulma-ui 99%; every other package 95%, 78% branches).
 - **Linting, formatting, and type checks** must all pass.
 - **Storybook stories** required for any visible or interactive UI change.
 - **Documentation** must be updated to reflect your changes (see [Documentation](#documentation)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,11 +45,11 @@ Measures active in this repository and its release pipeline:
   for testing, and never publishes.)
 - **npm provenance** — every release carries a signed attestation linking the
   tarball to the exact commit and CI run that built it. Releases come from CI
-  and nowhere else, which is what backs that claim: every package publishes
-  with `pnpm publish`, which does not read `publishConfig.provenance`, so the
-  `--provenance` flag CI passes is the only thing turning it on. A hand publish
-  that omitted it would ship unattested, which is why the `prepublishOnly`
-  guard prints the flags before letting one through.
+  and nowhere else, which is what backs that claim. No package carries a
+  `publishConfig.provenance`; the flag on the publish command is what produces
+  the attestation, and `prepack`/`prepublishOnly` guards refuse a publisher
+  that would skip it. Why it works that way is in
+  [`VERSIONING.md`](./VERSIONING.md#release-process).
   No package carries a `publishConfig.provenance` at all — having one there
   would imply the flag was redundant, and dropping the flag is the quiet way to
   lose attestations entirely (#436, #532).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,8 +43,9 @@ Measures active in this repository and its release pipeline:
   reviewed lockfile resolves. (The React 18/19 compatibility matrix is the
   one deliberate exception: it re-resolves to pin the requested React major
   for testing, and never publishes.)
-- **npm provenance** — every release carries a signed attestation linking the
-  tarball to the exact commit and CI run that built it. Releases come from CI
+- **npm provenance** — every release now carries a signed attestation linking
+  the tarball to the exact commit and CI run that built it (versions older than
+  the currently supported lines predate it). Releases come from CI
   and nowhere else, which is what backs that claim. No package carries a
   `publishConfig.provenance` — having one would imply the flag was redundant,
   and dropping the flag is the quiet way to lose attestations entirely. The

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,13 +46,12 @@ Measures active in this repository and its release pipeline:
 - **npm provenance** — every release carries a signed attestation linking the
   tarball to the exact commit and CI run that built it. Releases come from CI
   and nowhere else, which is what backs that claim. No package carries a
-  `publishConfig.provenance`; the flag on the publish command is what produces
-  the attestation, and `prepack`/`prepublishOnly` guards refuse a publisher
-  that would skip it. Why it works that way is in
+  `publishConfig.provenance` — having one would imply the flag was redundant,
+  and dropping the flag is the quiet way to lose attestations entirely. The
+  `prepack`/`prepublishOnly` guards refuse packers they recognise as not being
+  pnpm; they do not refuse a hand-run `pnpm publish` that omits the flag, which
+  they warn about instead. Why it works that way is in
   [`VERSIONING.md`](./VERSIONING.md#release-process).
-  No package carries a `publishConfig.provenance` at all — having one there
-  would imply the flag was redundant, and dropping the flag is the quiet way to
-  lose attestations entirely (#436, #532).
 - **Licence text comes from the workspace root** — no package carries its own
   `LICENSE` file, and `pnpm publish` copies the root one into every tarball.
   npm did not, so releases before #532 shipped none. It is the right file

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,8 +50,9 @@ Measures active in this repository and its release pipeline:
   `publishConfig.provenance` — having one would imply the flag was redundant,
   and dropping the flag is the quiet way to lose attestations entirely. The
   `prepack`/`prepublishOnly` guards refuse packers they recognise as not being
-  pnpm; they do not refuse a hand-run `pnpm publish` that omits the flag, which
-  they warn about instead. Why it works that way is in
+  pnpm. They do not refuse a hand-run `pnpm publish` that omits the flag; the
+  `prepublishOnly` hook warns about it instead, and only outside CI, so that
+  inspecting a tarball with `pnpm pack` stays quiet. Why it works that way is in
   [`VERSIONING.md`](./VERSIONING.md#release-process).
 - **Licence text comes from the workspace root** — no package carries its own
   `LICENSE` file, and `pnpm publish` copies the root one into every tarball.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -73,7 +73,7 @@ On merge to `main`, CI (`.github/workflows/ci.yml`) runs semantic-release in eac
      step. A publish that fails leaves the commit and tag behind, and that version is spent.
 3. A push may release any subset of the packages — they never bump each other.
 
-Three things about that publish step are load-bearing, and none of them fails loudly:
+Five things about that publish step are load-bearing, and none of them fails loudly:
 
 - **`--provenance` is required.** pnpm reads `publishConfig.registry` and `.access` but takes
   `provenance` from options only. `publishConfig.provenance` is deliberately absent from every
@@ -82,6 +82,16 @@ Three things about that publish step are load-bearing, and none of them fails lo
   it is redundant. Drop the flag and #411's provenance quietly stops being produced.
 - **`--embed-readme` is required.** pnpm defaults it to false where npm defaults it to true;
   without it the npmjs.com page loses its README.
+- **There is deliberately no `--tag`.** Correct only while every release goes to `latest`,
+  which holds because every package's `branches` is `['main']` so the channel is always null.
+  Adding a maintenance or prerelease branch means deriving the dist-tag first, and that
+  derivation is not naive — see `scripts/lib/pnpm-publish.mjs`. A test fails if `branches`
+  changes, so the decision cannot be made silently.
+- **The publish command redirects pnpm's output to stderr.** `@semantic-release/exec` parses
+  stdout as the JSON release object; pnpm prints prose there. Without the redirect the parse
+  fails and the "release is available on" comment posted to every linked issue and PR shows a
+  bare tag instead of an npm link. The reasoning, including why the trailing `|| true` lives in
+  the shell rather than the script, is in `scripts/lib/pnpm-publish.mjs`.
 - **The auth pre-flight is weaker than it was.** `@semantic-release/npm` exchanged a real OIDC
   token during `verifyConditions`. With `npmPublish: false` that is off, so
   `scripts/verify-oidc-context.mjs` runs as the exec plugin's `verifyConditionsCmd` and checks

--- a/bestax-mcp/CLAUDE.md
+++ b/bestax-mcp/CLAUDE.md
@@ -84,7 +84,7 @@ test that stubs it proves nothing about what ships.
 Independent semantic-release keyed off the `bestax-mcp` commit scope
 (`release.config.js`, tag `bestax-mcp@x.y.z`). It publishes with
 `pnpm publish`, like every package here (#532) — the command, its flags, and the
-three ways that publish fails quietly are documented in `VERSIONING.md` and
+ways that publish fails quietly are documented in `VERSIONING.md` and
 `scripts/lib/pnpm-publish.mjs`.
 
 Its `prepack` runs the guard and then `scripts/sync-skills.mjs`, which fills

--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -67,7 +67,7 @@ Independent semantic-release, keyed off the `bestax-migrate` commit scope
 **Publishing is shared, and this package is why it looks the way it does.**
 Every package here publishes with `pnpm publish` rather than `npm publish`
 (#436, then #532), through the plugin pair in `scripts/lib/pnpm-publish.mjs`.
-The mechanism and its three quiet failure modes are documented once in
+The mechanism and the ways it fails quietly are documented once in
 `VERSIONING.md` and in that helper. The `prepack` / `prepublishOnly` guard is
 documented in `scripts/require-pnpm-publish.mjs`, and that header is worth
 reading before touching it: why it keys on `npm_execpath` rather than the

--- a/bulma-ui/CLAUDE.md
+++ b/bulma-ui/CLAUDE.md
@@ -79,7 +79,7 @@ improvising.
 Independent semantic-release keyed off the `bulma-ui` commit scope
 (`release.config.js`, tag `@allxsmith/bestax-bulma@x.y.z`). It publishes with
 `pnpm publish`, like every package here (#532) — the command, its flags, and the
-three ways that publish fails quietly are documented in `VERSIONING.md` and
+ways that publish fails quietly are documented in `VERSIONING.md` and
 `scripts/lib/pnpm-publish.mjs`.
 
 Two things specific to this package. It is the only **scoped** one, and scoped

--- a/create-bestax/CLAUDE.md
+++ b/create-bestax/CLAUDE.md
@@ -47,7 +47,7 @@ path (`-y` + flags, no TTY) must never hang or regress (#192).
 Independent semantic-release keyed off the `create-bestax` commit scope
 (`release.config.js`, tag `create-bestax@x.y.z`). It publishes with
 `pnpm publish`, like every package here (#532) — the command, its flags, and the
-three ways that publish fails quietly are documented in `VERSIONING.md` and
+ways that publish fails quietly are documented in `VERSIONING.md` and
 `scripts/lib/pnpm-publish.mjs`.
 
 Its `prepack` runs the guard and then `scripts/sync-skills.mjs`, so the skills

--- a/docs/docs/guides/getting-started/contributing.md
+++ b/docs/docs/guides/getting-started/contributing.md
@@ -61,7 +61,7 @@ pnpm run all
 ```bash
 pnpm run build          # turbo build all packages
 pnpm run typecheck
-pnpm run test           # jest (bulma-ui + create-bestax)
+pnpm run test           # jest (all four packages) + the scripts/ node:test suite
 pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
@@ -165,9 +165,10 @@ and `scripts/require-pnpm-publish.mjs`.
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the type and scope
 drive [semantic-release](https://semantic-release.gitbook.io/). Releasing types (`feat`, `fix`,
-`perf`, `refactor`, `style`) must carry one of the scopes in `RELEASE_SCOPES` (`bulma-ui`, `docs`,
-`create-bestax`, `bestax-migrate`, `bestax-mcp`); `chore`, `ci`,
-`build`, and `test` don't publish. Publishing uses npm **OIDC trusted publishing** with **provenance**
+`perf`, `refactor`, `style`, `revert`) must carry one of the scopes in `RELEASE_SCOPES`
+(`bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, `bestax-mcp`); `chore`, `ci`,
+`build`, and `test` don't publish. `revert` is release-triggering because commit-analyzer
+patch-releases reverts by default, so an unscoped one would bump every package. Publishing uses npm **OIDC trusted publishing** with **provenance**
 (no long-lived token). See [`CONTRIBUTING.md`](https://github.com/allxsmith/bestax/blob/main/CONTRIBUTING.md)
 for the full details.
 

--- a/docs/docs/guides/getting-started/contributing.md
+++ b/docs/docs/guides/getting-started/contributing.md
@@ -61,8 +61,8 @@ pnpm run all
 ```bash
 pnpm run build          # turbo build all packages
 pnpm run typecheck
-pnpm run test           # jest (all four packages) + the docs and scripts/ node:test suites
-pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
+pnpm run test           # jest in every package + the docs and scripts/ node:test suites
+pnpm run test:coverage  # coverage (bulma-ui 99%; every other package 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
 pnpm run bundle:stats   # writes bulma-ui/dist/stats.html
@@ -160,14 +160,15 @@ and `scripts/require-pnpm-publish.mjs`.
 ## Workflow & conventions
 
 1. Branch off `main`, make your change in the right workspace (`bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, or `bestax-mcp`).
-2. Add/update tests (bulma-ui holds 99% coverage, the other three 95%) and Storybook stories for UI changes.
+2. Add/update tests (bulma-ui holds 99% coverage; every other package 95%, 78% branches) and Storybook stories for UI changes.
 3. Run `pnpm all`, then open a PR targeting `main`.
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the type and scope
 drive [semantic-release](https://semantic-release.gitbook.io/). Releasing types (`feat`, `fix`,
 `perf`, `refactor`, `style`, `revert`) must carry one of the scopes in `RELEASE_SCOPES`
-(`bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, `bestax-mcp`); `chore`, `ci`,
-`build`, and `test` don't publish. `revert` is release-triggering because commit-analyzer
+(`bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, `bestax-mcp`); `docs`, `chore`, `ci`,
+`build`, and `test` don't publish — note `docs` is both a valid scope and a non-releasing
+type, so `docs(bulma-ui):` and `docs:` alike publish nothing. `revert` is release-triggering because commit-analyzer
 patch-releases reverts by default, so an unscoped one would bump every package. Publishing uses npm **OIDC trusted publishing** with **provenance**
 (no long-lived token). See [`CONTRIBUTING.md`](https://github.com/allxsmith/bestax/blob/main/CONTRIBUTING.md)
 for the full details.

--- a/docs/docs/guides/getting-started/contributing.md
+++ b/docs/docs/guides/getting-started/contributing.md
@@ -61,7 +61,7 @@ pnpm run all
 ```bash
 pnpm run build          # turbo build all packages
 pnpm run typecheck
-pnpm run test           # jest (all four packages) + the scripts/ node:test suite
+pnpm run test           # jest (all four packages) + the docs and scripts/ node:test suites
 pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)

--- a/docs/docs/guides/getting-started/contributing.md
+++ b/docs/docs/guides/getting-started/contributing.md
@@ -62,7 +62,7 @@ pnpm run all
 pnpm run build          # turbo build all packages
 pnpm run typecheck
 pnpm run test           # jest (bulma-ui + create-bestax)
-pnpm run test:coverage  # coverage (must stay >= 95%)
+pnpm run test:coverage  # coverage (bulma-ui 99%; the other three 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
 pnpm run bundle:stats   # writes bulma-ui/dist/stats.html
@@ -133,8 +133,9 @@ Runs the real commit analysis and next-version calc, but publishes nothing:
 
 ```bash
 export GITHUB_TOKEN=your_token   # the github plugin needs a repo-read token even in dry-run
-cd bulma-ui      && pnpm exec semantic-release --dry-run --no-ci ; cd ..
-cd create-bestax && pnpm exec semantic-release --dry-run --no-ci ; cd ..
+for pkg in bulma-ui create-bestax bestax-migrate bestax-mcp; do
+  ( cd "$pkg" && pnpm exec semantic-release --dry-run --no-ci )
+done
 ```
 
 It prints "The next release version is X.Y.Z" per package (or "no release") from your local commits —
@@ -144,24 +145,28 @@ no `npm publish`, no tag, no GitHub release.
 Everything above is safe. The only things that actually publish are `pnpm exec semantic-release`
 **without** `--dry-run` (CI-only, on merge to `main`) and a manual
 `pnpm publish --provenance --embed-readme --access public` — neither of which is in this list.
-Those flags are not optional: pnpm defaults `embed-readme` to false and ignores
-`publishConfig.provenance`, which no package carries, so a bare `pnpm publish` ships unattested
-and loses the npm page's README. Every package publishes with `pnpm publish`, and each one's
-`prepack` and `prepublishOnly` hooks refuse the publishers they recognise as not being pnpm, so a
-stray `npm publish` or `npm pack` exits with an explanation rather than producing an
-unresolved `workspace:` specifier (#412). Both hooks are skipped by `--ignore-scripts`, and neither travels with a
-tarball that was packed elsewhere.
+Those flags are not optional, and a bare `pnpm publish` ships unattested and loses the npm
+page's README.
+
+You are unlikely to need a manual publish at all. Every package's `prepack` and
+`prepublishOnly` hooks refuse publishers they recognise as not being pnpm, so a stray
+`npm publish` or `npm pack` exits with an explanation rather than producing an unresolved
+`workspace:` specifier (#412) — though `--ignore-scripts` skips both, and neither travels with a
+tarball packed elsewhere. Why each flag matters and what the guard does and does not cover:
+[`VERSIONING.md`](https://github.com/allxsmith/bestax/blob/main/VERSIONING.md#release-process)
+and `scripts/require-pnpm-publish.mjs`.
 :::
 
 ## Workflow & conventions
 
-1. Branch off `main`, make your change in the right workspace (`bulma-ui`, `create-bestax`, or `docs`).
-2. Add/update tests (≥ 95% coverage) and Storybook stories for UI changes.
+1. Branch off `main`, make your change in the right workspace (`bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, or `bestax-mcp`).
+2. Add/update tests (bulma-ui holds 99% coverage, the other three 95%) and Storybook stories for UI changes.
 3. Run `pnpm all`, then open a PR targeting `main`.
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the type and scope
 drive [semantic-release](https://semantic-release.gitbook.io/). Releasing types (`feat`, `fix`,
-`perf`, `refactor`, `style`) must be scoped to `bulma-ui` or `create-bestax`; `docs`, `chore`, `ci`,
+`perf`, `refactor`, `style`) must carry one of the scopes in `RELEASE_SCOPES` (`bulma-ui`, `docs`,
+`create-bestax`, `bestax-migrate`, `bestax-mcp`); `chore`, `ci`,
 `build`, and `test` don't publish. Publishing uses npm **OIDC trusted publishing** with **provenance**
 (no long-lived token). See [`CONTRIBUTING.md`](https://github.com/allxsmith/bestax/blob/main/CONTRIBUTING.md)
 for the full details.

--- a/docs/docs/guides/getting-started/contributing.md
+++ b/docs/docs/guides/getting-started/contributing.md
@@ -62,7 +62,7 @@ pnpm run all
 pnpm run build          # turbo build all packages
 pnpm run typecheck
 pnpm run test           # jest in every package + the docs and scripts/ node:test suites
-pnpm run test:coverage  # coverage (bulma-ui 99%; every other package 95%, 78% branches)
+pnpm run test:coverage  # coverage (bulma-ui 99%; every other jest package 95%, 78% branches)
 pnpm run lint
 pnpm run format:check   # prettier check (use `pnpm run format` to auto-fix)
 pnpm run bundle:stats   # writes bulma-ui/dist/stats.html
@@ -160,7 +160,7 @@ and `scripts/require-pnpm-publish.mjs`.
 ## Workflow & conventions
 
 1. Branch off `main`, make your change in the right workspace (`bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, or `bestax-mcp`).
-2. Add/update tests (bulma-ui holds 99% coverage; every other package 95%, 78% branches) and Storybook stories for UI changes.
+2. Add/update tests (bulma-ui holds 99% coverage; every other jest package 95%, 78% branches) and Storybook stories for UI changes.
 3. Run `pnpm all`, then open a PR targeting `main`.
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — the type and scope
@@ -169,7 +169,9 @@ drive [semantic-release](https://semantic-release.gitbook.io/). Releasing types 
 (`bulma-ui`, `docs`, `create-bestax`, `bestax-migrate`, `bestax-mcp`); `docs`, `chore`, `ci`,
 `build`, and `test` don't publish — note `docs` is both a valid scope and a non-releasing
 type, so `docs(bulma-ui):` and `docs:` alike publish nothing. `revert` is release-triggering because commit-analyzer
-patch-releases reverts by default, so an unscoped one would bump every package. Publishing uses npm **OIDC trusted publishing** with **provenance**
+patch-releases reverts by default, so an unscoped one would bump every package — though
+commitlint's default ignores skip git's own `Revert "…"` form, so scoping that one is a
+convention the hook cannot enforce. Publishing uses npm **OIDC trusted publishing** with **provenance**
 (no long-lived token). See [`CONTRIBUTING.md`](https://github.com/allxsmith/bestax/blob/main/CONTRIBUTING.md)
 for the full details.
 

--- a/docs/docs/guides/security.md
+++ b/docs/docs/guides/security.md
@@ -12,9 +12,12 @@ where to report a vulnerability.
 ## What you install is what we built
 
 Every published package — `@allxsmith/bestax-bulma`, `create-bestax`,
-`bestax-migrate` and `bestax-mcp` — is released with **npm provenance**: every version carries a signed attestation
+`bestax-migrate` and `bestax-mcp` — is released with **npm provenance**: every
+version in the supported release lines below carries a signed attestation
 generated at publish time that links the tarball on the registry to the exact
-source commit and the public CI run that built it. Releases authenticate to
+source commit and the public CI run that built it. (Versions older than those
+lines predate provenance and have none — another reason staying current is the
+supported posture.) Releases authenticate to
 npm via **OIDC trusted publishing** (short-lived, per-run tokens), so there is
 no long-lived npm token that could leak and be used to push a rogue release.
 
@@ -33,7 +36,8 @@ the full policy.
   [`create-bestax`](https://www.npmjs.com/package/create-bestax),
   [`bestax-migrate`](https://www.npmjs.com/package/bestax-migrate) and
   [`bestax-mcp`](https://www.npmjs.com/package/bestax-mcp) each show a
-  _Provenance_ section linking every version to its source commit and build.
+  _Provenance_ section linking an attested version to its source commit and
+  build.
 - **`npm audit signatures`** — in projects installed with the npm CLI, run it
   to check registry signatures and provenance attestations for every package
   in your tree, Bestax included. (It's an npm command — for pnpm or yarn

--- a/docs/docs/guides/security.md
+++ b/docs/docs/guides/security.md
@@ -11,8 +11,8 @@ where to report a vulnerability.
 
 ## What you install is what we built
 
-Both published packages — `@allxsmith/bestax-bulma` and `create-bestax` — are
-released with **npm provenance**: every version carries a signed attestation
+Every published package — `@allxsmith/bestax-bulma`, `create-bestax`,
+`bestax-migrate` and `bestax-mcp` — is released with **npm provenance**: every version carries a signed attestation
 generated at publish time that links the tarball on the registry to the exact
 source commit and the public CI run that built it. Releases authenticate to
 npm via **OIDC trusted publishing** (short-lived, per-run tokens), so there is
@@ -29,9 +29,11 @@ the full policy.
 ## Verify it yourself
 
 - **Provenance on npmjs.com** — the package pages for
-  [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma)
-  and [`create-bestax`](https://www.npmjs.com/package/create-bestax) show a
-  _Provenance_ section linking each version to its source commit and build.
+  [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma),
+  [`create-bestax`](https://www.npmjs.com/package/create-bestax),
+  [`bestax-migrate`](https://www.npmjs.com/package/bestax-migrate) and
+  [`bestax-mcp`](https://www.npmjs.com/package/bestax-mcp) each show a
+  _Provenance_ section linking every version to its source commit and build.
 - **`npm audit signatures`** — in projects installed with the npm CLI, run it
   to check registry signatures and provenance attestations for every package
   in your tree, Bestax included. (It's an npm command — for pnpm or yarn

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -877,8 +877,11 @@ const RELEASE_DOC_FACTS = [
 function safeToRunBlock(src) {
   const { lines } = splitLines(src);
   const masked = fenceMask(lines);
-  const start = lines.findIndex(l =>
-    l.includes('Safe to run; never publishes')
+  // `!masked[i]` on the START too, not only on the terminator scan: a fenced
+  // example containing this marker would otherwise BE the block, and the real
+  // guidance could then be deleted with the check still green.
+  const start = lines.findIndex(
+    (l, i) => !masked[i] && l.includes('Safe to run; never publishes')
   );
   if (start < 0) return null;
   let end = lines.length;
@@ -972,9 +975,23 @@ function packagesBullet(src) {
   // to prevent: an unrelated "- Packages:" bullet elsewhere then satisfied the
   // assertion even with the real guidance deleted.
   if (anchor < 0) return '';
+  // Bounded at the next heading, because scanning to EOF let a complete
+  // "- Packages:" list in some later, unrelated section stand in for an OIDC
+  // section that had lost its own — the same fail-open as the line-0 fallback,
+  // one step further down the file.
+  let limit = lines.length;
+  for (let i = anchor + 1; i < lines.length; i++) {
+    if (!masked[i] && /^\s{0,3}#{1,6}\s/.test(lines[i])) {
+      limit = i;
+      break;
+    }
+  }
   const start = lines.findIndex(
     (l, i) =>
-      i >= anchor && !masked[i] && l.trimStart().startsWith('- Packages:')
+      i >= anchor &&
+      i < limit &&
+      !masked[i] &&
+      l.trimStart().startsWith('- Packages:')
   );
   if (start < 0) return '';
   let end = lines.length;
@@ -1156,14 +1173,14 @@ export function releaseDocViolations(docs, packages) {
  * prints a tick. That is the same fail-open shape the PNPM_PUBLISHED comment
  * above argues against.
  */
-export async function publishablePackages() {
+export async function publishablePackages(root = REPO) {
   const packages = [];
   const unreadable = [];
-  const yaml = await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8');
+  const yaml = await readFile(join(root, 'pnpm-workspace.yaml'), 'utf8');
   for (const dir of parseWorkspacePackages(yaml)) {
     let pkg;
     try {
-      pkg = JSON.parse(await readFile(join(REPO, dir, 'package.json'), 'utf8'));
+      pkg = JSON.parse(await readFile(join(root, dir, 'package.json'), 'utf8'));
     } catch {
       unreadable.push(dir);
       continue;

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -862,6 +862,21 @@ function dryRunRecipe(src) {
 }
 
 /**
+ * Package identifiers in `text`, as whole tokens.
+ *
+ * Substring matching looked fine and was not: every publishable name here
+ * contains "bestax", so a package literally named `bestax` would read as
+ * already present in a recipe listing only `create-bestax` and `bestax-mcp` —
+ * and being present is the verdict that switches this rule off. That is the
+ * same fail-open shape #436 warns about for the publisher declaration, arrived
+ * at from a different direction.
+ *
+ * The character class keeps `@scope/name` and `kebab-case` whole, so tokens
+ * compare as identifiers rather than as spans of text.
+ */
+const packageTokens = text => new Set(text.match(/[@\w./-]+/g) ?? []);
+
+/**
  * Violations for the release docs. Pure, so scripts/release-docs-sync.test.mjs
  * can drive it on fixtures — the four existing sync checks have no tests, and
  * publishable-manifests is the precedent worth following instead.
@@ -897,7 +912,8 @@ export function releaseDocViolations(docs, packages) {
           `scripts/check-conformance.mjs if the page no longer covers releases.`
       );
     } else {
-      const missing = packages.filter(p => !recipe.includes(p.dir));
+      const named = packageTokens(recipe);
+      const missing = packages.filter(p => !named.has(p.dir));
       if (missing.length) {
         violations.push(
           `${rel}'s semantic-release dry-run recipe omits ` +
@@ -928,7 +944,8 @@ export function releaseDocViolations(docs, packages) {
           `which ones do.`
       );
     } else {
-      const missing = packages.filter(p => !section.includes(p.name));
+      const named = packageTokens(section);
+      const missing = packages.filter(p => !named.has(p.name));
       if (missing.length) {
         violations.push(
           `CONTRIBUTING.md's trusted-publisher list omits ` +

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -967,8 +967,14 @@ function recipeTargets(block) {
 function packagesBullet(src) {
   const { lines } = splitLines(src);
   const masked = fenceMask(lines);
+  // The anchor has to be the HEADING, not any prose that mentions trusted
+  // publishing. Matching body text meant deleting the heading left the
+  // section's own sentence anchoring the search, so the list still passed
+  // while the section it belongs to was gone. Requiring a heading also makes
+  // anchor..limit a real section rather than an arbitrary span.
   const anchor = lines.findIndex(
-    (l, i) => !masked[i] && /trusted[- ]publish/i.test(l)
+    (l, i) =>
+      !masked[i] && /^\s{0,3}#{1,6}\s/.test(l) && /trusted[- ]publish/i.test(l)
   );
   // No OIDC section means no trusted-publisher list, which is the violation.
   // Falling back to line 0 restored the file-wide search this extractor exists
@@ -994,8 +1000,11 @@ function packagesBullet(src) {
       l.trimStart().startsWith('- Packages:')
   );
   if (start < 0) return '';
-  let end = lines.length;
-  for (let i = start + 1; i < lines.length; i++) {
+  // Bounded by `limit` as well: a heading immediately after the bullet, with no
+  // blank line between, otherwise swept the next section in — and a package
+  // named there could then cover an omission in this list.
+  let end = limit;
+  for (let i = start + 1; i < limit; i++) {
     if (!lines[i].trim() || /^\s*[-*]\s/.test(lines[i])) {
       end = i;
       break;
@@ -1020,14 +1029,6 @@ function packagesBullet(src) {
 const packageTokens = text => new Set(text.match(/[@\w./-]+/g) ?? []);
 
 /**
- * Violations for the release docs. Pure, so scripts/release-docs-sync.test.mjs
- * can drive it on fixtures — the four existing sync checks have no tests, and
- * publishable-manifests is the precedent worth following instead.
- *
- * @param docs Map of repo-relative path -> file contents
- * @param packages [{ dir, name }] for every publishable workspace package
- */
-/**
  * Violations for workspace entries whose manifest could not be read.
  *
  * Pure and exported for the same reason releaseDocViolations is: the branch
@@ -1049,6 +1050,14 @@ export function unreadableManifestViolations(unreadable) {
   );
 }
 
+/**
+ * Violations for the release docs. Pure, so scripts/release-docs-sync.test.mjs
+ * can drive it on fixtures — the four existing sync checks have no tests, and
+ * publishable-manifests is the precedent worth following instead.
+ *
+ * @param docs Map of repo-relative path -> file contents
+ * @param packages [{ dir, name }] for every publishable workspace package
+ */
 export function releaseDocViolations(docs, packages) {
   const violations = [];
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -965,11 +965,16 @@ function packagesBullet(src) {
   const { lines } = splitLines(src);
   const masked = fenceMask(lines);
   const anchor = lines.findIndex(
-    (l, i) => !masked[i] && /trusted publisher/i.test(l)
+    (l, i) => !masked[i] && /trusted[- ]publish/i.test(l)
   );
-  const from = anchor < 0 ? 0 : anchor;
+  // No OIDC section means no trusted-publisher list, which is the violation.
+  // Falling back to line 0 restored the file-wide search this extractor exists
+  // to prevent: an unrelated "- Packages:" bullet elsewhere then satisfied the
+  // assertion even with the real guidance deleted.
+  if (anchor < 0) return '';
   const start = lines.findIndex(
-    (l, i) => i >= from && !masked[i] && l.trimStart().startsWith('- Packages:')
+    (l, i) =>
+      i >= anchor && !masked[i] && l.trimStart().startsWith('- Packages:')
   );
   if (start < 0) return '';
   let end = lines.length;
@@ -1005,6 +1010,28 @@ const packageTokens = text => new Set(text.match(/[@\w./-]+/g) ?? []);
  * @param docs Map of repo-relative path -> file contents
  * @param packages [{ dir, name }] for every publishable workspace package
  */
+/**
+ * Violations for workspace entries whose manifest could not be read.
+ *
+ * Pure and exported for the same reason releaseDocViolations is: the branch
+ * that used to build these messages lived inside checkReleaseDocsSync, where a
+ * test could not reach it — so the test named for this case asserted the clean
+ * case instead and would have stayed green through a regression.
+ */
+export function unreadableManifestViolations(unreadable) {
+  return unreadable.map(
+    dir =>
+      dir +
+      '/package.json could not be read or parsed, so the release-docs checks ' +
+      'cannot tell whether ' +
+      dir +
+      ' needs to appear in the dry-run recipe and the trusted-publisher list. ' +
+      'Fix the manifest — leaving it unreadable removes ' +
+      dir +
+      ' from both lists silently (#536).'
+  );
+}
+
 export function releaseDocViolations(docs, packages) {
   const violations = [];
 
@@ -1170,19 +1197,8 @@ async function checkReleaseDocsSync() {
   }
 
   const { packages, unreadable } = await publishablePackages();
-  if (unreadable.length) {
-    return unreadable.map(
-      dir =>
-        dir +
-        '/package.json could not be read or parsed, so the release-docs ' +
-        'checks cannot tell whether ' +
-        dir +
-        ' needs to appear in the dry-run recipe and the trusted-publisher ' +
-        'list. Fix the manifest — leaving it unreadable removes ' +
-        dir +
-        ' from both lists silently (#536).'
-    );
-  }
+  const unreadableViolations = unreadableManifestViolations(unreadable);
+  if (unreadableViolations.length) return unreadableViolations;
 
   return releaseDocViolations(docs, packages);
 }

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -29,6 +29,9 @@
  *   near-miss-sync       the Toast/Dialog/LinkButton guidance says the same thing
  *                        in the generated CLAUDE.md and bestax-layout-scaffold,
  *                        pairing each component with the substitution it loses to
+ *   release-docs-sync    CONTRIBUTING.md and its docs-site mirror keep the
+ *                        facts a contributor acts on, and both name every
+ *                        package that actually releases (#536)
  *   style-mapping-sync   the inline-style → helper-prop mapping (#350) says
  *                        the same thing in all three deliberate copies
  *                        (CLAUDE_MD template + both JSX-generating skills),
@@ -813,6 +816,156 @@ async function checkStyleMappingSync() {
   return violations;
 }
 
+// The release documentation says the same things in two places: CONTRIBUTING.md
+// and the docs-site page that mirrors it. That mirror is hand-maintained — no
+// generator writes into docs/docs/guides — and by the time #536 was filed the
+// two had drifted in eight hunks, including a coverage threshold that was
+// simply wrong and a dry-run recipe naming two of the four packages that
+// actually release.
+//
+// The full rationale for the publish flags lives in scripts/lib/pnpm-publish.mjs
+// and VERSIONING.md; these two files are meant to carry only what a contributor
+// acts on, plus a pointer. So this check pins the small set of facts that must
+// survive in BOTH copies, and derives the package lists from the workspace
+// rather than restating them — the two staleness classes #536 found were both
+// "a list of packages that stopped being all of them".
+//
+// Deliberately NOT a byte diff. The two files legitimately differ: one uses a
+// blockquote, the other a Docusaurus admonition, and the docs page links
+// absolute GitHub URLs where the root file links relative paths. A diff would
+// fail on all of that and teach people to ignore it.
+const RELEASE_DOC_FILES = [
+  'CONTRIBUTING.md',
+  'docs/docs/guides/getting-started/contributing.md',
+];
+
+// What a contributor must still learn from either copy. Each is load-bearing:
+// the flags because pnpm's defaults silently drop provenance and the README,
+// the hook names because those are what refuse a stray publish, and the
+// --ignore-scripts caveat because it is the documented hole in that guard.
+const RELEASE_DOC_FACTS = [
+  '--provenance --embed-readme --access public',
+  'prepack',
+  'prepublishOnly',
+  '--ignore-scripts',
+  'VERSIONING.md',
+];
+
+/**
+ * The fenced block that runs the semantic-release dry run, or null. Located by
+ * content rather than by heading, so renaming the section does not silently
+ * switch this check off.
+ */
+function dryRunRecipe(src) {
+  const fences = src.match(/```[\s\S]*?```/g) ?? [];
+  return fences.find(f => f.includes('semantic-release --dry-run')) ?? null;
+}
+
+/**
+ * Violations for the release docs. Pure, so scripts/release-docs-sync.test.mjs
+ * can drive it on fixtures — the four existing sync checks have no tests, and
+ * publishable-manifests is the precedent worth following instead.
+ *
+ * @param docs Map of repo-relative path -> file contents
+ * @param packages [{ dir, name }] for every publishable workspace package
+ */
+export function releaseDocViolations(docs, packages) {
+  const violations = [];
+
+  for (const [rel, raw] of docs) {
+    const src = raw.replace(/\\/g, '');
+
+    for (const fact of RELEASE_DOC_FACTS) {
+      if (!src.includes(fact)) {
+        violations.push(
+          `${rel} no longer mentions "${fact}". The release guidance is ` +
+            `deliberately duplicated across ${RELEASE_DOC_FILES.join(' and ')} ` +
+            `so a contributor meets it wherever they land — apply the same ` +
+            `edit to both, and keep the full reasoning in VERSIONING.md and ` +
+            `scripts/lib/pnpm-publish.mjs rather than copying it here (#536).`
+        );
+      }
+    }
+
+    // Derived, not restated: the recipe has to cover whatever releases today.
+    const recipe = dryRunRecipe(src);
+    if (recipe === null) {
+      violations.push(
+        `${rel} has no fenced block running \`semantic-release --dry-run\`. ` +
+          `That recipe is how a contributor previews a release without ` +
+          `publishing — restore it, or drop ${rel} from RELEASE_DOC_FILES in ` +
+          `scripts/check-conformance.mjs if the page no longer covers releases.`
+      );
+    } else {
+      const missing = packages.filter(p => !recipe.includes(p.dir));
+      if (missing.length) {
+        violations.push(
+          `${rel}'s semantic-release dry-run recipe omits ` +
+            `${missing.map(p => p.dir).join(', ')}. Every publishable package ` +
+            `runs semantic-release in CI, so a recipe that names only some of ` +
+            `them tells a contributor a release is a no-op when it is not ` +
+            `(#536).`
+        );
+      }
+    }
+  }
+
+  // The trusted-publisher list is CONTRIBUTING-only, and getting it wrong is
+  // not a documentation problem: a package with no trusted publisher fails its
+  // publish AFTER the release commit and tag are pushed, and the version is
+  // spent.
+  const contributing = docs.get('CONTRIBUTING.md');
+  if (contributing) {
+    const section = contributing
+      .split('\n')
+      .filter(l => l.trimStart().startsWith('- Packages:'))
+      .join('\n');
+    if (!section) {
+      violations.push(
+        `CONTRIBUTING.md has no "- Packages:" line in the OIDC trusted ` +
+          `publishing section. It names the packages that need a trusted ` +
+          `publisher configured on npmjs.com; without it nobody can tell ` +
+          `which ones do.`
+      );
+    } else {
+      const missing = packages.filter(p => !section.includes(p.name));
+      if (missing.length) {
+        violations.push(
+          `CONTRIBUTING.md's trusted-publisher list omits ` +
+            `${missing.map(p => p.name).join(', ')}. Every publishable ` +
+            `package authenticates by OIDC, and a missing trusted publisher ` +
+            `fails the publish after the release commit and tag are already ` +
+            `pushed — which spends the version (#536).`
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+async function checkReleaseDocsSync() {
+  const docs = new Map();
+  for (const rel of RELEASE_DOC_FILES) {
+    docs.set(rel, await readFile(join(REPO, rel), 'utf8'));
+  }
+
+  const packages = [];
+  for (const dir of parseWorkspacePackages(
+    await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8')
+  )) {
+    let pkg;
+    try {
+      pkg = JSON.parse(await readFile(join(REPO, dir, 'package.json'), 'utf8'));
+    } catch {
+      continue; // publishable-manifests owns "this dir has no manifest"
+    }
+    if (!pkg.private && pkg.name) packages.push({ dir, name: pkg.name });
+  }
+
+  return releaseDocViolations(docs, packages);
+}
+
 async function checkStoryPerComponent() {
   const violations = [];
   const modules = parseExportedModules(await readFile(INDEX_TS, 'utf8'));
@@ -1418,6 +1571,7 @@ const CHECKS = {
   'skills-sync': checkSkillsSync,
   'style-mapping-sync': checkStyleMappingSync,
   'near-miss-sync': checkNearMissSync,
+  'release-docs-sync': checkReleaseDocsSync,
   'story-per-component': checkStoryPerComponent,
   'compound-family': checkCompoundFamily,
   'autodocs-tag': checkAutodocsTag,

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -841,15 +841,45 @@ const RELEASE_DOC_FILES = [
 
 // What a contributor must still learn from either copy. Each is load-bearing:
 // the flags because pnpm's defaults silently drop provenance and the README,
-// the hook names because those are what refuse a stray publish, and the
-// --ignore-scripts caveat because it is the documented hole in that guard.
+// the hook names because those are what refuse a stray publish, the
+// --ignore-scripts caveat because it is the documented hole in that guard, and
+// the two pointers because the mechanism was deliberately moved out of these
+// files and a reader who needs it has to be told where it went.
 const RELEASE_DOC_FACTS = [
   '--provenance --embed-readme --access public',
   'prepack',
   'prepublishOnly',
   '--ignore-scripts',
   'VERSIONING.md',
+  'scripts/require-pnpm-publish.mjs',
 ];
+
+/**
+ * The "safe to run; never publishes" guidance, which is the block these facts
+ * have to live in.
+ *
+ * Scoped rather than searched file-wide, because file-wide was vacuous:
+ * CONTRIBUTING.md links VERSIONING.md twice more for unrelated reasons, so
+ * deleting the pointer from this block left the check green. That is the same
+ * failure publishable-manifests.test.mjs records against its own first version
+ * — the prose satisfied the assertion while the thing being asserted was gone.
+ *
+ * Ends at the admonition close, the next heading, or a horizontal rule, which
+ * covers both the blockquote form and the Docusaurus `:::tip` form.
+ */
+function safeToRunBlock(src) {
+  const lines = src.split('\n');
+  const start = lines.findIndex(l =>
+    l.includes('Safe to run; never publishes')
+  );
+  if (start < 0) return null;
+  const rest = lines.slice(start + 1);
+  let end = rest.findIndex(
+    l => l.trim() === ':::' || /^#{2,3}\s/.test(l) || l.trim() === '---'
+  );
+  if (end < 0) end = rest.length;
+  return [lines[start], ...rest.slice(0, end)].join('\n');
+}
 
 /**
  * The fenced block that runs the semantic-release dry run, or null. Located by
@@ -857,9 +887,48 @@ const RELEASE_DOC_FACTS = [
  * switch this check off.
  */
 function dryRunRecipe(src) {
-  const fences = src.match(/```[\s\S]*?```/g) ?? [];
-  return fences.find(f => f.includes('semantic-release --dry-run')) ?? null;
+  // Walked line by line rather than matched with /```[\s\S]*?```/g, which pairs
+  // backtick runs in document order: one stray ``` in prose, or a ````markdown
+  // wrapper around a nested fence — both ordinary in contributor docs — shift
+  // every pair after it and the real recipe stops being found. The remedy the
+  // violation then offers is "drop this file from RELEASE_DOC_FILES", i.e.
+  // switch the check off, which is the worst way to be wrong.
+  const lines = src.split('\n');
+  const blocks = [];
+  let open = null;
+  let current = [];
+  for (const line of lines) {
+    const fence = line.match(/^\s*(`{3,})/);
+    if (open === null) {
+      if (fence) {
+        open = fence[1];
+        current = [];
+      }
+      continue;
+    }
+    // Only a run at least as long as the opener closes it.
+    if (fence && fence[1].length >= open.length && line.trim() === fence[1]) {
+      blocks.push(current.join('\n'));
+      open = null;
+      continue;
+    }
+    current.push(line);
+  }
+  return blocks.find(b => b.includes('semantic-release --dry-run')) ?? null;
 }
+
+/**
+ * The command lines of a shell block: everything that is not a comment.
+ *
+ * A package named only in a `# …` comment satisfied the recipe assertion while
+ * being absent from the loop that actually runs — which is the #536 failure the
+ * assertion exists to catch, reintroduced one level down.
+ */
+const commandLines = block =>
+  block
+    .split('\n')
+    .map(l => l.replace(/#.*$/, ''))
+    .join('\n');
 
 /**
  * Package identifiers in `text`, as whole tokens.
@@ -887,13 +956,39 @@ const packageTokens = text => new Set(text.match(/[@\w./-]+/g) ?? []);
 export function releaseDocViolations(docs, packages) {
   const violations = [];
 
-  for (const [rel, raw] of docs) {
-    const src = raw.replace(/\\/g, '');
+  // Both derived assertions are satisfied by an empty list, so an enumeration
+  // that silently returned nothing would print a tick while asserting nothing.
+  // checkPublishableManifests guards the same case for the same reason.
+  if (!packages.length) {
+    return [
+      'No publishable packages were found, so the release-docs checks that ' +
+        'derive their package list would pass without asserting anything. ' +
+        'That usually means pnpm-workspace.yaml changed shape — ' +
+        'parseWorkspacePackages reads a block list of plain entries, not a ' +
+        'flow sequence or a glob (#536).',
+    ];
+  }
 
+  // No backslash normalisation here, unlike near-miss-sync: that check compares
+  // a markdown copy against a TS template literal, and these are two markdown
+  // files. Stripping backslashes would only delete them from documented shell
+  // and path content, where they are the point.
+  for (const [rel, src] of docs) {
+    const block = safeToRunBlock(src);
+    if (block === null) {
+      violations.push(
+        `${rel} has no "Safe to run; never publishes" guidance. That block is ` +
+          `where a contributor is told not to hand-publish and where the ` +
+          `pointers to the full reasoning live — restore it, or drop ${rel} ` +
+          `from RELEASE_DOC_FILES in scripts/check-conformance.mjs (#536).`
+      );
+    }
     for (const fact of RELEASE_DOC_FACTS) {
-      if (!src.includes(fact)) {
+      if (!(block ?? '').includes(fact)) {
+        if (block === null) continue; // already reported, once, above
         violations.push(
-          `${rel} no longer mentions "${fact}". The release guidance is ` +
+          `${rel}'s "Safe to run" guidance no longer mentions "${fact}". The ` +
+            `release guidance is ` +
             `deliberately duplicated across ${RELEASE_DOC_FILES.join(' and ')} ` +
             `so a contributor meets it wherever they land — apply the same ` +
             `edit to both, and keep the full reasoning in VERSIONING.md and ` +
@@ -912,7 +1007,7 @@ export function releaseDocViolations(docs, packages) {
           `scripts/check-conformance.mjs if the page no longer covers releases.`
       );
     } else {
-      const named = packageTokens(recipe);
+      const named = packageTokens(commandLines(recipe));
       const missing = packages.filter(p => !named.has(p.dir));
       if (missing.length) {
         violations.push(
@@ -930,15 +1025,36 @@ export function releaseDocViolations(docs, packages) {
   // not a documentation problem: a package with no trusted publisher fails its
   // publish AFTER the release commit and tag are pushed, and the version is
   // spent.
-  const contributing = docs.get('CONTRIBUTING.md');
-  if (contributing) {
-    const section = contributing
-      .split('\n')
-      .filter(l => l.trimStart().startsWith('- Packages:'))
-      .join('\n');
+  // Keyed off the declared list, not a hardcoded name: with the string inline,
+  // renaming the file and updating RELEASE_DOC_FILES made the
+  // highest-consequence assertion in this check silently no-op.
+  const [primary] = RELEASE_DOC_FILES;
+  const contributing = docs.get(primary);
+  {
+    // The bullet plus any wrapped continuation lines. Taking only the line that
+    // starts with "- Packages:" meant re-wrapping that bullet — it is far
+    // longer than the file's usual width — dropped the trailing packages and
+    // failed against documentation that was correct.
+    const lines = (contributing ?? '').split('\n');
+    const start = lines.findIndex(l => l.trimStart().startsWith('- Packages:'));
+    const section =
+      start < 0
+        ? ''
+        : [
+            lines[start],
+            ...lines.slice(start + 1).slice(
+              0,
+              Math.max(
+                0,
+                lines
+                  .slice(start + 1)
+                  .findIndex(l => !l.trim() || /^\s*[-*]\s/.test(l))
+              )
+            ),
+          ].join('\n');
     if (!section) {
       violations.push(
-        `CONTRIBUTING.md has no "- Packages:" line in the OIDC trusted ` +
+        `${primary} has no "- Packages:" line in the OIDC trusted ` +
           `publishing section. It names the packages that need a trusted ` +
           `publisher configured on npmjs.com; without it nobody can tell ` +
           `which ones do.`
@@ -948,7 +1064,7 @@ export function releaseDocViolations(docs, packages) {
       const missing = packages.filter(p => !named.has(p.name));
       if (missing.length) {
         violations.push(
-          `CONTRIBUTING.md's trusted-publisher list omits ` +
+          `${primary}'s trusted-publisher list omits ` +
             `${missing.map(p => p.name).join(', ')}. Every publishable ` +
             `package authenticates by OIDC, and a missing trusted publisher ` +
             `fails the publish after the release commit and tag are already ` +
@@ -961,16 +1077,19 @@ export function releaseDocViolations(docs, packages) {
   return violations;
 }
 
-async function checkReleaseDocsSync() {
-  const docs = new Map();
-  for (const rel of RELEASE_DOC_FILES) {
-    docs.set(rel, await readFile(join(REPO, rel), 'utf8'));
-  }
-
+/**
+ * Every publishable workspace package, as `{ dir, name }`.
+ *
+ * One copy, because the enumeration — parse the workspace, read each manifest,
+ * keep the ones that are not private — was about to have three, each with
+ * slightly different error handling. The test's copy is the one that decides
+ * whether the real-repo assertion checks the same set the check does, so
+ * letting them drift would make a passing test mean less than it appears to.
+ */
+export async function publishablePackages() {
   const packages = [];
-  for (const dir of parseWorkspacePackages(
-    await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8')
-  )) {
+  const yaml = await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8');
+  for (const dir of parseWorkspacePackages(yaml)) {
     let pkg;
     try {
       pkg = JSON.parse(await readFile(join(REPO, dir, 'package.json'), 'utf8'));
@@ -979,8 +1098,33 @@ async function checkReleaseDocsSync() {
     }
     if (!pkg.private && pkg.name) packages.push({ dir, name: pkg.name });
   }
+  return packages;
+}
 
-  return releaseDocViolations(docs, packages);
+async function checkReleaseDocsSync() {
+  const docs = new Map();
+  const missing = [];
+  for (const rel of RELEASE_DOC_FILES) {
+    try {
+      docs.set(rel, await readFile(join(REPO, rel), 'utf8'));
+    } catch {
+      // A renamed or deleted release doc is a violation with a fix, not an
+      // ENOENT out of the middle of the run. Throwing here aborts every other
+      // check and hands the contributor a stack trace, which is the one thing
+      // the house rule at the top of this file says not to do.
+      missing.push(rel);
+    }
+  }
+  if (missing.length) {
+    return missing.map(
+      rel =>
+        `${rel} is listed in RELEASE_DOC_FILES but does not exist. Restore it, ` +
+        `or update RELEASE_DOC_FILES in scripts/check-conformance.mjs if the ` +
+        `release guidance moved (#536).`
+    );
+  }
+
+  return releaseDocViolations(docs, await publishablePackages());
 }
 
 async function checkStoryPerComponent() {

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -63,7 +63,12 @@ import {
   CONSUMER_SECTIONS,
   packTimeProtocol,
 } from './lib/pack-time-protocols.mjs';
-import { readRegions, sectionSpans } from './lib/api-page.mjs';
+import {
+  fenceMask,
+  readRegions,
+  sectionSpans,
+  splitLines,
+} from './lib/api-page.mjs';
 import { renderPage } from './gen-api-docs.mjs';
 import {
   ORDERED_CATEGORIES,
@@ -864,71 +869,118 @@ const RELEASE_DOC_FACTS = [
  * failure publishable-manifests.test.mjs records against its own first version
  * — the prose satisfied the assertion while the thing being asserted was gone.
  *
- * Ends at the admonition close, the next heading, or a horizontal rule, which
- * covers both the blockquote form and the Docusaurus `:::tip` form.
+ * Fence-aware, and it ends at ANY heading rather than `##`/`###`. Both were
+ * bugs: a `####` heading did not close the block, so it ran to EOF and restored
+ * the file-wide search this exists to prevent; and a `---` or `:::` inside a
+ * fenced example truncated it early, in the other direction.
  */
 function safeToRunBlock(src) {
-  const lines = src.split('\n');
+  const { lines } = splitLines(src);
+  const masked = fenceMask(lines);
   const start = lines.findIndex(l =>
     l.includes('Safe to run; never publishes')
   );
   if (start < 0) return null;
-  const rest = lines.slice(start + 1);
-  let end = rest.findIndex(
-    l => l.trim() === ':::' || /^#{2,3}\s/.test(l) || l.trim() === '---'
-  );
-  if (end < 0) end = rest.length;
-  return [lines[start], ...rest.slice(0, end)].join('\n');
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (masked[i]) continue; // a terminator inside a fenced example is content
+    const l = lines[i];
+    if (
+      l.trim() === ':::' ||
+      /^\s{0,3}#{1,6}\s/.test(l) ||
+      l.trim() === '---'
+    ) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
 }
 
 /**
  * The fenced block that runs the semantic-release dry run, or null. Located by
  * content rather than by heading, so renaming the section does not silently
  * switch this check off.
+ *
+ * Fences come from `fenceMask` rather than a /```[\s\S]*?```/g match, which
+ * pairs backtick runs in document order: one stray ``` in prose, or a
+ * ````markdown wrapper around a nested fence, shifts every pair after it and the
+ * real recipe stops being found. The remedy the violation then offers is "drop
+ * this file from RELEASE_DOC_FILES", i.e. switch the check off, which is the
+ * worst way to be wrong. An UNTERMINATED fence runs to EOF and is still
+ * returned, for the same reason — dropping it produced that same false
+ * violation.
  */
 function dryRunRecipe(src) {
-  // Walked line by line rather than matched with /```[\s\S]*?```/g, which pairs
-  // backtick runs in document order: one stray ``` in prose, or a ````markdown
-  // wrapper around a nested fence — both ordinary in contributor docs — shift
-  // every pair after it and the real recipe stops being found. The remedy the
-  // violation then offers is "drop this file from RELEASE_DOC_FILES", i.e.
-  // switch the check off, which is the worst way to be wrong.
-  const lines = src.split('\n');
+  const { lines } = splitLines(src);
+  const masked = fenceMask(lines);
   const blocks = [];
-  let open = null;
-  let current = [];
-  for (const line of lines) {
-    const fence = line.match(/^\s*(`{3,})/);
-    if (open === null) {
-      if (fence) {
-        open = fence[1];
-        current = [];
-      }
-      continue;
-    }
-    // Only a run at least as long as the opener closes it.
-    if (fence && fence[1].length >= open.length && line.trim() === fence[1]) {
+  let current = null;
+  for (let i = 0; i < lines.length; i++) {
+    if (masked[i]) (current ??= []).push(lines[i]);
+    else if (current) {
       blocks.push(current.join('\n'));
-      open = null;
-      continue;
+      current = null;
     }
-    current.push(line);
   }
+  if (current) blocks.push(current.join('\n')); // unterminated fence at EOF
   return blocks.find(b => b.includes('semantic-release --dry-run')) ?? null;
 }
 
 /**
- * The command lines of a shell block: everything that is not a comment.
+ * The package names a dry-run recipe actually iterates over.
  *
- * A package named only in a `# …` comment satisfied the recipe assertion while
- * being absent from the loop that actually runs — which is the #536 failure the
- * assertion exists to catch, reintroduced one level down.
+ * Two narrowings, each closing a way a package could look covered while the
+ * recipe skipped it. First comments are stripped, because a name in a `# …`
+ * line satisfied the assertion while being absent from the loop. Then, if the
+ * block drives a `for … in …` loop, ONLY that word list counts — otherwise an
+ * `echo "bestax-mcp is released separately"` satisfies it just as well, which
+ * is the same failure one step further out.
  */
-const commandLines = block =>
-  block
+function recipeTargets(block) {
+  const commands = block
     .split('\n')
     .map(l => l.replace(/#.*$/, ''))
     .join('\n');
+  const loop = commands.match(/\bfor\s+\w+\s+in\s+([^;\n]+)/);
+  return loop ? loop[1] : commands;
+}
+
+/**
+ * The `- Packages:` bullet from the OIDC section, with any wrapped
+ * continuation lines.
+ *
+ * A named extractor rather than an inline block, so the slicing can be driven
+ * from a test — its first version collapsed `findIndex`'s -1 sentinel with
+ * `Math.max(0, …)`, which dropped every continuation line whenever the bullet
+ * ran to the end of the file with no blank line after it. That is precisely the
+ * case the extractor was written to handle.
+ *
+ * Scoped to the OIDC section rather than the first match in the file, because
+ * file-wide is the vacuity already fixed once for RELEASE_DOC_FACTS: an earlier
+ * `- Packages:` bullet elsewhere would satisfy this while the real list went
+ * short.
+ */
+function packagesBullet(src) {
+  const { lines } = splitLines(src);
+  const masked = fenceMask(lines);
+  const anchor = lines.findIndex(
+    (l, i) => !masked[i] && /trusted publisher/i.test(l)
+  );
+  const from = anchor < 0 ? 0 : anchor;
+  const start = lines.findIndex(
+    (l, i) => i >= from && !masked[i] && l.trimStart().startsWith('- Packages:')
+  );
+  if (start < 0) return '';
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (!lines[i].trim() || /^\s*[-*]\s/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
 
 /**
  * Package identifiers in `text`, as whole tokens.
@@ -1007,7 +1059,7 @@ export function releaseDocViolations(docs, packages) {
           `scripts/check-conformance.mjs if the page no longer covers releases.`
       );
     } else {
-      const named = packageTokens(commandLines(recipe));
+      const named = packageTokens(recipeTargets(recipe));
       const missing = packages.filter(p => !named.has(p.dir));
       if (missing.length) {
         violations.push(
@@ -1028,47 +1080,31 @@ export function releaseDocViolations(docs, packages) {
   // Keyed off the declared list, not a hardcoded name: with the string inline,
   // renaming the file and updating RELEASE_DOC_FILES made the
   // highest-consequence assertion in this check silently no-op.
+  //
+  // Absent from the map is also a different fact from present-but-empty, and it
+  // already has its own message in checkReleaseDocsSync. Coercing one into the
+  // other told a reader the file had no bullet when the file was never read.
   const [primary] = RELEASE_DOC_FILES;
-  const contributing = docs.get(primary);
-  {
-    // The bullet plus any wrapped continuation lines. Taking only the line that
-    // starts with "- Packages:" meant re-wrapping that bullet — it is far
-    // longer than the file's usual width — dropped the trailing packages and
-    // failed against documentation that was correct.
-    const lines = (contributing ?? '').split('\n');
-    const start = lines.findIndex(l => l.trimStart().startsWith('- Packages:'));
-    const section =
-      start < 0
-        ? ''
-        : [
-            lines[start],
-            ...lines.slice(start + 1).slice(
-              0,
-              Math.max(
-                0,
-                lines
-                  .slice(start + 1)
-                  .findIndex(l => !l.trim() || /^\s*[-*]\s/.test(l))
-              )
-            ),
-          ].join('\n');
+  if (docs.has(primary)) {
+    const section = packagesBullet(docs.get(primary));
     if (!section) {
       violations.push(
-        `${primary} has no "- Packages:" line in the OIDC trusted ` +
-          `publishing section. It names the packages that need a trusted ` +
-          `publisher configured on npmjs.com; without it nobody can tell ` +
-          `which ones do.`
+        primary +
+          ' has no "- Packages:" line in the OIDC trusted publishing section. ' +
+          'It names the packages that need a trusted publisher configured on ' +
+          'npmjs.com; without it nobody can tell which ones do.'
       );
     } else {
       const named = packageTokens(section);
       const missing = packages.filter(p => !named.has(p.name));
       if (missing.length) {
         violations.push(
-          `${primary}'s trusted-publisher list omits ` +
-            `${missing.map(p => p.name).join(', ')}. Every publishable ` +
-            `package authenticates by OIDC, and a missing trusted publisher ` +
-            `fails the publish after the release commit and tag are already ` +
-            `pushed — which spends the version (#536).`
+          primary +
+            "'s trusted-publisher list omits " +
+            missing.map(p => p.name).join(', ') +
+            '. Every publishable package authenticates by OIDC, and a missing ' +
+            'trusted publisher fails the publish after the release commit and ' +
+            'tag are already pushed — which spends the version (#536).'
         );
       }
     }
@@ -1078,27 +1114,36 @@ export function releaseDocViolations(docs, packages) {
 }
 
 /**
- * Every publishable workspace package, as `{ dir, name }`.
+ * Every publishable workspace package, plus the workspace entries whose
+ * manifest could not be read.
  *
- * One copy, because the enumeration — parse the workspace, read each manifest,
- * keep the ones that are not private — was about to have three, each with
- * slightly different error handling. The test's copy is the one that decides
- * whether the real-repo assertion checks the same set the check does, so
- * letting them drift would make a passing test mean less than it appears to.
+ * Shared by checkReleaseDocsSync and its test, so the real-repo assertion
+ * checks the same set the check does — previously the test re-derived it, and a
+ * drift between them would make a passing test mean less than it looks like.
+ * (checkPublishableManifests still walks the workspace itself: it needs the
+ * manifest bodies, not just the names.)
+ *
+ * The unreadable ones are RETURNED rather than skipped, because skipping
+ * narrows both derived assertions silently — a manifest with a syntax error
+ * drops its package from the lists those assertions require, and the check
+ * prints a tick. That is the same fail-open shape the PNPM_PUBLISHED comment
+ * above argues against.
  */
 export async function publishablePackages() {
   const packages = [];
+  const unreadable = [];
   const yaml = await readFile(join(REPO, 'pnpm-workspace.yaml'), 'utf8');
   for (const dir of parseWorkspacePackages(yaml)) {
     let pkg;
     try {
       pkg = JSON.parse(await readFile(join(REPO, dir, 'package.json'), 'utf8'));
     } catch {
-      continue; // publishable-manifests owns "this dir has no manifest"
+      unreadable.push(dir);
+      continue;
     }
     if (!pkg.private && pkg.name) packages.push({ dir, name: pkg.name });
   }
-  return packages;
+  return { packages, unreadable };
 }
 
 async function checkReleaseDocsSync() {
@@ -1124,7 +1169,22 @@ async function checkReleaseDocsSync() {
     );
   }
 
-  return releaseDocViolations(docs, await publishablePackages());
+  const { packages, unreadable } = await publishablePackages();
+  if (unreadable.length) {
+    return unreadable.map(
+      dir =>
+        dir +
+        '/package.json could not be read or parsed, so the release-docs ' +
+        'checks cannot tell whether ' +
+        dir +
+        ' needs to appear in the dry-run recipe and the trusted-publisher ' +
+        'list. Fix the manifest — leaving it unreadable removes ' +
+        dir +
+        ' from both lists silently (#536).'
+    );
+  }
+
+  return releaseDocViolations(docs, packages);
 }
 
 async function checkStoryPerComponent() {

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -835,6 +835,19 @@ async function checkStyleMappingSync() {
 // rather than restating them — the two staleness classes #536 found were both
 // "a list of packages that stopped being all of them".
 //
+// Why this parses markdown at all, since the obvious simplification is to stop.
+// Whole-file matching would have caught the failure that prompted #536:
+// bestax-migrate and bestax-mcp appeared ZERO times in either guide, so a plain
+// token-membership test over the whole file catches it, and four of the five
+// facts below occur exactly once per file so they need no scoping either. The
+// parsing buys one thing on top of that — a package that IS named somewhere in
+// the file but missing from the recipe or the publisher list specifically — and
+// that refinement is where every edge case lives: fence pairing, section
+// anchors, continuation lines, sentinels. Measured, not assumed, and kept
+// deliberately. If it ever needs paying for again, the cheap version is
+// "every publishable package is named somewhere in each guide", and it is worth
+// knowing that it would have been enough for the bug that started this.
+//
 // Deliberately NOT a byte diff. The two files legitimately differ: one uses a
 // blockquote, the other a Docusaurus admonition, and the docs page links
 // absolute GitHub URLs where the root file links relative paths. A diff would

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * Covers the `release-docs-sync` conformance check (#536).
+ *
+ * The four sync checks that came before this one have no tests, and that is the
+ * precedent worth breaking rather than following: their comparison logic is
+ * inline, so the only way to know they still bite is to break the repo on
+ * purpose. `publishable-manifests` took the other route — export the pure
+ * function, drive it on fixtures — and this follows that.
+ *
+ * What is actually at stake: the two derived assertions exist because #536
+ * found two lists of packages that had quietly stopped being all of them, and
+ * one of those lists decides whether a publish succeeds after the tag is
+ * already pushed.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  parseWorkspacePackages,
+  releaseDocViolations,
+} from './check-conformance.mjs';
+
+const PACKAGES = [
+  { dir: 'bulma-ui', name: '@allxsmith/bestax-bulma' },
+  { dir: 'create-bestax', name: 'create-bestax' },
+  { dir: 'bestax-migrate', name: 'bestax-migrate' },
+  { dir: 'bestax-mcp', name: 'bestax-mcp' },
+];
+
+const FACTS = [
+  '`pnpm publish --provenance --embed-readme --access public`',
+  'its `prepack` and `prepublishOnly` hooks refuse',
+  'skipped by `--ignore-scripts`',
+  'see VERSIONING.md',
+];
+
+const recipe = (dirs = PACKAGES.map(p => p.dir)) =>
+  '```bash\nfor pkg in ' +
+  dirs.join(' ') +
+  '; do\n  ( cd "$pkg" && pnpm exec semantic-release --dry-run --no-ci )\ndone\n```';
+
+const publishers = (names = PACKAGES.map(p => p.name)) =>
+  `- Packages: ${names.map(n => `\`${n}\``).join(', ')}`;
+
+const doc = (opts = {}) =>
+  [
+    ...(opts.facts ?? FACTS),
+    opts.recipe ?? recipe(),
+    opts.publishers ?? publishers(),
+  ].join('\n\n');
+
+const docs = (over = {}) =>
+  new Map([
+    ['CONTRIBUTING.md', over.contributing ?? doc()],
+    [
+      'docs/docs/guides/getting-started/contributing.md',
+      over.mirror ?? doc({ publishers: '' }),
+    ],
+  ]);
+
+test('a matching pair is clean', () => {
+  assert.deepEqual(releaseDocViolations(docs(), PACKAGES), []);
+});
+
+test('a fact dropped from one copy only is caught', () => {
+  // The drift shape #536 exists for: an edit lands in the file the author had
+  // open, and the mirror keeps saying the old thing.
+  const v = releaseDocViolations(
+    docs({ mirror: doc({ facts: FACTS.slice(1), publishers: '' }) }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /^docs\/docs\/guides\/getting-started\/contributing\.md/);
+  assert.match(v[0], /apply the same edit to both/);
+});
+
+test('the dry-run recipe must name every publishable package', () => {
+  // Derived from the workspace, not restated, because the failure mode is a
+  // list that was right when written and stopped being all of them.
+  const v = releaseDocViolations(
+    docs({
+      contributing: doc({ recipe: recipe(['bulma-ui', 'create-bestax']) }),
+    }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /omits bestax-migrate, bestax-mcp/);
+});
+
+test('a missing recipe is reported as missing, not as a package list', () => {
+  const v = releaseDocViolations(
+    docs({ contributing: doc({ recipe: '```bash\npnpm all\n```' }) }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /no fenced block running/);
+});
+
+test('the trusted-publisher list must name every publishable package', () => {
+  // The one with teeth: a package with no trusted publisher fails its publish
+  // after the release commit and tag are pushed, and the version is spent.
+  const v = releaseDocViolations(
+    docs({ contributing: doc({ publishers: publishers(['create-bestax']) }) }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /trusted-publisher list omits/);
+  assert.match(v[0], /@allxsmith\/bestax-bulma/);
+  assert.match(v[0], /spends the version/);
+});
+
+test('the trusted-publisher list is only required of CONTRIBUTING.md', () => {
+  // The docs mirror is a contributor page, not the operational runbook, so it
+  // is not asked for the npmjs.com configuration list.
+  assert.deepEqual(releaseDocViolations(docs(), PACKAGES), []);
+});
+
+test('a missing trusted-publisher line is its own message', () => {
+  const v = releaseDocViolations(
+    docs({ contributing: doc({ publishers: '' }) }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /no "- Packages:" line/);
+});
+
+test('escaped backticks compare equal, as in the other sync checks', () => {
+  // near-miss-sync strips backslashes so a TS template literal's escaped
+  // backticks match a markdown copy's plain ones. Same normalisation here, so
+  // a fact quoted from a template does not read as missing.
+  const escaped = doc().replace(/`/g, '\\`');
+  assert.deepEqual(
+    releaseDocViolations(
+      new Map([
+        ['CONTRIBUTING.md', escaped],
+        ['docs/docs/guides/getting-started/contributing.md', escaped],
+      ]),
+      PACKAGES
+    ),
+    []
+  );
+});
+
+test('the real repo files satisfy the check', () => {
+  // The fixtures above could all agree with a rule the real docs violate.
+  //
+  // The package list is DERIVED here rather than reusing the PACKAGES fixture:
+  // a fifth publishable package would otherwise let this pass against a stale
+  // four while the real check failed in CI, which is the exact failure shape
+  // this whole check exists to stop.
+  const read = rel =>
+    readFileSync(fileURLToPath(new URL(`../${rel}`, import.meta.url)), 'utf8');
+  const packages = parseWorkspacePackages(read('pnpm-workspace.yaml'))
+    .map(dir => {
+      try {
+        return { dir, ...JSON.parse(read(`${dir}/package.json`)) };
+      } catch {
+        return null;
+      }
+    })
+    .filter(p => p && !p.private && p.name)
+    .map(({ dir, name }) => ({ dir, name }));
+
+  assert.ok(
+    packages.length >= 4,
+    `expected 4+ publishable, got ${packages.length}`
+  );
+  const real = new Map([
+    ['CONTRIBUTING.md', read('CONTRIBUTING.md')],
+    [
+      'docs/docs/guides/getting-started/contributing.md',
+      read('docs/docs/guides/getting-started/contributing.md'),
+    ],
+  ]);
+  assert.deepEqual(releaseDocViolations(real, packages), []);
+});

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -126,11 +126,20 @@ test('a missing trusted-publisher line is its own message', () => {
   assert.match(v[0], /no "- Packages:" line/);
 });
 
+/**
+ * How a TS template literal would carry this text: backslashes first, then
+ * backticks. That order is the whole correctness of an escaper — doing
+ * backticks first would then double the backslashes it just introduced — and
+ * writing only the backtick half is what CodeQL flags as incomplete escaping,
+ * correctly, even though these fixtures happen to contain no backslashes.
+ */
+const asTemplateLiteral = s => s.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
+
 test('escaped backticks compare equal, as in the other sync checks', () => {
   // near-miss-sync strips backslashes so a TS template literal's escaped
   // backticks match a markdown copy's plain ones. Same normalisation here, so
   // a fact quoted from a template does not read as missing.
-  const escaped = doc().replace(/`/g, '\\`');
+  const escaped = asTemplateLiteral(doc());
   assert.deepEqual(
     releaseDocViolations(
       new Map([

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -89,6 +89,32 @@ test('the dry-run recipe must name every publishable package', () => {
   assert.match(v[0], /omits bestax-migrate, bestax-mcp/);
 });
 
+test('an overlapping package name is not satisfied by a substring', () => {
+  // The membership test was `recipe.includes(dir)` and looked fine. Every
+  // publishable name here contains "bestax", so a package literally named
+  // `bestax` read as already present in a recipe that named only
+  // `create-bestax` and `bestax-mcp` — and "present" is the verdict that
+  // switches this rule off. Fail-open, from the same family as the parser
+  // #436 refused to write.
+  const withOverlap = [...PACKAGES, { dir: 'bestax', name: 'bestax' }];
+  const v = releaseDocViolations(
+    docs({
+      contributing: doc({
+        // Names every existing package, and not the new one.
+        recipe: recipe(PACKAGES.map(p => p.dir)),
+        publishers: publishers(PACKAGES.map(p => p.name)),
+      }),
+    }),
+    withOverlap
+  );
+  // Both recipes miss it, and so does the trusted-publisher list.
+  assert.equal(v.length, 3, v.join('\n'));
+  assert.ok(
+    v.every(m => /bestax\b/.test(m)),
+    'both messages must name the omitted package'
+  );
+});
+
 test('a missing recipe is reported as missing, not as a package list', () => {
   const v = releaseDocViolations(
     docs({ contributing: doc({ recipe: '```bash\npnpm all\n```' }) }),

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -213,6 +213,106 @@ test('a missing trusted-publisher line is its own message', () => {
   assert.match(v[0], /no "- Packages:" line/);
 });
 
+test('a stray fence in prose does not hide the recipe', () => {
+  // The regex this replaced paired backtick runs in document order, so one
+  // unpaired ``` shifted every pair after it and the recipe stopped being
+  // found — producing a violation whose suggested remedy is to switch the
+  // check off.
+  const withStray = doc().replace(
+    '> **Safe to run; never publishes:** everything above.',
+    'Fence code with ``` like this.\n\n> **Safe to run; never publishes:** everything above.'
+  );
+  assert.deepEqual(
+    releaseDocViolations(docs({ contributing: withStray }), PACKAGES),
+    []
+  );
+});
+
+test('an unterminated fence still counts as the recipe', () => {
+  // Dropping it produced the same false violation as the stray-fence case.
+  const unterminated = doc().replace(/\n```\s*$/, '');
+  assert.deepEqual(
+    releaseDocViolations(docs({ contributing: unterminated }), PACKAGES),
+    []
+  );
+});
+
+test('a package named only in a comment does not satisfy the recipe', () => {
+  const commented =
+    '```bash\n' +
+    '# bestax-migrate and bestax-mcp are covered separately\n' +
+    'for pkg in bulma-ui create-bestax; do\n' +
+    '  ( cd "$pkg" && pnpm exec semantic-release --dry-run --no-ci )\n' +
+    'done\n```';
+  const v = releaseDocViolations(
+    docs({ contributing: doc({ recipe: commented }) }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /omits bestax-migrate, bestax-mcp/);
+});
+
+test('a package named only in an echo does not satisfy the recipe either', () => {
+  // Stripping comments closed one hole and left the one beside it: only the
+  // loop's own word list should count.
+  const echoed =
+    '```bash\n' +
+    'echo "bestax-migrate bestax-mcp are released separately"\n' +
+    'for pkg in bulma-ui create-bestax; do\n' +
+    '  ( cd "$pkg" && pnpm exec semantic-release --dry-run --no-ci )\n' +
+    'done\n```';
+  const v = releaseDocViolations(
+    docs({ contributing: doc({ recipe: echoed }) }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /omits bestax-migrate, bestax-mcp/);
+});
+
+test('any heading closes the guidance block, not just ## and ###', () => {
+  // A #### heading did not terminate it, so the block ran to EOF and the
+  // file-wide search this scoping exists to prevent came back.
+  const leaked = [
+    '> **Safe to run; never publishes:** everything above.',
+    '> `pnpm publish --provenance --embed-readme --access public`',
+    '',
+    '#### An aside',
+    '',
+    'its `prepack` and `prepublishOnly` hooks refuse things, skipped by',
+    '`--ignore-scripts`, see VERSIONING.md and scripts/require-pnpm-publish.mjs',
+    '',
+    recipe(),
+    publishers(),
+  ].join('\n');
+  const v = releaseDocViolations(docs({ contributing: leaked }), PACKAGES);
+  assert.ok(
+    v.length >= 3,
+    `expected the leaked facts to be flagged:\n${v.join('\n')}`
+  );
+  assert.ok(v.every(m => /Safe to run/.test(m)));
+});
+
+test('a wrapped bullet at end of file keeps its continuation lines', () => {
+  // findIndex's -1 sentinel was collapsed with Math.max(0, …), which dropped
+  // every continuation line whenever nothing followed the bullet.
+  const atEof =
+    doc({ publishers: '' }).trimEnd() +
+    '\n\n### npm authentication (OIDC trusted publisher)\n\n' +
+    '- Packages: `@allxsmith/bestax-bulma`, `create-bestax`,\n' +
+    '  `bestax-migrate` and `bestax-mcp`';
+  assert.deepEqual(
+    releaseDocViolations(docs({ contributing: atEof }), PACKAGES),
+    []
+  );
+});
+
+test('an unreadable manifest is reported, not silently dropped', () => {
+  // publishablePackages returns these rather than skipping, because skipping
+  // narrows both derived assertions and the check still prints a tick.
+  const v = releaseDocViolations(docs(), PACKAGES);
+  assert.deepEqual(v, []);
+});
+
 test('the real repo files satisfy the check', async () => {
   // The fixtures above could all agree with a rule the real docs violate.
   //
@@ -223,7 +323,8 @@ test('the real repo files satisfy the check', async () => {
   // failure shape this check exists to stop.
   const read = rel =>
     readFileSync(fileURLToPath(new URL(`../${rel}`, import.meta.url)), 'utf8');
-  const packages = await publishablePackages();
+  const { packages, unreadable } = await publishablePackages();
+  assert.deepEqual(unreadable, [], `unreadable manifests: ${unreadable}`);
   assert.ok(
     packages.length >= 4,
     `expected 4+ publishable, got ${packages.length}`

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -317,6 +317,47 @@ test('a wrapped bullet at end of file keeps its continuation lines', () => {
   );
 });
 
+test('a fenced example is not mistaken for the guidance block', () => {
+  // masked was built and then not consulted when finding the START, so an
+  // example that quotes the marker became the block — and the real guidance
+  // could be deleted with the check still green.
+  const quoted = [
+    '````markdown',
+    '> **Safe to run; never publishes:** everything above.',
+    '> `pnpm publish --provenance --embed-readme --access public`',
+    '> its `prepack` and `prepublishOnly` hooks refuse, skipped by `--ignore-scripts`,',
+    '> see VERSIONING.md and scripts/require-pnpm-publish.mjs',
+    '````',
+    '',
+    recipe(),
+    publishers(),
+  ].join('\n');
+  const v = releaseDocViolations(docs({ contributing: quoted }), PACKAGES);
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /no "Safe to run; never publishes" guidance/);
+});
+
+test('a package list in a later section does not rescue the OIDC one', () => {
+  // The bullet search ran to EOF after the anchor, so a complete list further
+  // down stood in for an OIDC section that had lost its own.
+  const rescued = [
+    doc({ publishers: '' }).trimEnd(),
+    '',
+    '### npm authentication (OIDC trusted publishing)',
+    '',
+    'Each published package needs a trusted publisher configured on npmjs.com:',
+    '',
+    '(the bullet that belongs here has been deleted)',
+    '',
+    '### Something else entirely',
+    '',
+    '- Packages: `@allxsmith/bestax-bulma`, `create-bestax`, `bestax-migrate` and `bestax-mcp`',
+  ].join('\n');
+  const v = releaseDocViolations(docs({ contributing: rescued }), PACKAGES);
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /no "- Packages:" line in the OIDC trusted/);
+});
+
 test('a missing OIDC section is not rescued by a bullet elsewhere', () => {
   // packagesBullet fell back to line 0 when it found no "trusted publisher"
   // anchor, which is the file-wide search it exists to prevent: an unrelated

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'node:url';
 import {
   publishablePackages,
   releaseDocViolations,
+  unreadableManifestViolations,
 } from './check-conformance.mjs';
 
 const PACKAGES = [
@@ -42,8 +43,18 @@ const recipe = (dirs = PACKAGES.map(p => p.dir)) =>
   dirs.join(' ') +
   '; do\n  ( cd "$pkg" && pnpm exec semantic-release --dry-run --no-ci )\ndone\n```';
 
+// The bullet AND the section heading that anchors it. packagesBullet locates
+// the list by its OIDC section rather than by the first "- Packages:" in the
+// file, so a fixture without the anchor is not a valid stand-in for the real
+// document — and every fixture here was one until the anchor rule landed.
 const publishers = (names = PACKAGES.map(p => p.name)) =>
-  `- Packages: ${names.map(n => `\`${n}\``).join(', ')}`;
+  [
+    '### npm authentication (OIDC trusted publishing)',
+    '',
+    'Each published package needs a trusted publisher configured on npmjs.com:',
+    '',
+    `- Packages: ${names.map(n => `\`${n}\``).join(', ')}`,
+  ].join('\n');
 
 const doc = (opts = {}) =>
   [
@@ -306,11 +317,34 @@ test('a wrapped bullet at end of file keeps its continuation lines', () => {
   );
 });
 
-test('an unreadable manifest is reported, not silently dropped', () => {
-  // publishablePackages returns these rather than skipping, because skipping
-  // narrows both derived assertions and the check still prints a tick.
-  const v = releaseDocViolations(docs(), PACKAGES);
-  assert.deepEqual(v, []);
+test('a missing OIDC section is not rescued by a bullet elsewhere', () => {
+  // packagesBullet fell back to line 0 when it found no "trusted publisher"
+  // anchor, which is the file-wide search it exists to prevent: an unrelated
+  // "- Packages:" bullet then satisfied the assertion with the real guidance
+  // deleted.
+  const noOidcSection = [
+    '- Packages: `@allxsmith/bestax-bulma`, `create-bestax`, `bestax-migrate` and `bestax-mcp`',
+    '',
+    doc({ publishers: '' }),
+  ].join('\n');
+  const v = releaseDocViolations(
+    docs({ contributing: noOidcSection }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /no "- Packages:" line in the OIDC trusted/);
+});
+
+test('unreadable manifests each get a violation naming the package', () => {
+  // The branch this covers used to live inside checkReleaseDocsSync, where no
+  // test could reach it — so the test named for this asserted the clean case
+  // and would have stayed green through a regression.
+  assert.deepEqual(unreadableManifestViolations([]), []);
+  const v = unreadableManifestViolations(['bestax-mcp', 'create-bestax']);
+  assert.equal(v.length, 2);
+  assert.match(v[0], /^bestax-mcp\/package\.json could not be read/);
+  assert.match(v[0], /removes bestax-mcp from both lists silently/);
+  assert.match(v[1], /^create-bestax\/package\.json/);
 });
 
 test('the real repo files satisfy the check', async () => {

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -358,6 +358,41 @@ test('a package list in a later section does not rescue the OIDC one', () => {
   assert.match(v[0], /no "- Packages:" line in the OIDC trusted/);
 });
 
+test('body prose about trusted publishing is not an anchor', () => {
+  // The anchor matched any line mentioning it, so deleting the heading left
+  // the section's own sentence anchoring the search and the list still passed
+  // while the section it belongs to was gone.
+  const headingless = [
+    doc({ publishers: '' }).trimEnd(),
+    '',
+    'Each published package needs a trusted publisher configured on npmjs.com:',
+    '',
+    '- Packages: `@allxsmith/bestax-bulma`, `create-bestax`, `bestax-migrate` and `bestax-mcp`',
+  ].join('\n');
+  const v = releaseDocViolations(docs({ contributing: headingless }), PACKAGES);
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /no "- Packages:" line in the OIDC trusted/);
+});
+
+test('a heading butted against the bullet does not extend the list', () => {
+  // The continuation scan ran past the section, so a heading immediately after
+  // the bullet — no blank line — swept the next section in, and a package
+  // named there covered an omission in this one.
+  const butted = [
+    doc({ publishers: '' }).trimEnd(),
+    '',
+    '### npm authentication (OIDC trusted publishing)',
+    '',
+    '- Packages: `@allxsmith/bestax-bulma`, `create-bestax`',
+    '### Something else',
+    '`bestax-migrate` and `bestax-mcp` are mentioned here for other reasons',
+  ].join('\n');
+  const v = releaseDocViolations(docs({ contributing: butted }), PACKAGES);
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /trusted-publisher list omits/);
+  assert.match(v[0], /bestax-migrate/);
+});
+
 test('a missing OIDC section is not rescued by a bullet elsewhere', () => {
   // packagesBullet fell back to line 0 when it found no "trusted publisher"
   // anchor, which is the file-wide search it exists to prevent: an unrelated

--- a/scripts/release-docs-sync.test.mjs
+++ b/scripts/release-docs-sync.test.mjs
@@ -18,7 +18,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import {
-  parseWorkspacePackages,
+  publishablePackages,
   releaseDocViolations,
 } from './check-conformance.mjs';
 
@@ -34,6 +34,7 @@ const FACTS = [
   'its `prepack` and `prepublishOnly` hooks refuse',
   'skipped by `--ignore-scripts`',
   'see VERSIONING.md',
+  'and scripts/require-pnpm-publish.mjs',
 ];
 
 const recipe = (dirs = PACKAGES.map(p => p.dir)) =>
@@ -46,10 +47,14 @@ const publishers = (names = PACKAGES.map(p => p.name)) =>
 
 const doc = (opts = {}) =>
   [
-    ...(opts.facts ?? FACTS),
+    '> **Safe to run; never publishes:** everything above.',
+    ...(opts.facts ?? FACTS).map(f => `> ${f}`),
+    '',
+    '---',
+    '',
     opts.recipe ?? recipe(),
     opts.publishers ?? publishers(),
-  ].join('\n\n');
+  ].join('\n');
 
 const docs = (over = {}) =>
   new Map([
@@ -74,6 +79,51 @@ test('a fact dropped from one copy only is caught', () => {
   assert.equal(v.length, 1);
   assert.match(v[0], /^docs\/docs\/guides\/getting-started\/contributing\.md/);
   assert.match(v[0], /apply the same edit to both/);
+});
+
+test('a fact is required inside the safe-to-run block, not anywhere in the file', () => {
+  // The bug this exists for: the fact check searched the whole file, and
+  // CONTRIBUTING.md links VERSIONING.md twice more for unrelated reasons — so
+  // deleting the pointer from the guidance left the check green. The prose
+  // satisfied the assertion while the thing being asserted was gone.
+  const withStrayMention = [
+    '# Contributing',
+    '',
+    'Versioning details live in VERSIONING.md and are worth reading.',
+    'The guard is scripts/require-pnpm-publish.mjs, described elsewhere.',
+    '',
+    '> **Safe to run; never publishes:** run a manual',
+    '> `pnpm publish --provenance --embed-readme --access public` only if you must.',
+    '> The `prepack` and `prepublishOnly` hooks refuse a stray publish, though',
+    '> `--ignore-scripts` skips them.',
+    '',
+    '---',
+    '',
+    recipe(),
+    publishers(),
+  ].join('\n');
+
+  const v = releaseDocViolations(
+    docs({ contributing: withStrayMention }),
+    PACKAGES
+  );
+  const pointers = v.filter(m => /VERSIONING\.md|require-pnpm-publish/.test(m));
+  assert.equal(pointers.length, 2, v.join('\n'));
+  assert.ok(
+    pointers.every(m => /"Safe to run" guidance/.test(m)),
+    'the message must say which block is missing it'
+  );
+});
+
+test('a missing safe-to-run block is reported once, not once per fact', () => {
+  // Otherwise deleting the section produces six near-identical messages and
+  // buries the one that says what actually happened.
+  const v = releaseDocViolations(
+    docs({ contributing: [recipe(), publishers()].join('\n\n') }),
+    PACKAGES
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /no "Safe to run; never publishes" guidance/);
 });
 
 test('the dry-run recipe must name every publishable package', () => {
@@ -109,9 +159,11 @@ test('an overlapping package name is not satisfied by a substring', () => {
   );
   // Both recipes miss it, and so does the trusted-publisher list.
   assert.equal(v.length, 3, v.join('\n'));
+  // `\b` alone is not enough: "bestax" is followed by a word boundary inside
+  // "bestax-migrate", so /bestax\b/ matched every message and proved nothing.
   assert.ok(
-    v.every(m => /bestax\b/.test(m)),
-    'both messages must name the omitted package'
+    v.every(m => /omits bestax(,|\.|$|\s)/m.test(m)),
+    `each message must name \`bestax\` itself:\n${v.join('\n')}`
   );
 });
 
@@ -137,10 +189,19 @@ test('the trusted-publisher list must name every publishable package', () => {
   assert.match(v[0], /spends the version/);
 });
 
-test('the trusted-publisher list is only required of CONTRIBUTING.md', () => {
+test('the trusted-publisher list is only required of the primary file', () => {
   // The docs mirror is a contributor page, not the operational runbook, so it
-  // is not asked for the npmjs.com configuration list.
-  assert.deepEqual(releaseDocViolations(docs(), PACKAGES), []);
+  // is not asked for the npmjs.com configuration list — and an incomplete one
+  // there is not a violation either. Asserted with a deliberately short list on
+  // the mirror, because the previous version of this test was byte-identical to
+  // "a matching pair is clean" and so asserted nothing of its own.
+  assert.deepEqual(
+    releaseDocViolations(
+      docs({ mirror: doc({ publishers: publishers(['create-bestax']) }) }),
+      PACKAGES
+    ),
+    []
+  );
 });
 
 test('a missing trusted-publisher line is its own message', () => {
@@ -152,52 +213,17 @@ test('a missing trusted-publisher line is its own message', () => {
   assert.match(v[0], /no "- Packages:" line/);
 });
 
-/**
- * How a TS template literal would carry this text: backslashes first, then
- * backticks. That order is the whole correctness of an escaper — doing
- * backticks first would then double the backslashes it just introduced — and
- * writing only the backtick half is what CodeQL flags as incomplete escaping,
- * correctly, even though these fixtures happen to contain no backslashes.
- */
-const asTemplateLiteral = s => s.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
-
-test('escaped backticks compare equal, as in the other sync checks', () => {
-  // near-miss-sync strips backslashes so a TS template literal's escaped
-  // backticks match a markdown copy's plain ones. Same normalisation here, so
-  // a fact quoted from a template does not read as missing.
-  const escaped = asTemplateLiteral(doc());
-  assert.deepEqual(
-    releaseDocViolations(
-      new Map([
-        ['CONTRIBUTING.md', escaped],
-        ['docs/docs/guides/getting-started/contributing.md', escaped],
-      ]),
-      PACKAGES
-    ),
-    []
-  );
-});
-
-test('the real repo files satisfy the check', () => {
+test('the real repo files satisfy the check', async () => {
   // The fixtures above could all agree with a rule the real docs violate.
   //
-  // The package list is DERIVED here rather than reusing the PACKAGES fixture:
-  // a fifth publishable package would otherwise let this pass against a stale
-  // four while the real check failed in CI, which is the exact failure shape
-  // this whole check exists to stop.
+  // The package list comes from publishablePackages(), the same helper the
+  // check itself uses, rather than from the PACKAGES fixture or a third
+  // re-derivation. A fifth publishable package therefore cannot let this pass
+  // against a stale four while the real check fails — which is the exact
+  // failure shape this check exists to stop.
   const read = rel =>
     readFileSync(fileURLToPath(new URL(`../${rel}`, import.meta.url)), 'utf8');
-  const packages = parseWorkspacePackages(read('pnpm-workspace.yaml'))
-    .map(dir => {
-      try {
-        return { dir, ...JSON.parse(read(`${dir}/package.json`)) };
-      } catch {
-        return null;
-      }
-    })
-    .filter(p => p && !p.private && p.name)
-    .map(({ dir, name }) => ({ dir, name }));
-
+  const packages = await publishablePackages();
   assert.ok(
     packages.length >= 4,
     `expected 4+ publishable, got ${packages.length}`
@@ -210,4 +236,12 @@ test('the real repo files satisfy the check', () => {
     ],
   ]);
   assert.deepEqual(releaseDocViolations(real, packages), []);
+});
+
+test('an empty package list is refused, not silently satisfied', () => {
+  // Both derived assertions are vacuously true against no packages, so an
+  // enumeration that quietly returned nothing would print a tick.
+  const v = releaseDocViolations(docs(), []);
+  assert.equal(v.length, 1);
+  assert.match(v[0], /No publishable packages were found/);
 });


### PR DESCRIPTION
Closes #536.

**#536 is substantially stale, and the plan accounts for that rather than following it literally.** It was filed before #538 merged. #538 moved all four packages to `pnpm publish` and did much of the consolidation #536 asks for — but in the opposite direction:

- #536 proposes `bestax-migrate/CLAUDE.md` as the canonical home. #538 made that file a **pointer** and moved the rationale to `scripts/lib/pnpm-publish.mjs`, `scripts/require-pnpm-publish.mjs` and `VERSIONING.md`.
- #536 lists `bestax-migrate/release.config.js` as a duplication site. All four release configs are now three-line pointers at the shared helper.

Keeping #538's split, which is also what #536's own text argues for: *"the two that should keep their full reasoning inline… are also the two that have never drifted, which is not a coincidence."* Four packages' shared publish rationale does not belong inside one package's instructions file.

## The part that isn't duplication

Auditing #536 against current main turned up **six statements that had simply stopped being true**. Two would bite during a release, and one is drift I introduced in #538:

| Where | Said | Actually |
| --- | --- | --- |
| `CONTRIBUTING.md` | publish job "upgrades npm to a version that supports OIDC" | #532 removed that step — nothing runs `npm publish` |
| `CONTRIBUTING.md` | 2 packages need a trusted publisher | all 4 do, **and a missing one fails the publish after the tag is pushed** |
| both contributing files | dry-run recipe covers 2 packages | 4 run semantic-release |
| docs mirror | releasing types scoped to `bulma-ui` or `create-bestax` | `RELEASE_SCOPES` has 5 |
| both | coverage ">= 95%" / bulma-ui + create-bestax only | 99% bulma-ui, 95%/78% branches for the other three — read from the jest configs, not either file's prose |
| `docs/guides/security.md` | "**Both** published packages" and names 2 | 4 — and 11 lines below, the same file lists 4 release lines |

## Consolidation

`SECURITY.md` and the `CONTRIBUTING`/docs pair keep what their reader acts on — the guarantee, the flags to type, the fact that a stray `npm publish` is refused — and hand off the mechanism to `VERSIONING.md` and `scripts/require-pnpm-publish.mjs`.

`VERSIONING.md` gains the **two rules that appeared in no prose file at all**: there is deliberately no `--tag`, and the publish command redirects pnpm's output to stderr. Both are load-bearing, both fail quietly, and until now the only thing between them and a silent regression was a unit test.

**Left alone deliberately**, so it is not read as an oversight: `check-conformance.mjs` restates the both-hooks rationale to justify *its own rule*, and `npm-release-info.mjs` restates the `|| true` argument to justify *its own can't-fail contract*. Each is load-bearing where it sits.

## `release-docs-sync`

#536 leaned toward "consolidation plus nothing, revisiting if it drifts a fifth time." The audit found the fifth: the two contributing files differ in 8 hunks today, and two of those were package lists that had quietly stopped being all of them.

Built in the `near-miss-sync` style — fact-presence over a hoisted list, **not a byte diff**. The two files legitimately differ (blockquote vs Docusaurus admonition; absolute GitHub links vs relative paths), and a diff would fail on all of that and teach people to ignore it.

Two of the three assertions are **derived from the workspace** rather than restated, because both staleness classes above were the same shape:

1. both files carry the facts a contributor acts on
2. the dry-run recipe names every publishable package
3. `CONTRIBUTING.md`'s trusted-publisher list names every publishable package

Proven to bite, each naming the file and the fix:

```
docs/…/contributing.md no longer mentions "--provenance --embed-readme --access public". … apply the same edit to both (#536).
CONTRIBUTING.md's semantic-release dry-run recipe omits bestax-migrate, bestax-mcp. …
CONTRIBUTING.md's trusted-publisher list omits bestax-mcp. … fails the publish after the release commit and tag are already pushed — which spends the version (#536).
```

**Not doing** the "no mention of `--provenance` outside the canonical files" variant #536 also floats. That is the false-positive-prone option the issue warns about itself, and a legitimate mention in a changelog or blog post would red CI.

**Tested, which the four existing sync checks are not.** The comparison is an exported pure function driven on fixtures, following the `publishable-manifests` precedent rather than its neighbours. The smoke test derives its package list from the workspace, so a fifth package cannot let it pass against a stale four while the real check fails.

## Verification

263 script tests (+9), 15 conformance checks (+1), lint and format clean. Docs site builds. Every package's commit-analyzer reports **no release** for this branch — all commits are `docs`/`chore`, which are `release: false` in all four configs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor, security, and release guidance to cover all publishable packages.
  * Clarified coverage thresholds, npm provenance, publishing safeguards, release commands, and supported commit conventions.
  * Expanded guidance for testing documentation and release workflows.

* **Tests**
  * Added validation to ensure release documentation remains synchronized and complete.
  * Added checks for package coverage, publishing guidance, formatting, trusted publishing details, and repository documentation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->