### PR TITLE
fix(bestax-migrate): parenthesize comma-valued folded Sass variables

### DIFF
--- a/bestax-mcp/data/skills.json
+++ b/bestax-mcp/data/skills.json
@@ -93,7 +93,7 @@
         {
           "id": "css-migration",
           "file": "references/css-migration.md",
-          "bytes": 5679
+          "bytes": 5838
         },
         { "id": "prop-map", "file": "references/prop-map.md", "bytes": 6363 },
         {

--- a/bestax-migrate/e2e/kitchen-sink.test.ts
+++ b/bestax-migrate/e2e/kitchen-sink.test.ts
@@ -147,7 +147,7 @@ describe('kitchen-sink e2e', () => {
     );
     expect(scss).toContain("@use 'bulma/sass' with (");
     expect(scss).toContain('$primary: #1e6b99,');
-    expect(scss).toContain("$family-primary: 'Nunito', sans-serif");
+    expect(scss).toContain("$family-primary: ('Nunito', sans-serif)");
     expect(scss).toContain("@use '@allxsmith/bestax-bulma/scss/extras';");
     expect(scss).not.toContain('@import');
     expect(scss).toContain('.app-shell');

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
@@ -84,6 +84,20 @@ describe('transformStyles (.scss)', () => {
     );
   });
 
+  it('wraps a value whose /* … */-shaped span straddles two quoted strings', () => {
+    // The `/*`…`*/` markers each sit inside a different quoted string, so the
+    // span between them is NOT a comment. A strip-first regex would delete it
+    // together with the real top-level comma, folding the list unparenthesized;
+    // recognizing comments only outside strings keeps the comma top-level.
+    const source = [
+      '$foo: "a /* b", "c */ d";',
+      '',
+      "@import 'bulma/bulma.sass';",
+    ].join('\n');
+    const { output } = run('straddle.scss', source);
+    expect(output).toContain('$foo: ("a /* b", "c */ d")');
+  });
+
   it('leaves a comma-free folded value unparenthesized', () => {
     const source = [
       '$primary: #1e6b99;',

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
@@ -34,10 +34,37 @@ describe('transformStyles (.scss)', () => {
     const { output } = run('theme.scss', source);
     expect(output).toContain("@use 'bulma/sass' with (");
     expect(output).toContain('$primary: #ff6b35,');
-    expect(output).toContain("$family-primary: 'Nunito', sans-serif");
+    expect(output).toContain("$family-primary: ('Nunito', sans-serif)");
     expect(output).toContain("@use '@allxsmith/bestax-bulma/scss/extras';");
     expect(output).not.toContain('@import');
     expect(output).not.toContain('!default');
+  });
+
+  it('wraps a folded value with a top-level comma in parens (#554)', () => {
+    // A bare comma list inside `with (…)` reads as extra arguments to Dart
+    // Sass, not a single list value — this is the repo's own kitchen-sink
+    // fixture, which used to emit Sass that fails to compile.
+    const source = [
+      '$primary: #1e6b99;',
+      "$family-primary: 'Nunito', sans-serif;",
+      '',
+      "@import 'bulma/bulma.sass';",
+    ].join('\n');
+    const { output } = run('fonts.scss', source);
+    expect(output).toContain(
+      "@use 'bulma/sass' with (\n  $primary: #1e6b99,\n  $family-primary: ('Nunito', sans-serif)\n);"
+    );
+  });
+
+  it('leaves a comma-free folded value unparenthesized', () => {
+    const source = [
+      '$primary: #1e6b99;',
+      '',
+      "@import 'bulma/bulma.sass';",
+    ].join('\n');
+    const { output } = run('plain.scss', source);
+    expect(output).toContain('$primary: #1e6b99\n');
+    expect(output).not.toContain('$primary: (#1e6b99)');
   });
 
   it('handles the plain root import without variables', () => {

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
@@ -56,6 +56,18 @@ describe('transformStyles (.scss)', () => {
     );
   });
 
+  it('does not wrap a single quoted string whose escaped quote precedes a comma', () => {
+    // `"a\", b"` is one string value — the escaped `"` must not close the
+    // quote and expose the comma as top-level, or we would emit needless
+    // parens. Track backslash escapes while scanning.
+    const source = ['$foo: "a\\", b";', '', "@import 'bulma/bulma.sass';"].join(
+      '\n'
+    );
+    const { output } = run('escaped.scss', source);
+    expect(output).toContain('$foo: "a\\", b"\n');
+    expect(output).not.toContain('$foo: ("a\\", b")');
+  });
+
   it('leaves a comma-free folded value unparenthesized', () => {
     const source = [
       '$primary: #1e6b99;',

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/styles.test.ts
@@ -68,6 +68,22 @@ describe('transformStyles (.scss)', () => {
     expect(output).not.toContain('$foo: ("a\\", b")');
   });
 
+  it('wraps a folded value whose block comment holds a quote before the comma', () => {
+    // The `/* … */` comment carries an apostrophe (`user's`); without stripping
+    // it the scanner enters string state on that apostrophe, never closes, and
+    // misses the real top-level comma — emitting the bare list Dart Sass rejects
+    // with `expected "$"`.
+    const source = [
+      "$family-primary: /* user's choice */ Arial, sans-serif;",
+      '',
+      "@import 'bulma/bulma.sass';",
+    ].join('\n');
+    const { output } = run('commented.scss', source);
+    expect(output).toContain(
+      "$family-primary: (/* user's choice */ Arial, sans-serif)"
+    );
+  });
+
   it('leaves a comma-free folded value unparenthesized', () => {
     const source = [
       '$primary: #1e6b99;',

--- a/bestax-migrate/src/sources/react-bulma-components/styles.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/styles.ts
@@ -85,6 +85,33 @@ function isFoldableValue(value: string): boolean {
   return !/[()$@]|#\{/.test(value);
 }
 
+/**
+ * Whether `value` has a comma outside any quoted string — a bare Sass list
+ * (`'Nunito', sans-serif`) that must be parenthesized before it can sit
+ * inside `with (…)`, or Dart Sass reads the comma as an argument separator
+ * instead of a list delimiter.
+ */
+function hasTopLevelComma(value: string): boolean {
+  let quote: string | null = null;
+  for (const char of value) {
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ',') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Formats a folded value for the `with (…)` clause, parenthesizing a bare list. */
+function formatFoldedValue(value: string): string {
+  return hasTopLevelComma(value) ? `(${value})` : value;
+}
+
 function report(
   collector: TodoCollector | undefined,
   file: string,
@@ -151,7 +178,7 @@ export const transformStyles: StylesTransform = (
         out.push(`${indent}@use '${bulmaSass}' with (`);
         foldableVars.forEach(({ name, value }, index) => {
           const comma = index < foldableVars.length - 1 ? ',' : '';
-          out.push(`${indent}  $${name}: ${value}${comma}`);
+          out.push(`${indent}  $${name}: ${formatFoldedValue(value)}${comma}`);
         });
         out.push(`${indent});`);
       } else {

--- a/bestax-migrate/src/sources/react-bulma-components/styles.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/styles.ts
@@ -83,9 +83,41 @@ const VAR_DECL = /^\s*\$([\w-]+)\s*:\s*(.+?)\s*(!default)?\s*;\s*$/;
  * that would otherwise fool the character scanners into mis-reading the
  * value's structure; the comment is inert to Sass, so removing it for
  * analysis is safe. The emitted value still carries the comment verbatim.
+ *
+ * The scan tracks quote state first and only recognizes a block comment
+ * outside a string, in one pass — a bare regex would treat a slash-star …
+ * star-slash-shaped span that straddles two quoted strings (opening marker in
+ * one string, closing marker in the next) as a comment and delete the real
+ * top-level comma between them, so a genuine list would fold unparenthesized.
+ * An unterminated comment consumes the rest of the value.
  */
 function stripSassComments(value: string): string {
-  return value.replace(/\/\*[\s\S]*?\*\//g, '');
+  let result = '';
+  let quote: string | null = null;
+  let escaped = false;
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (quote) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '/' && value[i + 1] === '*') {
+      const end = value.indexOf('*/', i + 2);
+      if (end === -1) break; // unterminated comment — drop the rest
+      i = end + 1; // resume after the closing */
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    result += char;
+  }
+  return result;
 }
 
 /**

--- a/bestax-migrate/src/sources/react-bulma-components/styles.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/styles.ts
@@ -77,24 +77,38 @@ const EXTENSION_IMPORT =
 const VAR_DECL = /^\s*\$([\w-]+)\s*:\s*(.+?)\s*(!default)?\s*;\s*$/;
 
 /**
+ * Strips Sass block comments (slash-star … star-slash spans) from a value
+ * before it is analyzed for foldability or top-level commas. A comment can
+ * carry an unbalanced quote (an apostrophe in `user's`) or a stray `(`/`$`
+ * that would otherwise fool the character scanners into mis-reading the
+ * value's structure; the comment is inert to Sass, so removing it for
+ * analysis is safe. The emitted value still carries the comment verbatim.
+ */
+function stripSassComments(value: string): string {
+  return value.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
  * A value is fold-safe for `with (…)` when it is a plain literal — no
  * function calls, interpolation, variable references, or at-rules. Hex
- * colors (`#ff6b35`) are fine; `#{…}` interpolation is not.
+ * colors (`#ff6b35`) are fine; `#{…}` interpolation is not. Block comments are
+ * ignored for this test — their contents don't make the value non-literal.
  */
 function isFoldableValue(value: string): boolean {
-  return !/[()$@]|#\{/.test(value);
+  return !/[()$@]|#\{/.test(stripSassComments(value));
 }
 
 /**
  * Whether `value` has a comma outside any quoted string — a bare Sass list
  * (`'Nunito', sans-serif`) that must be parenthesized before it can sit
  * inside `with (…)`, or Dart Sass reads the comma as an argument separator
- * instead of a list delimiter.
+ * instead of a list delimiter. Block comments are stripped first so a quote or
+ * comma inside one (an apostrophe in `user's`) can't skew the scan.
  */
 function hasTopLevelComma(value: string): boolean {
   let quote: string | null = null;
   let escaped = false;
-  for (const char of value) {
+  for (const char of stripSassComments(value)) {
     if (escaped) {
       escaped = false;
       continue;

--- a/bestax-migrate/src/sources/react-bulma-components/styles.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/styles.ts
@@ -93,7 +93,16 @@ function isFoldableValue(value: string): boolean {
  */
 function hasTopLevelComma(value: string): boolean {
   let quote: string | null = null;
+  let escaped = false;
   for (const char of value) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
     if (quote) {
       if (char === quote) quote = null;
       continue;

--- a/skills/bestax-migrate/references/css-migration.md
+++ b/skills/bestax-migrate/references/css-migration.md
@@ -22,12 +22,17 @@ finish what it flagged.
 
   ```scss
   @use 'bulma/sass' with (
-      $primary: #ff6b35,
-      $family-primary: 'Nunito',
-      sans-serif
-    );
+    $primary: #ff6b35,
+    $family-primary: (
+      'Nunito',
+      sans-serif,
+    )
+  );
   @use '@allxsmith/bestax-bulma/scss/extras';
   ```
+
+  A comma-valued override (a font-family stack) is wrapped in parens so Dart Sass
+  reads it as one list value, not extra arguments to `with (…)`.
 
   0.9 `_all` aggregator imports (`bulma/sass/elements/_all`) became directory modules
   (`@use 'bulma/sass/elements';`). Relative node_modules paths


### PR DESCRIPTION
## Summary

`transformStyles` folds leading `$var: value;` overrides into `@use 'bulma/sass' with (…)`. `isFoldableValue` accepted any value with no `(`, `$`, `@`, or `#{`, which includes bare comma lists like `'Nunito', sans-serif`. The emitter wrote each folded value unparenthesized, so a comma-containing value (e.g. a font-family stack) was read by Dart Sass as extra arguments to `with (…)` instead of one list value — the migrated stylesheet then failed to compile with `Error: expected "$".`

This reproduced on the repo's own `fixtures/kitchen-sink/src/styles.scss`, which has `$family-primary: 'Nunito', sans-serif;`. `pnpm --filter bestax-migrate test` was green because the e2e typechecks the migrated TSX but never compiles the migrated SCSS.

## Fix

Added `hasTopLevelComma`/`formatFoldedValue` in `bestax-migrate/src/sources/react-bulma-components/styles.ts`: a folded value with a comma outside any quoted string is wrapped in parens on emit (`$family-primary: ('Nunito', sans-serif)`); comma-free values are untouched. This is the "parenthesize on emit" option from the issue — narrow, and doesn't change behavior for the common case (colors, keywords, numbers).

## Regression test gate

Added a failing-first test (`wraps a folded value with a top-level comma in parens (#554)`) reproducing the exact kitchen-sink values; confirmed it failed against pre-fix code for the reported reason (`$family-primary: 'Nunito', sans-serif` emitted unparenthesized), then confirmed it passes after the fix. Also added a comma-free regression test and updated the two existing tests (`styles.test.ts`, `e2e/kitchen-sink.test.ts`) that asserted the old (buggy) unparenthesized output.

## Scope note: Sass-compile e2e guard not added

The issue's Definition of Done also asks for the kitchen-sink e2e to actually *compile* the migrated stylesheet (not just typecheck the TSX), which needs a `sass` devDependency on `bestax-migrate` (not currently declared there — `bulma-ui` has it, but the isolated linker doesn't let `bestax-migrate` reach it as a phantom dependency). Per this loop's operating rules, I cannot add or upgrade dependencies unilaterally, so that half of the DoD is left for a maintainer to pick up (issue confirms the dep needs sign-off anyway, given the workspace's cooldown/`allowBuilds` policy).

## Test plan

- [x] `pnpm --filter bestax-migrate exec jest src/sources/react-bulma-components/__tests__/styles.test.ts` — new regression test fails pre-fix (for the reported reason), passes post-fix; 16/16 pass post-fix
- [x] `pnpm exec turbo run build --filter=bestax-migrate`
- [x] `pnpm --filter bestax-migrate run lint`
- [x] `pnpm --filter bestax-migrate run typecheck`
- [x] `pnpm --filter bestax-migrate run test:coverage` — 226/226 pass, bestax-migrate coverage 96.53%/87.38%/98%/97.77% (stmts/branch/funcs/lines), above the 95%/78% thresholds
- [x] `pnpm run format:check`
- [x] `pnpm run check:conformance`
- [ ] Sass-compile guard on the kitchen-sink e2e (needs a new `sass` devDependency — out of scope for this loop, see note above)

Fixes #554

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SCSS migration formatting for configuration values containing commas.
  * Preserved comma-separated Sass values as lists by wrapping them in parentheses.
  * Correctly handled comments and escaped quotes while detecting commas.
  * Kept comma-free values in their existing format.

* **Documentation**
  * Clarified how to format comma-separated font-family values in migration guidance.

* **Tests**
  * Added coverage for comma-containing, commented, escaped, and comma-free Sass values.
  * Updated migration assertions to reflect the corrected output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->