### PR TITLE
fix(bestax-migrate): pick Heading target by prop value, not presence

### DIFF
--- a/bestax-mcp/data/skills.json
+++ b/bestax-mcp/data/skills.json
@@ -88,7 +88,7 @@
         {
           "id": "component-map",
           "file": "references/component-map.md",
-          "bytes": 11894
+          "bytes": 12984
         },
         {
           "id": "css-migration",

--- a/bestax-migrate/e2e/kitchen-sink.test.ts
+++ b/bestax-migrate/e2e/kitchen-sink.test.ts
@@ -174,6 +174,8 @@ describe('kitchen-sink e2e', () => {
     expect(rules).toContain('prop:colorVariant');
     expect(rules).toContain('prop:value');
     expect(rules).toContain('prop:delta');
+    expect(rules).toContain('prop:subtitle');
+    expect(rules).toContain('prop:heading');
     expect(todos.length).toBeGreaterThanOrEqual(10);
     const migrated = fs.readFileSync(
       path.join(tmpDir, 'src', 'leftovers.tsx'),

--- a/bestax-migrate/fixtures/kitchen-sink/src/leftovers.tsx
+++ b/bestax-migrate/fixtures/kitchen-sink/src/leftovers.tsx
@@ -12,6 +12,7 @@ import {
   Card,
   Dropdown,
   Element,
+  Heading,
   Hero,
   Modal,
   Pagination,
@@ -60,6 +61,8 @@ export function Leftovers() {
         showFirstLast
         autoHide
       />
+      <Heading subtitle={choice === 'a'}>Dynamic subtitle</Heading>
+      <Heading heading={choice === 'a'}>Dynamic heading</Heading>
     </div>
   );
 }

--- a/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.input.tsx
+++ b/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.input.tsx
@@ -1,0 +1,12 @@
+import { Heading } from 'react-bulma-components';
+
+export function Titles() {
+  return (
+    <div>
+      <Heading subtitle={true}>a</Heading>
+      <Heading subtitle={false}>b</Heading>
+      <Heading heading={false}>c</Heading>
+      <Heading size={3}>d</Heading>
+    </div>
+  );
+}

--- a/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.input.tsx
+++ b/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.input.tsx
@@ -7,6 +7,7 @@ export function Titles() {
       <Heading subtitle={false}>b</Heading>
       <Heading heading={false}>c</Heading>
       <Heading size={3}>d</Heading>
+      <Heading heading subtitle>e</Heading>
     </div>
   );
 }

--- a/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.output.tsx
+++ b/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.output.tsx
@@ -7,6 +7,7 @@ export function Titles() {
       <Title>b</Title>
       <Title>c</Title>
       <Title size="3">d</Title>
+      <p className="heading subtitle">e</p>
     </div>
   );
 }

--- a/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.output.tsx
+++ b/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/heading-literals.output.tsx
@@ -1,0 +1,12 @@
+import { SubTitle, Title } from "@allxsmith/bestax-bulma";
+
+export function Titles() {
+  return (
+    <div>
+      <SubTitle>a</SubTitle>
+      <Title>b</Title>
+      <Title>c</Title>
+      <Title size="3">d</Title>
+    </div>
+  );
+}

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
@@ -327,6 +327,46 @@ describe('react-bulma-components transform fixtures', () => {
       expect((output ?? '').match(/<a /g)).toHaveLength(1);
     });
 
+    it('flags a dynamic Heading subtitle and falls back to Title', () => {
+      const source = [
+        "import { Heading } from 'react-bulma-components';",
+        'export const A = ({ isSub }: { isSub?: boolean }) => (',
+        '  <Heading subtitle={isSub}>x</Heading>',
+        ');',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(
+        transform,
+        'heading-subtitle.tsx',
+        source,
+        {
+          add: entry => todos.push(entry),
+        }
+      );
+      expect(todos.some(t => t.rule === 'prop:subtitle')).toBe(true);
+      expect(output).toContain('<Title>x</Title>');
+    });
+
+    it('flags a dynamic Heading heading prop and keeps Title/SubTitle instead of collapsing to a plain element', () => {
+      const source = [
+        "import { Heading } from 'react-bulma-components';",
+        'export const A = ({ useHeadingStyle }: { useHeadingStyle?: boolean }) => (',
+        '  <Heading heading={useHeadingStyle}>x</Heading>',
+        ');',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(
+        transform,
+        'heading-heading.tsx',
+        source,
+        {
+          add: entry => todos.push(entry),
+        }
+      );
+      expect(todos.some(t => t.rule === 'prop:heading')).toBe(true);
+      expect(output).toContain('<Title>x</Title>');
+    });
+
     it('flags a Menu.List title it cannot lift to a sibling', () => {
       const source = [
         "import { Menu } from 'react-bulma-components';",

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
@@ -344,7 +344,29 @@ describe('react-bulma-components transform fixtures', () => {
         }
       );
       expect(todos.some(t => t.rule === 'prop:subtitle')).toBe(true);
-      expect(output).toContain('<Title>x</Title>');
+      // The dynamic expression is preserved on the element (not deleted) so
+      // the branch can be split by hand.
+      expect(output).toContain('<Title subtitle={isSub}>x</Title>');
+    });
+
+    it('does not collapse `<Heading heading subtitle={expr}>` to a plain element and flags the dynamic subtitle', () => {
+      const source = [
+        "import { Heading } from 'react-bulma-components';",
+        'export const A = ({ isSub }: { isSub?: boolean }) => (',
+        '  <Heading heading subtitle={isSub}>x</Heading>',
+        ');',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(transform, 'heading-both.tsx', source, {
+        add: entry => todos.push(entry),
+      });
+      // The dynamic subtitle blocks the structural `heading` collapse: it must
+      // NOT become a `<p className="heading">` (that would silently drop the
+      // dynamic subtitle) and it must leave a prop:subtitle TODO.
+      expect(todos.some(t => t.rule === 'prop:subtitle')).toBe(true);
+      expect(output).not.toContain('className="heading"');
+      expect(output).toContain('subtitle={isSub}');
+      expect(output).toContain('<Title');
     });
 
     it('flags a dynamic Heading heading prop and keeps Title/SubTitle instead of collapsing to a plain element', () => {
@@ -364,7 +386,8 @@ describe('react-bulma-components transform fixtures', () => {
         }
       );
       expect(todos.some(t => t.rule === 'prop:heading')).toBe(true);
-      expect(output).toContain('<Title>x</Title>');
+      // The dynamic expression is preserved on the element (not deleted).
+      expect(output).toContain('<Title heading={useHeadingStyle}>x</Title>');
     });
 
     it('flags a Menu.List title it cannot lift to a sibling', () => {

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
@@ -390,6 +390,41 @@ describe('react-bulma-components transform fixtures', () => {
       expect(output).toContain('<Title heading={useHeadingStyle}>x</Title>');
     });
 
+    it('resolves a statically-truthy string `heading` literal without a dynamic TODO', () => {
+      const source = [
+        "import { Heading } from 'react-bulma-components';",
+        'export const A = () => <Heading heading="heading">x</Heading>;',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(transform, 'heading-string.tsx', source, {
+        add: entry => todos.push(entry),
+      });
+      // A statically-known truthy value renders the plain `.heading` paragraph
+      // at runtime, so it collapses just like a bare `heading` — never the
+      // "dynamic value" TODO that main resolved correctly.
+      expect(todos.some(t => t.rule === 'prop:heading')).toBe(false);
+      expect(output).toContain('className="heading"');
+      expect(output).not.toContain('<Title');
+    });
+
+    it('resolves a statically-truthy string `subtitle` literal to SubTitle without a dynamic TODO', () => {
+      const source = [
+        "import { Heading } from 'react-bulma-components';",
+        'export const A = () => <Heading subtitle="yes">x</Heading>;',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(
+        transform,
+        'subtitle-string.tsx',
+        source,
+        {
+          add: entry => todos.push(entry),
+        }
+      );
+      expect(todos.some(t => t.rule === 'prop:subtitle')).toBe(false);
+      expect(output).toContain('<SubTitle>x</SubTitle>');
+    });
+
     it('flags a Menu.List title it cannot lift to a sibling', () => {
       const source = [
         "import { Menu } from 'react-bulma-components';",

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
@@ -420,6 +420,22 @@ describe('react-bulma-components transform fixtures', () => {
       expect(output).toContain('<Title');
     });
 
+    it('keeps the `subtitle` class when a literal-truthy `subtitle` collapses alongside `heading`', () => {
+      const source = [
+        "import { Heading } from 'react-bulma-components';",
+        'export const A = () => <Heading heading subtitle>x</Heading>;',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(transform, 'heading-both.tsx', source, {
+        add: entry => todos.push(entry),
+      });
+      // Both props are truthy literals, so the element collapses to the plain
+      // `.heading` paragraph — but RBC applies the subtitle class independently,
+      // so it must ride along rather than being silently dropped.
+      expect(todos).toHaveLength(0);
+      expect(output).toContain('className="heading subtitle"');
+    });
+
     it('flags a dynamic Heading heading prop and keeps Title/SubTitle instead of collapsing to a plain element', () => {
       const source = [
         "import { Heading } from 'react-bulma-components';",

--- a/bestax-migrate/src/sources/react-bulma-components/specials.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/specials.ts
@@ -282,13 +282,16 @@ const SPECIALS: Record<string, SpecialHandler> = {
 
     // A truthy literal `heading` collapses to a plain `.heading` paragraph —
     // but only when `subtitle` isn't a dynamic value the collapse would drop.
+    // A truthy *literal* `subtitle` is safe to collapse: RBC applies its class
+    // independently, so it rides along on the paragraph as `heading subtitle`
+    // (dropping it would be the same silent loss the dynamic guard prevents).
     if (headingTruthy && !subtitleDynamic) {
       removeAttr(element, headingAttr);
       const className = mergeClassName(
         ctx,
         path,
         element,
-        'heading',
+        subtitleTruthy ? 'heading subtitle' : 'heading',
         'Heading'
       );
       const rest = stripModifierProps(

--- a/bestax-migrate/src/sources/react-bulma-components/specials.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/specials.ts
@@ -216,11 +216,16 @@ const SPECIALS: Record<string, SpecialHandler> = {
   /**
    * Heading → Title / SubTitle / plain `.heading` paragraph, matching RBC's
    * `title: !subtitle && !heading` / `subtitle: subtitle` — the *value* of
-   * each prop picks the target, not merely whether it was passed. A literal
-   * `false` is equivalent to the prop being absent; a dynamic value can't be
-   * resolved at codemod time, so it's left in place with a TODO and a
-   * conservative (Title/SubTitle, never the structural plain-element rewrite)
-   * fallback so the branch can be split by hand. The subtitle class is applied
+   * each prop picks the target, not merely whether it was passed. Any
+   * statically-known literal resolves to a fixed truthiness at codemod time
+   * (a bare prop and `heading={true}`/`heading="heading"` are all truthy;
+   * `heading={false}`/`heading=""`/`heading={0}` are falsy and equivalent to
+   * the prop being absent), exactly as RBC evaluates the prop at runtime —
+   * this mirrors the Button `remove` handler so the two don't contradict each
+   * other on string/number literals. Only a genuine expression can't be
+   * resolved: it's left in place with a TODO and a conservative
+   * (Title/SubTitle, never the structural plain-element rewrite) fallback so
+   * the branch can be split by hand. The subtitle class is applied
    * independently of heading in RBC, so a dynamic `subtitle` blocks the
    * structural `heading` collapse — collapsing would silently drop it.
    */
@@ -229,8 +234,14 @@ const SPECIALS: Record<string, SpecialHandler> = {
     const subtitleAttr = findAttr(element, 'subtitle');
     const headingLit = headingAttr ? literalValueOf(headingAttr) : undefined;
     const subtitleLit = subtitleAttr ? literalValueOf(subtitleAttr) : undefined;
-    const headingDynamic = !!headingLit && headingLit.kind !== 'boolean';
-    const subtitleDynamic = !!subtitleLit && subtitleLit.kind !== 'boolean';
+    const headingDynamic = headingLit?.kind === 'expression';
+    const subtitleDynamic = subtitleLit?.kind === 'expression';
+    // A resolvable literal (boolean/string/number) collapses to its runtime
+    // truthiness; an expression stays dynamic.
+    const headingTruthy =
+      !!headingLit && headingLit.kind !== 'expression' && !!headingLit.value;
+    const subtitleTruthy =
+      !!subtitleLit && subtitleLit.kind !== 'expression' && !!subtitleLit.value;
 
     // Dynamic values can't be resolved to a target: leave the prop on the
     // element (so its expression survives for hand-splitting) plus a TODO.
@@ -251,13 +262,9 @@ const SPECIALS: Record<string, SpecialHandler> = {
       );
     }
 
-    // Literal-true `heading` collapses to a plain `.heading` paragraph — but
-    // only when `subtitle` isn't a dynamic value the collapse would drop.
-    if (
-      headingLit?.kind === 'boolean' &&
-      headingLit.value === true &&
-      !subtitleDynamic
-    ) {
+    // A truthy literal `heading` collapses to a plain `.heading` paragraph —
+    // but only when `subtitle` isn't a dynamic value the collapse would drop.
+    if (headingTruthy && !subtitleDynamic) {
       removeAttr(element, headingAttr);
       const className = mergeClassName(
         ctx,
@@ -286,18 +293,18 @@ const SPECIALS: Record<string, SpecialHandler> = {
       return { replaced: true };
     }
 
-    // A resolvable literal `heading` (`false`, or `true` blocked by a dynamic
-    // subtitle) behaves as if the prop were absent — drop it. A dynamic
-    // `heading` stays put (its TODO is already filed above).
-    if (headingLit?.kind === 'boolean') {
+    // A resolvable literal `heading` that didn't collapse (falsy, or truthy
+    // but blocked by a dynamic subtitle) behaves as if the prop were absent —
+    // drop it. A dynamic `heading` stays put (its TODO is already filed above).
+    if (headingLit && !headingDynamic) {
       removeAttr(element, headingAttr);
       ctx.dirty = true;
     }
 
-    if (subtitleLit?.kind === 'boolean') {
+    if (subtitleLit && !subtitleDynamic) {
       removeAttr(element, subtitleAttr);
       ctx.dirty = true;
-      return { target: subtitleLit.value ? 'SubTitle' : 'Title' };
+      return { target: subtitleTruthy ? 'SubTitle' : 'Title' };
     }
     // Dynamic subtitle (attr kept) or no subtitle → conservative Title.
     return { target: 'Title' };

--- a/bestax-migrate/src/sources/react-bulma-components/specials.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/specials.ts
@@ -213,42 +213,77 @@ const SPECIALS: Record<string, SpecialHandler> = {
     return { target: 'Delete' };
   },
 
-  /** Heading → Title / SubTitle / plain `.heading` paragraph. */
+  /**
+   * Heading → Title / SubTitle / plain `.heading` paragraph, matching RBC's
+   * `title: !subtitle && !heading` / `subtitle: subtitle` — the *value* of
+   * each prop picks the target, not merely whether it was passed. A literal
+   * `false` is equivalent to the prop being absent; a dynamic value can't be
+   * resolved at codemod time, so it's left as a TODO with a conservative
+   * (Title/SubTitle, never the structural plain-element rewrite) fallback.
+   */
   heading(ctx, path, element) {
     const headingAttr = findAttr(element, 'heading');
     if (headingAttr) {
-      removeAttr(element, headingAttr);
-      const className = mergeClassName(
-        ctx,
-        path,
-        element,
-        'heading',
-        'Heading'
-      );
-      const rest = stripModifierProps(
-        ctx,
-        path,
-        attributesOf(element).filter(
-          a => !['size', 'weight', 'spaced', 'subtitle'].includes(a.name.name)
-        ),
-        'Heading'
-      );
-      const replacement = plainElement(
-        ctx.j,
-        'p',
-        className,
-        rest,
-        element.children ?? []
-      );
-      path.replace(replacement);
-      ctx.dirty = true;
-      return { replaced: true };
+      const literal = literalValueOf(headingAttr);
+      if (literal.kind === 'boolean' && literal.value === true) {
+        removeAttr(element, headingAttr);
+        const className = mergeClassName(
+          ctx,
+          path,
+          element,
+          'heading',
+          'Heading'
+        );
+        const rest = stripModifierProps(
+          ctx,
+          path,
+          attributesOf(element).filter(
+            a => !['size', 'weight', 'spaced', 'subtitle'].includes(a.name.name)
+          ),
+          'Heading'
+        );
+        const replacement = plainElement(
+          ctx.j,
+          'p',
+          className,
+          rest,
+          element.children ?? []
+        );
+        path.replace(replacement);
+        ctx.dirty = true;
+        return { replaced: true };
+      }
+      if (literal.kind === 'boolean') {
+        // `heading={false}` behaves as if the prop were absent.
+        removeAttr(element, headingAttr);
+        ctx.dirty = true;
+      } else {
+        addTodo(
+          ctx,
+          path,
+          'prop:heading',
+          '`heading` has a dynamic value; when truthy it renders a plain `<p className="heading">` instead of Title/SubTitle — resolve by hand'
+        );
+        removeAttr(element, headingAttr);
+      }
     }
     const subtitleAttr = findAttr(element, 'subtitle');
     if (subtitleAttr) {
+      const literal = literalValueOf(subtitleAttr);
+      if (literal.kind === 'boolean') {
+        removeAttr(element, subtitleAttr);
+        ctx.dirty = true;
+        return { target: literal.value ? 'SubTitle' : 'Title' };
+      }
+      addTodo(
+        ctx,
+        path,
+        'prop:subtitle',
+        '`subtitle` has a dynamic value; pick between Title / SubTitle by hand'
+      );
       removeAttr(element, subtitleAttr);
       ctx.dirty = true;
-      return { target: 'SubTitle' };
+      return { target: 'Title' };
     }
     return { target: 'Title' };
   },

--- a/bestax-migrate/src/sources/react-bulma-components/specials.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/specials.ts
@@ -218,73 +218,88 @@ const SPECIALS: Record<string, SpecialHandler> = {
    * `title: !subtitle && !heading` / `subtitle: subtitle` — the *value* of
    * each prop picks the target, not merely whether it was passed. A literal
    * `false` is equivalent to the prop being absent; a dynamic value can't be
-   * resolved at codemod time, so it's left as a TODO with a conservative
-   * (Title/SubTitle, never the structural plain-element rewrite) fallback.
+   * resolved at codemod time, so it's left in place with a TODO and a
+   * conservative (Title/SubTitle, never the structural plain-element rewrite)
+   * fallback so the branch can be split by hand. The subtitle class is applied
+   * independently of heading in RBC, so a dynamic `subtitle` blocks the
+   * structural `heading` collapse — collapsing would silently drop it.
    */
   heading(ctx, path, element) {
     const headingAttr = findAttr(element, 'heading');
-    if (headingAttr) {
-      const literal = literalValueOf(headingAttr);
-      if (literal.kind === 'boolean' && literal.value === true) {
-        removeAttr(element, headingAttr);
-        const className = mergeClassName(
-          ctx,
-          path,
-          element,
-          'heading',
-          'Heading'
-        );
-        const rest = stripModifierProps(
-          ctx,
-          path,
-          attributesOf(element).filter(
-            a => !['size', 'weight', 'spaced', 'subtitle'].includes(a.name.name)
-          ),
-          'Heading'
-        );
-        const replacement = plainElement(
-          ctx.j,
-          'p',
-          className,
-          rest,
-          element.children ?? []
-        );
-        path.replace(replacement);
-        ctx.dirty = true;
-        return { replaced: true };
-      }
-      if (literal.kind === 'boolean') {
-        // `heading={false}` behaves as if the prop were absent.
-        removeAttr(element, headingAttr);
-        ctx.dirty = true;
-      } else {
-        addTodo(
-          ctx,
-          path,
-          'prop:heading',
-          '`heading` has a dynamic value; when truthy it renders a plain `<p className="heading">` instead of Title/SubTitle — resolve by hand'
-        );
-        removeAttr(element, headingAttr);
-      }
-    }
     const subtitleAttr = findAttr(element, 'subtitle');
-    if (subtitleAttr) {
-      const literal = literalValueOf(subtitleAttr);
-      if (literal.kind === 'boolean') {
-        removeAttr(element, subtitleAttr);
-        ctx.dirty = true;
-        return { target: literal.value ? 'SubTitle' : 'Title' };
-      }
+    const headingLit = headingAttr ? literalValueOf(headingAttr) : undefined;
+    const subtitleLit = subtitleAttr ? literalValueOf(subtitleAttr) : undefined;
+    const headingDynamic = !!headingLit && headingLit.kind !== 'boolean';
+    const subtitleDynamic = !!subtitleLit && subtitleLit.kind !== 'boolean';
+
+    // Dynamic values can't be resolved to a target: leave the prop on the
+    // element (so its expression survives for hand-splitting) plus a TODO.
+    if (subtitleDynamic) {
       addTodo(
         ctx,
         path,
         'prop:subtitle',
         '`subtitle` has a dynamic value; pick between Title / SubTitle by hand'
       );
+    }
+    if (headingDynamic) {
+      addTodo(
+        ctx,
+        path,
+        'prop:heading',
+        '`heading` has a dynamic value; when truthy it renders a plain `<p className="heading">` instead of Title/SubTitle — resolve by hand'
+      );
+    }
+
+    // Literal-true `heading` collapses to a plain `.heading` paragraph — but
+    // only when `subtitle` isn't a dynamic value the collapse would drop.
+    if (
+      headingLit?.kind === 'boolean' &&
+      headingLit.value === true &&
+      !subtitleDynamic
+    ) {
+      removeAttr(element, headingAttr);
+      const className = mergeClassName(
+        ctx,
+        path,
+        element,
+        'heading',
+        'Heading'
+      );
+      const rest = stripModifierProps(
+        ctx,
+        path,
+        attributesOf(element).filter(
+          a => !['size', 'weight', 'spaced', 'subtitle'].includes(a.name.name)
+        ),
+        'Heading'
+      );
+      const replacement = plainElement(
+        ctx.j,
+        'p',
+        className,
+        rest,
+        element.children ?? []
+      );
+      path.replace(replacement);
+      ctx.dirty = true;
+      return { replaced: true };
+    }
+
+    // A resolvable literal `heading` (`false`, or `true` blocked by a dynamic
+    // subtitle) behaves as if the prop were absent — drop it. A dynamic
+    // `heading` stays put (its TODO is already filed above).
+    if (headingLit?.kind === 'boolean') {
+      removeAttr(element, headingAttr);
+      ctx.dirty = true;
+    }
+
+    if (subtitleLit?.kind === 'boolean') {
       removeAttr(element, subtitleAttr);
       ctx.dirty = true;
-      return { target: 'Title' };
+      return { target: subtitleLit.value ? 'SubTitle' : 'Title' };
     }
+    // Dynamic subtitle (attr kept) or no subtitle → conservative Title.
     return { target: 'Title' };
   },
 

--- a/docs/docs/guides/getting-started/migration/react-bulma-components.md
+++ b/docs/docs/guides/getting-started/migration/react-bulma-components.md
@@ -43,7 +43,9 @@ in place:
   and the `const { Input, Field } = Form;` destructuring pattern.
 - **Components** — all 32 components and their compound sub-components are mapped, e.g.
   `Form.Textarea` → `TextArea`, `Card.Footer.Item` → `Card.FooterItem`, `Hero.Footer` →
-  `Hero.Foot`, `Panel.Header` → `Panel.Heading`, `Heading subtitle` → `SubTitle`,
+  `Hero.Foot`, `Panel.Header` → `Panel.Heading`, `Heading` → `Title`/`SubTitle` by prop value
+  (`subtitle={true}` → `SubTitle`, `subtitle={false}`/absent → `Title`, a dynamic `subtitle`/`heading`
+  value is left in place with a `TODO(bestax-migrate)`),
   `Level.Side align="right"` → `Level.Right`, `Loader` → a plain `<div className="loader">`.
 - **Props** — `renderAs` → `as` (where supported), boolean modifiers gain their bestax prefixes
   (`loading` → `isLoading`, `fullwidth` → `isFullWidth`, now a deprecated alias of

--- a/skills/bestax-migrate/references/component-map.md
+++ b/skills/bestax-migrate/references/component-map.md
@@ -6,40 +6,40 @@ codemod converts it; **Flagged** = it leaves a `TODO(bestax-migrate)` comment (s
 
 ## Top-level components
 
-| RBC            | bestax                                       | Notes                                                                                 |
-| -------------- | -------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `Block`        | `Block`                                      | Auto                                                                                  |
-| `Box`          | `Box`                                        | Auto                                                                                  |
-| `Breadcrumb`   | `Breadcrumb`                                 | Auto; `align` → `alignment` (`center`→`centered`)                                     |
-| `Button`       | `Button`                                     | Auto; `<Button remove/>` → `<Delete/>`; see prop map                                  |
-| `Card`         | `Card`                                       | Auto                                                                                  |
-| `Columns`      | `Columns`                                    | Auto; `breakpoint="mobile"`→`isMobile`, `multiline`→`isMultiline`, …                  |
-| `Container`    | `Container`                                  | Auto; `breakpoint="fluid"`→`fluid`, `max`→`isMax`                                     |
-| `Content`      | `Content`                                    | Auto                                                                                  |
-| `Dropdown`     | `Dropdown`                                   | Structure auto; controlled `value`/`onChange` flagged                                 |
-| `Element`      | —                                            | Flagged: no generic element; use a semantic component + helper props                  |
-| `Footer`       | `Footer`                                     | Auto                                                                                  |
-| `Form.*`       | flat imports                                 | See Form table below                                                                  |
-| `Heading`      | `Title` / `SubTitle` / `<p class="heading">` | Auto; `subtitle` picks `SubTitle`, `heading` picks the plain element                  |
-| `Hero`         | `Hero`                                       | Auto; `hasNavbar`→`fullheightWithNavbar`; `halfheight`/`gradient` flagged             |
-| `Icon`         | `Icon`                                       | `<i class="fas fa-x">` children → `name`/`library`/`variant` props; else flagged      |
-| `Image`        | `Image`                                      | Auto; numeric `size={128}` → `size="128x128"`, `rounded`→`isRounded`                  |
-| `Level`        | `Level`                                      | Auto; `breakpoint="mobile"`→`isMobile`                                                |
-| `Loader`       | plain `<div className="loader">`             | Auto (Bulma v1 still ships the class)                                                 |
-| `Media`        | `Media`                                      | Auto                                                                                  |
-| `Menu`         | `Menu`                                       | Auto                                                                                  |
-| `Message`      | `Message`                                    | Auto; `size` flagged                                                                  |
-| `Modal`        | `Modal`                                      | `show`→`active`; `closeOnEsc`/`closeOnBlur`/`showClose` flagged (defaults cover them) |
-| `Navbar`       | `Navbar`                                     | Auto; see dropdown note below                                                         |
-| `Notification` | `Notification`                               | Auto; `light`→`isLight`                                                               |
-| `Pagination`   | `Pagination`                                 | `onChange`→`onPageChange`; `delta`/labels/`showFirstLast`/`autoHide` flagged          |
-| `Panel`        | `Panel`                                      | Auto                                                                                  |
-| `Progress`     | `Progress`                                   | Auto                                                                                  |
-| `Section`      | `Section`                                    | Auto                                                                                  |
-| `Table`        | `Table`                                      | Auto; `size="fullwidth"`→`isFullwidth`, `striped`→`isStriped`, …                      |
-| `Tabs`         | `Tabs`                                       | Auto; children wrapped in `Tabs.List`; `type="toggle-rounded"`→`toggle rounded`       |
-| `Tag`          | `Tag`                                        | Auto; `remove`→`isDelete`, `rounded`→`isRounded`                                      |
-| `Tile`         | —                                            | Flagged: Bulma v1 replaced tiles with `Grid`/`Cell`                                   |
+| RBC            | bestax                                       | Notes                                                                                                                 |
+| -------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `Block`        | `Block`                                      | Auto                                                                                                                  |
+| `Box`          | `Box`                                        | Auto                                                                                                                  |
+| `Breadcrumb`   | `Breadcrumb`                                 | Auto; `align` → `alignment` (`center`→`centered`)                                                                     |
+| `Button`       | `Button`                                     | Auto; `<Button remove/>` → `<Delete/>`; see prop map                                                                  |
+| `Card`         | `Card`                                       | Auto                                                                                                                  |
+| `Columns`      | `Columns`                                    | Auto; `breakpoint="mobile"`→`isMobile`, `multiline`→`isMultiline`, …                                                  |
+| `Container`    | `Container`                                  | Auto; `breakpoint="fluid"`→`fluid`, `max`→`isMax`                                                                     |
+| `Content`      | `Content`                                    | Auto                                                                                                                  |
+| `Dropdown`     | `Dropdown`                                   | Structure auto; controlled `value`/`onChange` flagged                                                                 |
+| `Element`      | —                                            | Flagged: no generic element; use a semantic component + helper props                                                  |
+| `Footer`       | `Footer`                                     | Auto                                                                                                                  |
+| `Form.*`       | flat imports                                 | See Form table below                                                                                                  |
+| `Heading`      | `Title` / `SubTitle` / `<p class="heading">` | Auto for literal `subtitle`/`heading` (by value, not presence — `subtitle={false}` is `Title`); dynamic value flagged |
+| `Hero`         | `Hero`                                       | Auto; `hasNavbar`→`fullheightWithNavbar`; `halfheight`/`gradient` flagged                                             |
+| `Icon`         | `Icon`                                       | `<i class="fas fa-x">` children → `name`/`library`/`variant` props; else flagged                                      |
+| `Image`        | `Image`                                      | Auto; numeric `size={128}` → `size="128x128"`, `rounded`→`isRounded`                                                  |
+| `Level`        | `Level`                                      | Auto; `breakpoint="mobile"`→`isMobile`                                                                                |
+| `Loader`       | plain `<div className="loader">`             | Auto (Bulma v1 still ships the class)                                                                                 |
+| `Media`        | `Media`                                      | Auto                                                                                                                  |
+| `Menu`         | `Menu`                                       | Auto                                                                                                                  |
+| `Message`      | `Message`                                    | Auto; `size` flagged                                                                                                  |
+| `Modal`        | `Modal`                                      | `show`→`active`; `closeOnEsc`/`closeOnBlur`/`showClose` flagged (defaults cover them)                                 |
+| `Navbar`       | `Navbar`                                     | Auto; see dropdown note below                                                                                         |
+| `Notification` | `Notification`                               | Auto; `light`→`isLight`                                                                                               |
+| `Pagination`   | `Pagination`                                 | `onChange`→`onPageChange`; `delta`/labels/`showFirstLast`/`autoHide` flagged                                          |
+| `Panel`        | `Panel`                                      | Auto                                                                                                                  |
+| `Progress`     | `Progress`                                   | Auto                                                                                                                  |
+| `Section`      | `Section`                                    | Auto                                                                                                                  |
+| `Table`        | `Table`                                      | Auto; `size="fullwidth"`→`isFullwidth`, `striped`→`isStriped`, …                                                      |
+| `Tabs`         | `Tabs`                                       | Auto; children wrapped in `Tabs.List`; `type="toggle-rounded"`→`toggle rounded`                                       |
+| `Tag`          | `Tag`                                        | Auto; `remove`→`isDelete`, `rounded`→`isRounded`                                                                      |
+| `Tile`         | —                                            | Flagged: Bulma v1 replaced tiles with `Grid`/`Cell`                                                                   |
 
 ## Compound sub-components
 


### PR DESCRIPTION
## Summary

The `heading` special (`bestax-migrate/src/sources/react-bulma-components/specials.ts`) picked its rewrite target by checking whether the `subtitle` / `heading` **attribute was present**, never what its literal value was. That meant:

- `<Heading subtitle={false}>` silently became `<SubTitle>` instead of `<Title>`
- `<Heading heading={false}>` silently became a plain `<p className="heading">` instead of `<Title>`
- `<Heading subtitle={expr}>` / `<Heading heading={expr}>` (dynamic values) were also silently mapped without any `TODO(bestax-migrate)`, which the package's own hard rule forbids.

RBC v4's actual semantics (`esm/components/heading/heading.js`) are `title: !subtitle && !heading`, `subtitle: subtitle` — the *value* picks the target.

### Fix

`heading`'s special handler now inspects `literalValueOf(attr)` (the same pattern already used by `alignTarget`, `columns`, `panel-tab`, and `breadcrumb-item`):

- literal `true` → same structural rewrite as before (`SubTitle` / plain `<p className="heading">`)
- literal `false` → treated as if the prop were absent (falls through to `Title` unless `subtitle` says otherwise)
- dynamic (non-literal) → leaves a `prop:subtitle` / `prop:heading` `TODO(bestax-migrate)` comment and picks a conservative fallback (`Title`/`SubTitle` — never the structural plain-element rewrite, since that can't be undone by hand as easily)

### Tests

- New fixture pair `__testfixtures__/heading-literals.{input,output}.tsx` covering the literal `subtitle={true|false}` / `heading={false}` cases — confirmed this fails against the pre-fix code (`b`/`c` cases mis-transform) and passes after the fix.
- New unit tests in `transform.test.ts` asserting the `prop:subtitle` / `prop:heading` TODO rules fire for dynamic values and that the fallback target is `Title`.
- `fixtures/kitchen-sink/src/leftovers.tsx` gained two `Heading` dynamic-value cases; `e2e/kitchen-sink.test.ts` now asserts both TODO rules appear.
- Updated `skills/bestax-migrate/references/component-map.md`'s `Heading` row to describe value-based (not presence-based) selection.

Fixes #552

## Test plan

- [x] `pnpm --filter bestax-migrate run lint`
- [x] `pnpm --filter bestax-migrate run typecheck`
- [x] `pnpm --filter bestax-migrate run test:coverage` (227 tests passed; 96.53% stmts / 87.35% branches, above the 95%/78% threshold)
- [x] `pnpm run format:check`
- [x] `pnpm run gen:catalog:check`
- [x] `pnpm run check:conformance`
- [x] Confirmed the new fixture test fails against the pre-fix `specials.ts` and passes after the fix (regression-test gate)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved migration of Bulma heading components based on `heading` and `subtitle` prop values.
  - Static values now produce appropriate title, subtitle, or plain heading output.
  - Dynamic or unsupported values retain TODO annotations for review.

- **Documentation**
  - Updated migration guidance and component mappings to describe heading conversion behavior.

- **Tests**
  - Added coverage for static, dynamic, truthy, and falsy heading properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->