### PR TITLE
ci: make the AGENTS.md roster scope fence-aware, closing the class

### DIFF
--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2236,8 +2236,25 @@ export const SKILL_ROSTERS = [
   {
     file: 'bulma-ui/AGENTS.md',
     // This one ships in the npm tarball, so a stale roster here is
-    // consumer-facing rather than internal.
-    scope: text => text.match(/Agent skills \(([^)]*)\)/)?.[1] ?? null,
+    // consumer-facing rather than internal. Fence-aware like every other
+    // scope — the #548 deep review named this as the one straggler in the
+    // class: a fenced example quoting "Agent skills (…)" before the real
+    // parenthetical would steal the match and scope the check to the quote.
+    scope: text => {
+      const { lines } = splitLines(text);
+      const masked = fenceMask(lines);
+      // The parenthetical wraps across lines, so match on the joined
+      // unmasked text from the first unmasked occurrence.
+      const start = lines.findIndex(
+        (l, i) => !masked[i] && l.includes('Agent skills (')
+      );
+      if (start < 0) return null;
+      const rest = lines
+        .slice(start)
+        .filter((_, i) => !masked[start + i])
+        .join('\n');
+      return rest.match(/Agent skills \(([^)]*)\)/)?.[1] ?? null;
+    },
     copies: [
       {
         what: 'the "Agent skills (…)" list',

--- a/scripts/skills-roster.test.mjs
+++ b/scripts/skills-roster.test.mjs
@@ -592,3 +592,17 @@ test('renderInstallBlock is a pure function of its inputs, order preserved', asy
       '```\n'
   );
 });
+
+test('a fenced quote of "Agent skills (…)" is not the parenthetical', () => {
+  // The #548 deep review named this scope as the one non-fence-aware
+  // straggler: a fenced example quoting the phrase before the real roster
+  // stole the match, scoping the check to the quote.
+  const decoyed = REAL['bulma-ui/AGENTS.md'].replace(
+    'Agent skills (',
+    '```md\nAgent skills (bestax-fake):\n```\n\nAgent skills ('
+  );
+  assert.deepEqual(
+    rosterViolations(SKILLS, withFile('bulma-ui/AGENTS.md', decoyed)),
+    []
+  );
+});


### PR DESCRIPTION
## Description

The #548 deep review named the `bulma-ui/AGENTS.md` roster scope as **the one remaining extractor** in the hardened class that was not fence-aware: a fenced example quoting `Agent skills (…)` before the real parenthetical steals the match and scopes the check to the quote. No current trigger exists (the phrase occurs once in the file), which is why it was advisory-grade — closed here the same way every sibling was, with the decoy as a fixture.

## Review-round accounting (verified against main, not assumed)

- The #546 Copilot finding (protocol rule advising the plain-range spelling the sibling rule forbids) is **already fixed on main** — the consumer branch skips sibling names citing that review. My initial probe double-reported only because it omitted the third argument the walk passes.
- The #545 CodeRabbit findings (quote parity, trim'd compare) landed via the pre-merge reconciliation commits.
- This was the only surviving finding from the full deep-review + Copilot + CodeRabbit round across #544/#545/#546/#548.

Refs #548

## Checklist
- [x] Fixture proves the decoy no longer steals the anchor
- [x] All 17 conformance checks and full script suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of agent skill rosters by ignoring matching text inside fenced examples.
  * Prevented quoted or illustrative content from being mistaken for the active roster.

* **Tests**
  * Added coverage confirming fenced examples do not affect roster validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->