### PR TITLE
fix(docs): fail the build on broken anchor links

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -49,7 +49,12 @@ const config = {
   trailingSlash: false,
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenAnchors: 'throw',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
## Summary

`onBrokenLinks: 'throw'` already makes dead page links build-fatal, but anchor
fragments (`#anchor`) only warned — the Docusaurus default when
`onBrokenAnchors` is unset. The two new blog posts plus their generated-API
cross-links now carry roughly seventy `#anchor` links; a heading rename would
break them silently. This was Advisory 1 from the Claude deep review on #462.

- Add `onBrokenAnchors: 'throw'` next to `onBrokenLinks` in
  `docs/docusaurus.config.js`.
- Companion cleanup: migrate the deprecated `onBrokenMarkdownLinks` top-level
  option to `markdown.hooks.onBrokenMarkdownLinks` (removes the duplicate
  deprecation warning printed per build).

## Verification

- `pnpm exec turbo run build --filter=@allxsmith/bestax-docs` — clean build,
  zero broken-anchor warnings today, confirming the flip is safe now.
- Local spot test: temporarily broke an anchor reference in
  `docs/docs/guides/helpers/color.md` (`#composable-mini-hooks` →
  `#composable-mini-hooks-broken-test`) and re-ran the docs build — it failed
  with `Docusaurus found broken anchors!` naming the exact broken link, then
  reverted the test change (working tree is clean, only the config file
  changed).
- `pnpm run lint`, `pnpm run format:check`, `pnpm run check:conformance` all
  pass.

## Test plan

- [x] Docs build passes with the flag set
- [x] A deliberately broken anchor fails the build in a local spot test
- [x] Deprecation warning gone (companion change landed in this PR)

Fixes #467

Generated with [Claude Code](https://claude.ai/code)