### PR TITLE
docs: sync guide extras table with shipped avatar/badge/reveal and pickers

### DIFF
--- a/docs/docs/guides/library/index.md
+++ b/docs/docs/guides/library/index.md
@@ -376,10 +376,10 @@ Every component in this library — including all extras — is free and always 
 
 Beyond the core Bulma wrappers, bestax-bulma ships additional components that fill gaps where Bulma doesn't provide a built-in solution:
 
-| Category       | Extras                                                              |
-| -------------- | ------------------------------------------------------------------- |
-| **Components** | Carousel, Steps, Dialog, Toast, Sidebar, Loading, Tooltip, Collapse |
-| **Form**       | Autocomplete, Switch, Slider, Numberinput, Rate, Taginput           |
-| **Elements**   | LinkButton                                                          |
+| Category       | Extras                                                                                              |
+| -------------- | --------------------------------------------------------------------------------------------------- |
+| **Components** | Avatar, Avatars, Badge, Carousel, Collapse, Dialog, Loading, Reveal, Sidebar, Steps, Toast, Tooltip |
+| **Form**       | Autocomplete, DateInput, DateTimeInput, Numberinput, Rate, Slider, Switch, Taginput, TimeInput      |
+| **Elements**   | LinkButton                                                                                          |
 
 These extras include purpose-built SCSS that follows Bulma v1's CSS-variable conventions, so they theme and customise exactly like native Bulma components. They're bundled into `bestax.css` — no separate import needed.


### PR DESCRIPTION
## Summary

The Library Overview guide's extras table (`docs/docs/guides/library/index.md`) predated two rounds of shipping:

- **Components** row listed only the January eight (Carousel, Steps, Dialog, Toast, Sidebar, Loading, Tooltip, Collapse). Added Avatar, Avatars, Badge, and Reveal, matching the homepage `EnhancedAddons` grid (`docs/src/components/EnhancedAddons/index.js`), which is now the authoritative 12-item list.
- **Form** row (Autocomplete, Switch, Slider, Numberinput, Rate, Taginput) predated the pickers. Added DateInput, TimeInput, and DateTimeInput, which ship extras SCSS (`bulma-ui/src/scss/form/_dateinput.scss`, `_timeinput.scss`, `_datetimeinput.scss`, `_picker-popover.scss`).
- Both rows are now alphabetized to match the `EnhancedAddons` grid ordering.

**Implementer's call:** Checkbox and Radio also ship their own extras SCSS (`_checkbox.scss`, `_radio.scss`), but they are themed restyles of Bulma's built-in checkbox/radio inputs rather than components filling a gap where Bulma has no built-in — which is the stated criterion for this table ("ships additional components that fill gaps where Bulma doesn't provide a built-in solution"). Left them out of the table for that reason.

## Test plan

- [x] `pnpm exec prettier --check docs/docs/guides/library/index.md` passes
- [x] `pnpm run format:check` passes repo-wide
- [x] `pnpm exec turbo run build --filter=@allxsmith/bestax-docs` succeeds

Fixes #466

Generated with [Claude Code](https://claude.ai/code)