### PR TITLE
ci: reword deep-review dedupe comment to match the relabel exception

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,8 +18,10 @@ name: Claude Deep Review
 # Security posture: same-repo PRs only (never forks), the labeler's live
 # role is re-verified via the collaborators API (triage+ required, so a
 # label applied by automation on behalf of an outsider is a silent no-op),
-# and the dedupe marker still caps usage at one review per PR ever —
-# re-labeling never re-fires it.
+# and the dedupe marker caps AUTOMATIC usage at one review per PR — a
+# triage+ user re-applying `deep-review` is the one deliberate re-run
+# path (e.g. after new commits or a prompt upgrade; see the dedupe
+# step's EXCEPTION below).
 #
 # Deliberately does NOT trigger on `synchronize`: one review per PR, so
 # Claude's own fix pushes can never re-fire this workflow (no reviewer/fixer


### PR DESCRIPTION
## What

Comment-only change to `.github/workflows/claude-review.yml`. The security-posture paragraph in the header claimed the dedupe marker "caps usage at one review per PR ever — re-labeling never re-fires it", which the dedupe step's own EXCEPTION contradicts: a triage+-verified re-application of `deep-review` deliberately skips the probe and runs a fresh review (verified live on #417).

The reword states what the mechanism actually delivers: the cap applies to *automatic* usage, and a verified triage+ re-label is the one deliberate re-run path. Root `CLAUDE.md` already described this correctly; the workflow header was the stale copy.

## Why it matters

This file gates who can spend opus usage, so its header carries more weight than average — and it reads top-down, so the wrong sentence lands before the correct EXCEPTION comment 80 lines later. Per the `.github/CLAUDE.md` review checklist, security comments must claim exactly what the mechanism delivers.

No triggers, permissions, allowlists, or step logic change — the diff touches `#` comment lines only.

Fixes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that automatic deep reviews are limited to one per pull request.
  * Documented that verified triage users can re-run reviews by reapplying the `deep-review` label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->