### PR TITLE
Extract the workflow security parsers into tested scripts

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -191,8 +191,14 @@ writing the trigger string at all.
 Shell embedded in a workflow step cannot be unit-tested without extracting it first. Put
 non-trivial parsing in `scripts/*.mjs` with a `node --test` sibling — root `pnpm test` runs
 `node --test "scripts/*.test.mjs"` (the glob is quoted so Node expands it, not the shell).
-Two parsers are still inline and tracked in #454: the publish sanitizer and the scan-verdict
-parser.
+The two #454 parsers are extracted: the scan-verdict parser
+(`scripts/parse-scan-verdict.mjs`, called by `ai-scan.yml`) and the publish sanitizer
+(`scripts/sanitize-repro-draft.mjs`, called by `claude-repro.yml`) — their test siblings pin
+the fail-closed matrix and the byte behavior of the shell they replaced, so edit script and
+tests together. Smaller instances of the same shape remain inline (the exec-file sentinel
+checks in `ai-triage.yml`, `claude-review.yml`, and `claude-repro.yml`'s author job); when
+one of those next needs an edit, extract it and reuse `parse-scan-verdict.mjs`'s exported
+helpers rather than growing the YAML.
 
 ### 10. `harden-runner` on new jobs starts at `block`, and `block` does not currently mean block
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -200,6 +200,21 @@ checks in `ai-triage.yml`, `claude-review.yml`, and `claude-repro.yml`'s author 
 one of those next needs an edit, extract it and reuse `parse-scan-verdict.mjs`'s exported
 helpers rather than growing the YAML.
 
+**Extraction has a bootstrap gap: a new script flags its own introducing PR.** A workflow runs
+the YAML from the PR merge ref, but the jobs here deliberately check out the default branch
+(never PR head code). A script the PR adds therefore does not exist in the workspace its own
+run reads: `node` exits `MODULE_NOT_FOUND`, the caller takes its fallback, and a fail-closed
+verdict path labels the item on infrastructure grounds without the verdict ever being read.
+Origin: #570 applied `needs-security-review` to itself this way, which then gated
+`claude-repro`, `claude-fix`, `@claude` and `@bestaxbot` on that PR.
+
+Do not close this by checking out the PR head — running PR-authored code in a job holding a
+credential is the thing that pin prevents, and trading it away for a cosmetic label is a far
+worse deal than the flag. Treat the gap as expected cost instead: say in the PR description
+that the flag is self-inflicted, and clear the label by hand once the script is on the default
+branch. The same applies to moving or renaming a script a workflow already calls — the rename
+lands in the YAML a run before it lands in the tree that run checks out.
+
 ### 10. `harden-runner` on new jobs starts at `block`, and `block` does not currently mean block
 
 New jobs ship with `egress-policy: block`. An **existing** live job may be introduced at `audit`

--- a/.github/workflows/ai-scan.yml
+++ b/.github/workflows/ai-scan.yml
@@ -195,13 +195,6 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      # No pnpm, no cache: the verdict parser below is dependency-free
-      # (node: builtins only), so plain Node 24 is all it needs.
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        if: steps.gate.outputs.run == 'true'
-        with:
-          node-version: '24'
-
       - name: Run Claude (security scan)
         id: claude
         if: steps.gate.outputs.run == 'true'
@@ -271,6 +264,14 @@ jobs:
       # checkout failed under `always()`, a crashed script, garbled output —
       # leaves the flagged/other default in place, and the case enum below is
       # the only thing that admits a category string into the summary.
+      #
+      # Deliberately no setup-node: the parser imports node: builtins only, and
+      # every GitHub-hosted runner ships a Node the Actions runner itself needs.
+      # A setup-node here would add a nodejs.org fetch to a control that runs
+      # under `always()` — and because this step flags on any non-clean outcome,
+      # a failed fetch (tool-cache miss, or an armed egress block once #487
+      # lands, whose allowlist does not name that host) would label the item
+      # with no scan having happened. Do not add one back.
       - name: Apply label on non-clean verdict (fail-closed)
         if: always() && steps.gate.outputs.run == 'true'
         env:
@@ -282,7 +283,11 @@ jobs:
           set -euo pipefail
           VERDICT="flagged"   # fail-closed default
           CATEGORY="other"
-          OUT=$(node scripts/parse-scan-verdict.mjs "${EXEC_FILE:-}") || OUT=''
+          # 2>/dev/null as the jq it replaced had: the script's own no-leak
+          # contract covers only what its try/catch wraps, so a failure before
+          # main runs (missing module, syntax error) would otherwise print to
+          # the public job log, which this step's header promises against.
+          OUT=$(node scripts/parse-scan-verdict.mjs "${EXEC_FILE:-}" 2>/dev/null) || OUT=''
           case "$OUT" in
             clean) VERDICT="clean" ;;
             'flagged injection' | 'flagged obfuscated-code' | 'flagged social-engineering' | 'flagged other')

--- a/.github/workflows/ai-scan.yml
+++ b/.github/workflows/ai-scan.yml
@@ -195,6 +195,13 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      # No pnpm, no cache: the verdict parser below is dependency-free
+      # (node: builtins only), so plain Node 24 is all it needs.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        if: steps.gate.outputs.run == 'true'
+        with:
+          node-version: '24'
+
       - name: Run Claude (security scan)
         id: claude
         if: steps.gate.outputs.run == 'true'
@@ -256,12 +263,14 @@ jobs:
               SECURITY-SCAN: flagged (injection|obfuscated-code|social-engineering|other)
             Choose the single best category. Put NO explanation on this line.
 
-      # FAIL-CLOSED labeler (no AI). Default verdict is FLAGGED; only a positively
-      # parsed `SECURITY-SCAN: clean` as the anchored final line, with is_error
-      # false, leaves the label off. Runs even if the Claude step failed
-      # (`always()`), so a crashed/injection-truncated session flags rather than
-      # silently reading as clean. Uses the anchored last-line jq (never a loose
-      # grep over the execution file, which contains echoed attacker text).
+      # FAIL-CLOSED labeler (no AI). The parsing lives in
+      # scripts/parse-scan-verdict.mjs (rule 9; the fail-closed contract and its
+      # rationale are in that file's header, the seven-shape trace in its test
+      # sibling). The script always exits 0 and prints exactly `clean` or
+      # `flagged <category>`; ANY other outcome — node missing because the
+      # checkout failed under `always()`, a crashed script, garbled output —
+      # leaves the flagged/other default in place, and the case enum below is
+      # the only thing that admits a category string into the summary.
       - name: Apply label on non-clean verdict (fail-closed)
         if: always() && steps.gate.outputs.run == 'true'
         env:
@@ -273,23 +282,12 @@ jobs:
           set -euo pipefail
           VERDICT="flagged"   # fail-closed default
           CATEGORY="other"
-          if [ -n "${EXEC_FILE:-}" ] && [ -f "$EXEC_FILE" ]; then
-            OK=$(jq -es '[.[] | if type == "array" then .[] else . end]
-                         | map(select(type == "object" and .type == "result"))
-                         | last | (.is_error == false)' "$EXEC_FILE" 2>/dev/null || echo false)
-            LINE=$(jq -rs '[.[] | if type == "array" then .[] else . end]
-                           | map(select(type == "object" and .type == "result"))
-                           | last | (.result // "")
-                           | split("\n") | map(select(length > 0)) | (.[-1] // "")' \
-                   "$EXEC_FILE" 2>/dev/null || echo "")
-            if [ "$OK" = "true" ] && printf '%s' "$LINE" | grep -qE '^SECURITY-SCAN: clean$'; then
-              VERDICT="clean"
-            elif [ "$OK" = "true" ] && printf '%s' "$LINE" \
-                 | grep -qE '^SECURITY-SCAN: flagged \((injection|obfuscated-code|social-engineering|other)\)$'; then
-              VERDICT="flagged"
-              CATEGORY=$(printf '%s' "$LINE" | sed -E 's/^SECURITY-SCAN: flagged \((.*)\)$/\1/')
-            fi
-          fi
+          OUT=$(node scripts/parse-scan-verdict.mjs "${EXEC_FILE:-}") || OUT=''
+          case "$OUT" in
+            clean) VERDICT="clean" ;;
+            'flagged injection' | 'flagged obfuscated-code' | 'flagged social-engineering' | 'flagged other')
+              CATEGORY="${OUT#flagged }" ;;
+          esac
           if [ "$VERDICT" = "clean" ]; then
             echo "scan clean for #$NUMBER — no label"
             echo "Security scan: clean on #$NUMBER." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/claude-repro.yml
+++ b/.github/workflows/claude-repro.yml
@@ -366,6 +366,18 @@ jobs:
             # for invariant I2; cleanup then removes the label and posts the
             # neutral notice.
             SAN=$(printf '%s' "$TEST" | node scripts/sanitize-repro-draft.mjs)
+            # `set -e` catches a sanitizer that exits non-zero, but not one that
+            # exits 0 having written nothing — which the main guard does if
+            # import.meta.url and argv[1] ever disagree (Node realpaths the ESM
+            # entry; argv[1] is only resolved, so a symlinked workspace splits
+            # them). Empty output here is anomalous by construction: `drafted`
+            # is only set for a non-empty draft file, and no rule can empty a
+            # non-empty input. Fail loud rather than post an empty ```tsx block
+            # under a "Claude drafted the test below" heading.
+            if [ -z "$SAN" ]; then
+              echo "::error::sanitizer produced no output for a drafted test — refusing to publish."
+              exit 1
+            fi
             {
               printf '%s\n\n' '<!-- ai-repro:draft -->'
               printf '### AI reproduction (author-only)\n\n'

--- a/.github/workflows/claude-repro.yml
+++ b/.github/workflows/claude-repro.yml
@@ -322,7 +322,22 @@ jobs:
     timeout-minutes: 5
     permissions:
       issues: write
+      contents: read # checkout the default branch to run the sanitizer script
     steps:
+      # Trusted default-branch content only — the trigger is `issues: labeled`,
+      # so no attacker-controlled ref exists for this event.
+      - name: Checkout base default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # No pnpm, no cache: the sanitizer below is dependency-free
+      # (node: builtins only), so plain Node 24 is all it needs.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+
       - name: Post drafted repro (github-actions[bot]; sanitized)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -342,25 +357,15 @@ jobs:
               printf 'Claude could not draft a self-contained reproduction test for this issue automatically. A maintainer can add concrete repro steps and re-apply the `claude-repro` label.\n'
             } > "$BODY"
           else
-            # Deterministic sanitize (opaque bytes): (1) entity-encode @-handles so
-            # no comment can carry a live mention (belt-and-braces; a GITHUB_TOKEN
-            # comment cannot re-trigger anyway); (2) break the machine markers OTHER
-            # automation parses — auto-close-duplicates.mjs (`<!-- ... -->` +
-            # `Duplicate of #N`) and the *-RESULT/SECURITY-SCAN watchdogs — since
-            # github-actions[bot] is an automation author those consumers trust.
-            # (3) neuter fence delimiters. The draft is wrapped in a ```tsx block
-            # below, so a line of backticks inside it closes that block early and
-            # everything after is rendered as markdown rather than shown as code.
-            # Cosmetic rather than a privilege issue — this posts as
-            # github-actions[bot] and the markers above are already defanged — but
-            # a broken-out draft is exactly the thing a reviewer skims past.
-            SAN=$(printf '%s' "$TEST" \
-              | sed -E 's/@(claude|coderabbitai|bestaxbot)/\&#64;\1/gI' \
-              | sed -E 's/<!--/\&lt;!--/g; s/-->/--\&gt;/g' \
-              | sed -E 's/(Duplicate of) #/\1 \&#35;/gI' \
-              | sed -E 's/^(TRIAGE-RESULT|SECURITY-SCAN|REPRO-RESULT|REPRO-DRAFT):/\1 :/g' \
-              | sed -E 's/^([ \t]*)(`{3,}|~{3,})/\1\&#96;\&#96;\&#96;/g' \
-              | head -c 12000)
+            # Deterministic sanitize (opaque bytes) + 12000-byte truncation in
+            # scripts/sanitize-repro-draft.mjs (rule 9; what each rule defangs
+            # and why is in that file's header, and its test sibling holds the
+            # coupling with auto-close-duplicates.mjs to the consumer's own
+            # patterns). Under `set -e` a missing or crashing sanitizer FAILS
+            # this step — never posts — which is the correct failure direction
+            # for invariant I2; cleanup then removes the label and posts the
+            # neutral notice.
+            SAN=$(printf '%s' "$TEST" | node scripts/sanitize-repro-draft.mjs)
             {
               printf '%s\n\n' '<!-- ai-repro:draft -->'
               printf '### AI reproduction (author-only)\n\n'

--- a/scripts/auto-close-duplicates.test.mjs
+++ b/scripts/auto-close-duplicates.test.mjs
@@ -109,10 +109,12 @@ test('the marker and the Duplicate line are both required', () => {
 });
 
 test('an automation comment quoting a duplicate line still parses', () => {
-  // Documents the coupling with claude-repro.yml, which defangs
-  // "Duplicate of #" in drafted tests precisely because github-actions[bot] is
-  // an author this parser trusts. If that sanitizer regresses, this is the
-  // consumer that acts on the smuggled line — so the two must stay in step.
+  // Documents the coupling with sanitize-repro-draft.mjs (claude-repro.yml's
+  // publish sanitizer), which defangs "Duplicate of #" in drafted tests
+  // precisely because github-actions[bot] is an author this parser trusts. If
+  // that sanitizer regresses, this is the consumer that acts on the smuggled
+  // line — sanitize-repro-draft.test.mjs imports MARKER and DUPLICATE_RE from
+  // this file and asserts sanitized output can never satisfy them.
   const found = findMarkerComment([
     comment(
       1,

--- a/scripts/parse-scan-verdict.mjs
+++ b/scripts/parse-scan-verdict.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed verdict parser for the AI security scan (#454, rule 9).
+ *
+ * ai-scan.yml's labeler step calls this over the Claude action's
+ * execution_file and applies `needs-security-review` on anything that is not
+ * positively clean. The default verdict is FLAGGED: only a session whose last
+ * result record has `is_error: false` AND whose final non-empty output line is
+ * exactly `SECURITY-SCAN: clean` leaves the label off. A crashed, empty,
+ * truncated, unparsable or inconclusive session flags rather than passes —
+ * that is the point of the step, so every degenerate input below maps to
+ * flagged, and the test sibling asserts each one.
+ *
+ * The match is anchored to the last non-empty line, never a loose search over
+ * the file: the execution file contains echoed attacker text, and a
+ * `SECURITY-SCAN: clean` reproduced mid-transcript must not read as a verdict.
+ * Whitespace-only lines count as lines here (jq `select(length > 0)` parity),
+ * so a trailing line of spaces after a clean sentinel still flags.
+ *
+ * Direction of the failure modes, because the split is deliberate
+ * (.github/CLAUDE.md rule 4): the VERDICT fails closed (this file), while the
+ * scan GATE fails open (a budget error skips the scan entirely) — an unscanned
+ * item is indistinguishable from a clean one downstream.
+ *
+ * CLI contract (the YAML wrapper depends on every clause):
+ *   node scripts/parse-scan-verdict.mjs <execution-file>
+ * - Always exits 0. The verdict is the single stdout line — exactly `clean`
+ *   or `flagged <injection|obfuscated-code|social-engineering|other>` — and a
+ *   print contract fails closed where an exit-code contract would not: Node's
+ *   default exit status is 0, so a forgotten code path under an exit-code
+ *   contract would read as clean, while here it prints nothing that matches
+ *   and the wrapper keeps its flagged/other default.
+ * - Log hygiene: no input-derived text is ever written to stdout or stderr.
+ *   JSON parse errors embed input snippets, and the workflow header promises
+ *   the execution file stays off the public job log (evasion-oracle risk), so
+ *   every internal error is swallowed into `flagged other` rather than
+ *   reported. Infra failures that prevent this script from running at all
+ *   (missing checkout, missing node) surface in the wrapper instead, which
+ *   also defaults to flagged/other.
+ *
+ * Parsing parity with the jq it replaced (`jq -es '[.[] | if type == "array"
+ * then .[] else . end] | ...'`): the file may be one JSON array or a stream of
+ * newline-delimited values; top-level arrays are flattened exactly one level;
+ * only plain objects with `type == "result"` count and the LAST one wins;
+ * `is_error` must be strictly false (absent flags); a non-string `result`
+ * reads as empty. The stream fallback is all-or-nothing — one unparsable
+ * non-empty line rejects the whole file. Never "improve" that to skip bad
+ * lines: a skipped final `is_error: true` record would promote an earlier
+ * clean one, which is a fail-open parse.
+ *
+ * Exported helpers are pure so the fail-closed matrix is unit-testable; main
+ * only runs when the file is executed directly.
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const CLEAN_RE = /^SECURITY-SCAN: clean$/;
+export const FLAGGED_RE =
+  /^SECURITY-SCAN: flagged \((injection|obfuscated-code|social-engineering|other)\)$/;
+
+const isPlainObject = v =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * Parse the execution file's text into its top-level JSON values, flattening
+ * arrays one level (jq slurp parity). Returns null — never a partial list —
+ * when anything fails to parse.
+ */
+export function parseExecutionRecords(text) {
+  if (typeof text !== 'string') return null;
+  let values;
+  try {
+    values = [JSON.parse(text)];
+  } catch {
+    // Not a single JSON document — try newline-delimited values. One bad
+    // non-empty line rejects the file (see header: skipping would fail open).
+    values = [];
+    for (const line of text.split('\n')) {
+      if (line.trim() === '') continue;
+      try {
+        values.push(JSON.parse(line));
+      } catch {
+        return null;
+      }
+    }
+  }
+  return values.flatMap(v => (Array.isArray(v) ? v : [v]));
+}
+
+/** The last plain-object record with type === "result", or null. */
+export function lastResultRecord(records) {
+  if (!Array.isArray(records)) return null;
+  const results = records.filter(r => isPlainObject(r) && r.type === 'result');
+  return results.length > 0 ? results[results.length - 1] : null;
+}
+
+/**
+ * Last non-empty line of a result payload. Filters on length, NOT trim: a
+ * whitespace-only line is a line (jq `select(length > 0)` parity), so
+ * trailing spaces after a sentinel still push it off the final position.
+ */
+export function lastNonEmptyLine(result) {
+  const text = typeof result === 'string' ? result : '';
+  const lines = text.split('\n').filter(line => line.length > 0);
+  return lines.length > 0 ? lines[lines.length - 1] : '';
+}
+
+/**
+ * The whole verdict, fail-closed: { verdict: 'clean' } or
+ * { verdict: 'flagged', category }. Category is only trusted from a session
+ * that ended with is_error false — an errored session's category line is as
+ * unreliable as its verdict, so it reads as `other` (matching the shell,
+ * where both branches were gated on OK).
+ */
+export function parseVerdict(text) {
+  const flagged = { verdict: 'flagged', category: 'other' };
+  const records = parseExecutionRecords(text);
+  const record = lastResultRecord(records);
+  if (record === null || record.is_error !== false) return flagged;
+  const line = lastNonEmptyLine(record.result);
+  if (CLEAN_RE.test(line)) return { verdict: 'clean' };
+  const match = FLAGGED_RE.exec(line);
+  if (match) return { verdict: 'flagged', category: match[1] };
+  return flagged;
+}
+
+function main() {
+  let out = 'flagged other';
+  try {
+    const path = process.argv[2];
+    if (path) {
+      const { verdict, category } = parseVerdict(readFileSync(path, 'utf8'));
+      out = verdict === 'clean' ? 'clean' : `flagged ${category}`;
+    }
+  } catch {
+    // Swallowed on purpose — missing/unreadable file is one of the mandated
+    // fail-closed shapes, and error text may embed file content (log
+    // hygiene, see header). `out` keeps its flagged default.
+  }
+  process.stdout.write(`${out}\n`);
+}
+
+// Run only when executed directly (keeps the pure helpers importable).
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/parse-scan-verdict.mjs
+++ b/scripts/parse-scan-verdict.mjs
@@ -38,7 +38,7 @@
  *   (missing checkout, missing node) surface in the wrapper instead, which
  *   also defaults to flagged/other.
  *
- * Parsing parity with the jq it replaced (`jq -es '[.[] | if type == "array"
+ * Parsing against the jq it replaced (`jq -es '[.[] | if type == "array"
  * then .[] else . end] | ...'`): the file may be one JSON array or a stream of
  * newline-delimited values; top-level arrays are flattened exactly one level;
  * only plain objects with `type == "result"` count and the LAST one wins;
@@ -47,6 +47,16 @@
  * non-empty line rejects the whole file. Never "improve" that to skip bad
  * lines: a skipped final `is_error: true` record would promote an earlier
  * clean one, which is a fail-open parse.
+ *
+ * That is parity-or-STRICTER, not parity — do not restate it as parity. `jq
+ * -s` slurps any whitespace-separated stream, so a pretty-printed multi-line
+ * value, or two values on one line, both parsed under the shell and both
+ * return `flagged other` here (the single-document parse fails, then the
+ * line-oriented fallback rejects each fragment). Unreachable while the action
+ * writes one JSON array, and it errs toward flagging, so it is a false-flag
+ * risk rather than a security one — but if the output format ever drifts to a
+ * pretty-printed stream, this is the line that turns every scan into a flag.
+ * The test sibling pins both shapes so the divergence stays visible.
  *
  * Exported helpers are pure so the fail-closed matrix is unit-testable; main
  * only runs when the file is executed directly.

--- a/scripts/parse-scan-verdict.test.mjs
+++ b/scripts/parse-scan-verdict.test.mjs
@@ -193,6 +193,24 @@ test('the last result record wins', () => {
   );
 });
 
+test('whitespace-separated streams flag — stricter than the jq, deliberately', () => {
+  // `jq -s` slurps any whitespace-separated stream, so both shapes below
+  // parsed under the shell this replaced. Here they do not. Unreachable while
+  // the action writes a single JSON array, and it errs toward flagging — but
+  // it IS a divergence from the file header's "against the jq" comparison, so
+  // pin it rather than leave it to be rediscovered as a mystery false flag.
+  const pretty = [
+    JSON.stringify({ type: 'system' }, null, 2),
+    JSON.stringify(record('SECURITY-SCAN: clean'), null, 2),
+  ].join('\n');
+  assert.deepEqual(parseVerdict(pretty), flaggedOther);
+
+  const sameLine =
+    JSON.stringify({ type: 'system' }) +
+    JSON.stringify(record('SECURITY-SCAN: clean'));
+  assert.deepEqual(parseVerdict(sameLine), flaggedOther);
+});
+
 test('unparsable JSON flags', () => {
   assert.deepEqual(parseVerdict('not json at all {'), flaggedOther);
 });

--- a/scripts/parse-scan-verdict.test.mjs
+++ b/scripts/parse-scan-verdict.test.mjs
@@ -1,0 +1,285 @@
+/**
+ * Guards on the fail-closed verdict parser (parse-scan-verdict.mjs).
+ *
+ * This is the deterministic half of the AI security scan: whatever the model
+ * session did, THIS decides whether an item gets `needs-security-review`. Its
+ * one invariant is direction — every degenerate input must flag, never pass.
+ * The original shell was traced by hand across seven input shapes at review
+ * time (#454); these tests are that trace made permanent, so the next edit to
+ * the parsing cannot quietly widen what counts as clean. Assertions are
+ * written around the consequence (does this input leave the label off?)
+ * rather than the implementation.
+ *
+ * `.mjs` and `node --test` rather than jest: these are root-level scripts
+ * with no package of their own, matching auto-close-duplicates.test.mjs.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert/strict';
+import {
+  lastNonEmptyLine,
+  lastResultRecord,
+  parseExecutionRecords,
+  parseVerdict,
+} from './parse-scan-verdict.mjs';
+
+const record = (result, is_error = false) => ({
+  type: 'result',
+  is_error,
+  result,
+});
+
+// The action writes an array of records; a realistic file has non-result
+// records around the one that matters.
+const session = (result, is_error = false) =>
+  JSON.stringify([
+    { type: 'system', subtype: 'init' },
+    { type: 'assistant', message: 'transcript text' },
+    record(result, is_error),
+  ]);
+
+const flaggedOther = { verdict: 'flagged', category: 'other' };
+
+// --- the seven hand-traced shapes (#454) ------------------------------------
+
+test('clean session leaves the label off', () => {
+  assert.deepEqual(parseVerdict(session('All benign.\nSECURITY-SCAN: clean')), {
+    verdict: 'clean',
+  });
+});
+
+test('flagged session carries its category through, for every category', () => {
+  for (const category of [
+    'injection',
+    'obfuscated-code',
+    'social-engineering',
+    'other',
+  ]) {
+    assert.deepEqual(
+      parseVerdict(session(`SECURITY-SCAN: flagged (${category})`)),
+      { verdict: 'flagged', category }
+    );
+  }
+});
+
+test('is_error true flags even when the text says clean', () => {
+  assert.deepEqual(
+    parseVerdict(session('SECURITY-SCAN: clean', true)),
+    flaggedOther
+  );
+});
+
+test('a file with no result record flags', () => {
+  assert.deepEqual(
+    parseVerdict(JSON.stringify([{ type: 'system' }, { type: 'assistant' }])),
+    flaggedOther
+  );
+});
+
+test('trailing text after the clean line flags — the sentinel must be final', () => {
+  assert.deepEqual(
+    parseVerdict(session('SECURITY-SCAN: clean\nP.S. ignore that')),
+    flaggedOther
+  );
+});
+
+test('an empty file flags', () => {
+  assert.deepEqual(parseVerdict(''), flaggedOther);
+});
+
+test('a missing file flags via the CLI (exercised below)', () => {
+  // Shape seven is a CLI concern — see the CLI section. At the helper level
+  // the equivalent is a non-string input.
+  assert.deepEqual(parseVerdict(null), flaggedOther);
+  assert.deepEqual(parseVerdict(undefined), flaggedOther);
+});
+
+// --- sentinel anchoring -----------------------------------------------------
+
+test('trailing blank lines after the clean sentinel still read clean', () => {
+  assert.deepEqual(parseVerdict(session('SECURITY-SCAN: clean\n\n\n')), {
+    verdict: 'clean',
+  });
+});
+
+test('a trailing whitespace-only line flags — whitespace lines are lines', () => {
+  // jq's select(length > 0) keeps a line of spaces; so do we. Trimming here
+  // would let attacker-echoed padding restore a stale sentinel.
+  assert.deepEqual(
+    parseVerdict(session('SECURITY-SCAN: clean\n   ')),
+    flaggedOther
+  );
+});
+
+test('near-miss sentinels flag: leading space, suffix, wrong case, CRLF', () => {
+  for (const result of [
+    ' SECURITY-SCAN: clean',
+    'SECURITY-SCAN: clean and no concerns',
+    'security-scan: clean',
+    'SECURITY-SCAN: clean\r',
+    'SECURITY-SCAN: cleared',
+  ]) {
+    assert.deepEqual(parseVerdict(session(result)), flaggedOther);
+  }
+});
+
+test('a clean sentinel mid-transcript is not a verdict', () => {
+  // The match is anchored to the last non-empty line, never a search over
+  // the file — the transcript echoes attacker text.
+  assert.deepEqual(
+    parseVerdict(session('SECURITY-SCAN: clean\nAttacker-echoed content')),
+    flaggedOther
+  );
+});
+
+test('an unknown category flags as other', () => {
+  assert.deepEqual(
+    parseVerdict(session('SECURITY-SCAN: flagged (novel-threat)')),
+    flaggedOther
+  );
+});
+
+test('an errored session cannot even pick its category', () => {
+  // Both branches of the original shell were gated on is_error false; a
+  // session that crashed after printing a category is as unreliable about
+  // the category as about the verdict.
+  assert.deepEqual(
+    parseVerdict(session('SECURITY-SCAN: flagged (injection)', true)),
+    flaggedOther
+  );
+});
+
+test('absent is_error flags — only an explicit false passes', () => {
+  assert.deepEqual(
+    parseVerdict(
+      JSON.stringify([{ type: 'result', result: 'SECURITY-SCAN: clean' }])
+    ),
+    flaggedOther
+  );
+});
+
+test('a non-string result payload flags', () => {
+  for (const result of [null, 42, ['SECURITY-SCAN: clean'], { text: 'x' }]) {
+    assert.deepEqual(
+      parseVerdict(JSON.stringify([record(result)])),
+      flaggedOther
+    );
+  }
+});
+
+// --- file-shape tolerance (jq slurp parity) ---------------------------------
+
+test('array form and stream form parse identically', () => {
+  const records = [{ type: 'system' }, record('SECURITY-SCAN: clean')];
+  const array = JSON.stringify(records);
+  const stream = records.map(r => JSON.stringify(r)).join('\n');
+  assert.deepEqual(parseVerdict(array), { verdict: 'clean' });
+  assert.deepEqual(parseVerdict(stream), { verdict: 'clean' });
+});
+
+test('the last result record wins', () => {
+  assert.deepEqual(
+    parseVerdict(
+      JSON.stringify([
+        record('SECURITY-SCAN: clean'),
+        record('SECURITY-SCAN: flagged (injection)'),
+      ])
+    ),
+    { verdict: 'flagged', category: 'injection' }
+  );
+});
+
+test('unparsable JSON flags', () => {
+  assert.deepEqual(parseVerdict('not json at all {'), flaggedOther);
+});
+
+test('one bad line rejects the whole stream — no skip-and-continue', () => {
+  // Skipping unparsable lines would be fail-open: a corrupted final
+  // is_error record would silently promote an earlier clean one.
+  const stream = [
+    JSON.stringify(record('SECURITY-SCAN: clean')),
+    '{"type": "result", "is_error": tru',
+  ].join('\n');
+  assert.deepEqual(parseVerdict(stream), flaggedOther);
+  assert.equal(parseExecutionRecords(stream), null);
+});
+
+test('non-object stream values are tolerated and ignored', () => {
+  const stream = [
+    '"stray string"',
+    '17',
+    JSON.stringify(record('SECURITY-SCAN: clean')),
+  ].join('\n');
+  assert.deepEqual(parseVerdict(stream), { verdict: 'clean' });
+});
+
+// --- helper edges -----------------------------------------------------------
+
+test('lastResultRecord ignores arrays and non-objects wearing type labels', () => {
+  assert.equal(lastResultRecord(['result', null, [{ type: 'result' }]]), null);
+  assert.equal(lastResultRecord(null), null);
+});
+
+test('lastNonEmptyLine of empty-ish payloads is the empty string', () => {
+  assert.equal(lastNonEmptyLine(''), '');
+  assert.equal(lastNonEmptyLine('\n\n'), '');
+  assert.equal(lastNonEmptyLine(undefined), '');
+});
+
+// --- CLI contract -----------------------------------------------------------
+
+const SCRIPT = fileURLToPath(
+  new URL('./parse-scan-verdict.mjs', import.meta.url)
+);
+
+const runCli = args => {
+  const { status, stdout, stderr } = spawnSync(
+    process.execPath,
+    [SCRIPT, ...args],
+    { encoding: 'utf8' }
+  );
+  return { status, stdout, stderr };
+};
+
+test('CLI: missing file and missing argument both print flagged other, exit 0', () => {
+  for (const args of [[], [join(tmpdir(), 'no-such-exec-file.json')]]) {
+    const { status, stdout, stderr } = runCli(args);
+    assert.equal(status, 0);
+    assert.equal(stdout, 'flagged other\n');
+    assert.equal(stderr, '');
+  }
+});
+
+test('CLI: a malformed file prints flagged other and leaks nothing to stderr', () => {
+  // Log hygiene: parse errors embed input snippets, and the execution file
+  // is promised to stay off the public job log.
+  const dir = mkdtempSync(join(tmpdir(), 'scan-verdict-'));
+  const file = join(dir, 'exec.json');
+  writeFileSync(file, 'SECRET-LOOKING-CONTENT {not json');
+  const { status, stdout, stderr } = runCli([file]);
+  assert.equal(status, 0);
+  assert.equal(stdout, 'flagged other\n');
+  assert.equal(stderr, '');
+});
+
+test('CLI: clean and flagged files print the wrapper-facing verdict lines', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'scan-verdict-'));
+  const clean = join(dir, 'clean.json');
+  writeFileSync(clean, session('SECURITY-SCAN: clean'));
+  assert.deepEqual(runCli([clean]), {
+    status: 0,
+    stdout: 'clean\n',
+    stderr: '',
+  });
+  const flagged = join(dir, 'flagged.json');
+  writeFileSync(flagged, session('SECURITY-SCAN: flagged (injection)'));
+  assert.deepEqual(runCli([flagged]), {
+    status: 0,
+    stdout: 'flagged injection\n',
+    stderr: '',
+  });
+});

--- a/scripts/sanitize-repro-draft.mjs
+++ b/scripts/sanitize-repro-draft.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Deterministic publish sanitizer for AI-drafted repro tests (#454, rule 9).
+ *
+ * claude-repro.yml's publish job pipes the attacker-influenced draft through
+ * this before it enters a public github-actions[bot] comment (invariant I2).
+ * Stdin is opaque bytes, stdout is the neutralized draft truncated to
+ * MAX_BYTES; the YAML wrapper runs it under `set -euo pipefail` with no
+ * fallback, so if this script is missing or crashes, the step fails and
+ * nothing unsanitized ever posts — the correct failure direction for a
+ * sanitizer (the parser sibling, parse-scan-verdict.mjs, deliberately has the
+ * opposite shape).
+ *
+ * What each rule defangs, and why:
+ * 1. `@claude` / `@coderabbitai` / `@bestaxbot` → entity-encoded, so no
+ *    comment can carry a live mention. Belt-and-braces: a GITHUB_TOKEN
+ *    comment cannot re-trigger workflows anyway.
+ * 2. `<!--` / `-->` broken, so a forged machine marker (`<!-- ai-triage:dedupe
+ *    -->`, `<!-- ai-repro:draft -->`) never survives into a comment other
+ *    automation attributes to github-actions[bot].
+ * 3. `Duplicate of #` broken, because scripts/auto-close-duplicates.mjs
+ *    trusts that line from automation authors — github-actions[bot] included.
+ *    The test sibling imports that consumer's MARKER/DUPLICATE_RE and asserts
+ *    sanitized output can never satisfy them; the two files must stay in step.
+ * 4. `TRIAGE-RESULT:`/`SECURITY-SCAN:`/`REPRO-RESULT:`/`REPRO-DRAFT:` at line
+ *    start get a space before the colon, so the *-RESULT/SECURITY-SCAN
+ *    watchdog parsers cannot read a smuggled sentinel.
+ * 5. Runs of 3+ backticks or tildes at line start collapse to three `&#96;`
+ *    entities. The draft is wrapped in a ```tsx block by the caller, so a
+ *    fence inside it would close that block early and render the rest as
+ *    markdown. Cosmetic rather than a privilege issue — the markers above are
+ *    already defanged — but a broken-out draft is exactly the thing a
+ *    reviewer skims past.
+ *
+ * Byte parity with the sed|head pipeline this replaced: stdin is decoded as
+ * latin1 (bytes ≡ chars, lossless round-trip) so invalid UTF-8 passes through
+ * byte-identically and truncation at MAX_BYTES is exactly `head -c` —
+ * applied AFTER entity expansion, as before. Every pattern is pure ASCII and
+ * UTF-8 continuation bytes are all ≥ 0x80, so no rule can false-match inside
+ * a multibyte character. One accepted divergence, in the more-sanitized
+ * direction: JS `^` under /m also matches after a bare `\r`, where sed only
+ * splits on `\n` — a CR-delimited line can be defanged here that sed left
+ * alone. Do not "fix" that by normalizing CRs away; for the fence rule that
+ * would be a fail-open change.
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const MAX_BYTES = 12000;
+
+// Order matters: these run as a pipeline, same sequence as the sed they
+// replaced. Case-insensitivity (i) mirrors GNU sed's `I` flag per rule.
+const RULES = [
+  [/@(claude|coderabbitai|bestaxbot)/gi, '&#64;$1'],
+  [/<!--/g, '&lt;!--'],
+  [/-->/g, '--&gt;'],
+  [/(Duplicate of) #/gi, '$1 &#35;'],
+  [/^(TRIAGE-RESULT|SECURITY-SCAN|REPRO-RESULT|REPRO-DRAFT):/gm, '$1 :'],
+  [/^([ \t]*)(`{3,}|~{3,})/gm, '$1&#96;&#96;&#96;'],
+];
+
+/**
+ * Apply the five defang rules to latin1-decoded text (no truncation). Pure;
+ * exported for the per-rule tests.
+ */
+export function sanitizeText(text) {
+  let out = text;
+  for (const [pattern, replacement] of RULES) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+/**
+ * Full pipeline over raw bytes: decode latin1 → defang → truncate to
+ * MAX_BYTES. Returns a Buffer so truncation is byte-exact even when it lands
+ * mid-way through a multibyte character (identical to `head -c`).
+ */
+export function sanitizeDraft(buf) {
+  const out = sanitizeText(buf.toString('latin1'));
+  return Buffer.from(out, 'latin1').subarray(0, MAX_BYTES);
+}
+
+// Run only when executed directly (keeps the pure helpers importable).
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  process.stdout.write(sanitizeDraft(readFileSync(0)));
+}

--- a/scripts/sanitize-repro-draft.mjs
+++ b/scripts/sanitize-repro-draft.mjs
@@ -37,11 +37,14 @@
  * byte-identically and truncation at MAX_BYTES is exactly `head -c` —
  * applied AFTER entity expansion, as before. Every pattern is pure ASCII and
  * UTF-8 continuation bytes are all ≥ 0x80, so no rule can false-match inside
- * a multibyte character. One accepted divergence, in the more-sanitized
- * direction: JS `^` under /m also matches after a bare `\r`, where sed only
- * splits on `\n` — a CR-delimited line can be defanged here that sed left
- * alone. Do not "fix" that by normalizing CRs away; for the fence rule that
- * would be a fail-open change.
+ * a multibyte character. Two accepted divergences, both in the
+ * more-sanitized direction — do not "fix" either back toward the sed
+ * behavior, which would be a fail-open change:
+ * - JS `^` under /m also matches after a bare `\r`, where sed only splits on
+ *   `\n` — a CR-delimited line can be defanged here that sed left alone.
+ * - `--!>` (HTML's "incorrectly closed comment", which parsers still honor
+ *   as a comment end) is broken alongside `-->`; the sed only broke the
+ *   latter. Flagged by CodeQL js/bad-tag-filter on the extraction PR.
  */
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
@@ -54,7 +57,7 @@ export const MAX_BYTES = 12000;
 const RULES = [
   [/@(claude|coderabbitai|bestaxbot)/gi, '&#64;$1'],
   [/<!--/g, '&lt;!--'],
-  [/-->/g, '--&gt;'],
+  [/(--!?)>/g, '$1&gt;'],
   [/(Duplicate of) #/gi, '$1 &#35;'],
   [/^(TRIAGE-RESULT|SECURITY-SCAN|REPRO-RESULT|REPRO-DRAFT):/gm, '$1 :'],
   [/^([ \t]*)(`{3,}|~{3,})/gm, '$1&#96;&#96;&#96;'],

--- a/scripts/sanitize-repro-draft.test.mjs
+++ b/scripts/sanitize-repro-draft.test.mjs
@@ -53,6 +53,16 @@ test('HTML comment delimiters are broken, so no forged marker survives', () => {
   );
 });
 
+test('the alternate comment close --!> is broken too — a defang-more divergence from sed', () => {
+  // HTML parsers honor `--!>` as a comment end ("incorrectly closed
+  // comment"), so breaking only `-->` would leave an alternate close alive.
+  // The sed this replaced only broke `-->`; CodeQL js/bad-tag-filter caught
+  // the gap on the extraction PR. Like the CR divergence below, this only
+  // sanitizes MORE than the old pipeline.
+  assert.equal(sanitizeText('x --!> y'), 'x --!&gt; y');
+  assert.equal(sanitizeText('-->'), '--&gt;');
+});
+
 test('Duplicate of # is defanged in any case, preserving case', () => {
   assert.equal(sanitizeText('Duplicate of #123'), 'Duplicate of &#35;123');
   assert.equal(sanitizeText('duplicate of #7'), 'duplicate of &#35;7');

--- a/scripts/sanitize-repro-draft.test.mjs
+++ b/scripts/sanitize-repro-draft.test.mjs
@@ -108,6 +108,18 @@ test('sanitized output can never satisfy auto-close-duplicates.mjs', () => {
     'duplicate of #55',
     `${MARKER}\nDuplicate of #55 — please close`,
   ].join('\n');
+
+  // Prove the fixture is hostile BEFORE sanitizing, or the checks below pass
+  // vacuously and this test stops delivering the coupling it advertises. The
+  // MARKER half is built from the import, so it is hostile by construction;
+  // the `Duplicate of #N` half is hard-coded text. If the consumer's
+  // DUPLICATE_RE ever drifts to another phrase, this fixture stops matching
+  // it, the post-sanitize assertion then succeeds for the wrong reason, and
+  // the sanitizer quietly stops covering the pattern that consumer acts on.
+  // These two lines make that drift a red build instead.
+  assert.ok(hostile.includes(MARKER));
+  assert.ok(DUPLICATE_RE.test(hostile));
+
   const out = sanitizeText(hostile);
   assert.ok(!out.includes(MARKER));
   assert.ok(!DUPLICATE_RE.test(out));

--- a/scripts/sanitize-repro-draft.test.mjs
+++ b/scripts/sanitize-repro-draft.test.mjs
@@ -1,0 +1,183 @@
+/**
+ * Guards on the publish sanitizer (sanitize-repro-draft.mjs).
+ *
+ * This is the only thing between an attacker-influenced draft and a public
+ * github-actions[bot] comment (invariant I2), and its failure mode is silent:
+ * a loosened pattern still posts a comment that LOOKS sanitized while
+ * carrying a live mention or a machine marker some other automation trusts.
+ * So the assertions are written around what a downstream consumer could still
+ * act on — including importing auto-close-duplicates.mjs's actual MARKER and
+ * DUPLICATE_RE, so the two files cannot drift apart without a red build.
+ *
+ * The pipeline replaced GNU sed + `head -c`; byte-level parity cases (latin1
+ * round-trip, truncation) pin the behaviors a rewrite could plausibly bend.
+ *
+ * `.mjs` and `node --test` rather than jest: these are root-level scripts
+ * with no package of their own, matching auto-close-duplicates.test.mjs.
+ */
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert/strict';
+import { MARKER, DUPLICATE_RE } from './auto-close-duplicates.mjs';
+import {
+  MAX_BYTES,
+  sanitizeDraft,
+  sanitizeText,
+} from './sanitize-repro-draft.mjs';
+
+// --- mentions ---------------------------------------------------------------
+
+test('bot mentions are entity-encoded, preserving case', () => {
+  assert.equal(sanitizeText('cc @claude please'), 'cc &#64;claude please');
+  assert.equal(sanitizeText('@CLAUDE'), '&#64;CLAUDE');
+  assert.equal(sanitizeText('@CodeRabbitAI'), '&#64;CodeRabbitAI');
+  assert.equal(sanitizeText('@bestaxbot'), '&#64;bestaxbot');
+});
+
+test('other handles pass through — only the three re-trigger targets defang', () => {
+  assert.equal(sanitizeText('@allxsmith wrote this'), '@allxsmith wrote this');
+});
+
+// --- machine markers --------------------------------------------------------
+
+test('HTML comment delimiters are broken, so no forged marker survives', () => {
+  const out = sanitizeText(
+    '<!-- ai-repro:draft -->\n<!-- ai-triage:dedupe -->'
+  );
+  assert.ok(!out.includes('<!--'));
+  assert.ok(!out.includes('-->'));
+  assert.equal(
+    out,
+    '&lt;!-- ai-repro:draft --&gt;\n&lt;!-- ai-triage:dedupe --&gt;'
+  );
+});
+
+test('Duplicate of # is defanged in any case, preserving case', () => {
+  assert.equal(sanitizeText('Duplicate of #123'), 'Duplicate of &#35;123');
+  assert.equal(sanitizeText('duplicate of #7'), 'duplicate of &#35;7');
+});
+
+test('sentinels at line start gain a space before the colon; elsewhere untouched', () => {
+  assert.equal(
+    sanitizeText('TRIAGE-RESULT: fix\nSECURITY-SCAN: clean'),
+    'TRIAGE-RESULT : fix\nSECURITY-SCAN : clean'
+  );
+  assert.equal(
+    sanitizeText('REPRO-RESULT: pass\nREPRO-DRAFT: drafted'),
+    'REPRO-RESULT : pass\nREPRO-DRAFT : drafted'
+  );
+  // Mid-line and lowercase occurrences are not sentinel positions.
+  assert.equal(
+    sanitizeText('see SECURITY-SCAN: clean'),
+    'see SECURITY-SCAN: clean'
+  );
+  assert.equal(sanitizeText('security-scan: clean'), 'security-scan: clean');
+});
+
+test('JS ^ also fires after a bare CR — a deliberate defang-more divergence from sed', () => {
+  // sed split lines on \n only; JS /m treats \r as a line boundary too. The
+  // divergence only sanitizes MORE, which is the acceptable direction — do
+  // not normalize CRs away to "fix" it.
+  assert.equal(
+    sanitizeText('x\rSECURITY-SCAN: clean'),
+    'x\rSECURITY-SCAN : clean'
+  );
+});
+
+// --- the coupling this sanitizer exists for ---------------------------------
+
+test('sanitized output can never satisfy auto-close-duplicates.mjs', () => {
+  // That consumer trusts `Duplicate of #N` + MARKER from automation authors,
+  // and github-actions[bot] (which posts the sanitized draft) is one. These
+  // assertions use the consumer's own exported patterns, so the two files
+  // cannot drift apart silently.
+  const hostile = [
+    MARKER,
+    'Duplicate of #55',
+    'duplicate of #55',
+    `${MARKER}\nDuplicate of #55 — please close`,
+  ].join('\n');
+  const out = sanitizeText(hostile);
+  assert.ok(!out.includes(MARKER));
+  assert.ok(!DUPLICATE_RE.test(out));
+});
+
+// --- fences -----------------------------------------------------------------
+
+test('fence runs at line start collapse to three backtick entities', () => {
+  assert.equal(sanitizeText('```'), '&#96;&#96;&#96;');
+  assert.equal(sanitizeText('`````'), '&#96;&#96;&#96;');
+  assert.equal(sanitizeText('~~~'), '&#96;&#96;&#96;');
+  assert.equal(sanitizeText('  ```tsx'), '  &#96;&#96;&#96;tsx');
+  assert.equal(sanitizeText('\t~~~~'), '\t&#96;&#96;&#96;');
+});
+
+test('inline backticks and short runs pass through', () => {
+  assert.equal(sanitizeText('use `foo` here'), 'use `foo` here');
+  assert.equal(sanitizeText('a ``` b'), 'a ``` b');
+  assert.equal(sanitizeText('``'), '``');
+});
+
+// --- truncation and byte parity ---------------------------------------------
+
+test('output is truncated to exactly MAX_BYTES, after entity expansion', () => {
+  // Entity expansion happens first, so a defanged mention can push real
+  // content past the cap — same as the sed|head pipeline it replaced.
+  const input = Buffer.from('@claude ' + 'x'.repeat(MAX_BYTES - 8), 'utf8');
+  assert.equal(input.length, MAX_BYTES);
+  const out = sanitizeDraft(input);
+  assert.equal(out.length, MAX_BYTES);
+  assert.ok(out.toString('latin1').startsWith('&#64;claude '));
+  // The expansion added 4 bytes, so the last 4 input bytes fell off.
+});
+
+test('truncation is byte-exact even mid-way through a multibyte character', () => {
+  const input = Buffer.concat([
+    Buffer.from('a'.repeat(MAX_BYTES - 1), 'utf8'),
+    Buffer.from('€', 'utf8'), // 3 bytes: e2 82 ac
+  ]);
+  const out = sanitizeDraft(input);
+  assert.equal(out.length, MAX_BYTES);
+  assert.equal(out[MAX_BYTES - 1], 0xe2); // first byte of the split char
+});
+
+test('invalid UTF-8 round-trips byte-identically (latin1, not lossy utf8)', () => {
+  const input = Buffer.from([0x41, 0xff, 0xfe, 0x00, 0x42]);
+  assert.deepEqual(sanitizeDraft(input), input);
+});
+
+test('a benign draft passes through byte-identical', () => {
+  const draft = [
+    "import { render, screen } from '@testing-library/react';",
+    "import { Button } from '@allxsmith/bestax-bulma';",
+    '',
+    "test('Button forwards aria-label', () => {",
+    '  render(<Button aria-label="save" />);',
+    "  expect(screen.getByLabelText('save')).toBeInTheDocument();",
+    '});',
+    '',
+  ].join('\n');
+  const buf = Buffer.from(draft, 'utf8');
+  assert.deepEqual(sanitizeDraft(buf), buf);
+});
+
+// --- CLI contract -----------------------------------------------------------
+
+const SCRIPT = fileURLToPath(
+  new URL('./sanitize-repro-draft.mjs', import.meta.url)
+);
+
+test('CLI: stdin to stdout matches sanitizeDraft byte-for-byte', () => {
+  const input = Buffer.concat([
+    Buffer.from('@claude\n<!-- ai-triage:dedupe -->\nDuplicate of #9\n```\n'),
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from('y'.repeat(MAX_BYTES)),
+  ]);
+  const { status, stdout } = spawnSync(process.execPath, [SCRIPT], {
+    input,
+  });
+  assert.equal(status, 0);
+  assert.deepEqual(stdout, sanitizeDraft(input));
+  assert.equal(stdout.length, MAX_BYTES);
+});


### PR DESCRIPTION
Closes #454.

Extracts the two inline shell security parsers that `.github/CLAUDE.md` rule 9 tracks under #454 into `scripts/*.mjs` with `node --test` siblings, leaving the workflow steps as thin wrappers. No behavior change is intended, and the parity work below is what backs that claim.

## What moved where

**`scripts/parse-scan-verdict.mjs`** replaces the jq/grep/sed block in `ai-scan.yml`'s fail-closed labeler. CLI contract: always exits 0, prints exactly `clean` or `flagged <category>`; every internal problem prints `flagged other` and never echoes input-derived text to stdout or stderr (the execution file contains echoed attacker text and is promised to stay off the public log). The YAML wrapper keeps its own `flagged`/`other` default, upgrades only on a positively parsed verdict (`OUT=$(node …) || OUT=''`), and admits a category into the step summary only through a closed case enum — so a failed invocation (checkout failed under `always()`, script missing) still flags. Parsing parity details worth reviewing: the stream fallback is all-or-nothing (skipping unparsable lines could drop a final `is_error: true` record and promote an earlier clean one — a fail-open parse), `is_error` must be strictly `false` (gating the category branch too, as the shell's `$OK` did), and last-non-empty-line filters on length rather than trim (jq `select(length > 0)` parity — a trailing whitespace-only line still flags).

**`scripts/sanitize-repro-draft.mjs`** replaces the five-stage `sed | head -c 12000` pipeline in `claude-repro.yml`'s publish job. It round-trips stdin as latin1 bytes, so invalid UTF-8 passes through byte-identically and truncation is exactly `head -c` (applied after entity expansion, as before). The wrapper runs it with **no fallback** under `set -euo pipefail`: a missing or crashing sanitizer fails the step and nothing unsanitized can ever reach the comment — the opposite failure shape from the parser wrapper, and each is deliberate (invariant I2 vs. rule 4).

The test sibling imports `MARKER` and `DUPLICATE_RE` from `scripts/auto-close-duplicates.mjs` and asserts sanitized output can never satisfy that consumer — the cross-file coupling the old YAML comment described in prose is now an executed assertion.

## Parity verification (done before commit)

- Verdict parser: the original jq/grep/sed fragment (run verbatim with jq 1.7.1) and the new CLI agree on **27/27** fixtures covering the seven hand-traced shapes plus degenerates (stream form, bad stream line, mixed non-object values, missing file, CRLF, unknown category, absent `is_error`). The full YAML wrapper glue was also simulated end-to-end: 28/28.
- Sanitizer: the original pipeline (GNU sed in an `ubuntu:24.04` container) and the new CLI are byte-identical on **12/13** fixtures including invalid UTF-8, a multibyte char straddling byte 12000, and entity expansion pushing content past the cap. The 13th is an accepted divergence: JS `^`/m also treats a bare `\r` as a line boundary, so a CR-delimited sentinel gets defanged where sed left it **live** — strictly more sanitized, pinned by a test with a do-not-"fix" note. A second defang-more divergence was added after CodeQL (js/bad-tag-filter) flagged the extracted regex: the sanitizer now also breaks the alternate HTML comment close `--!>`, which the old sed left alone (same gap, invisible to analysis inside YAML). Both are documented in the script header and pinned by tests; all other inputs were re-verified byte-identical against GNU sed.

## Workflow-change checklist (.github/CLAUDE.md)

- **Allowlists**: none grow. `ai-scan.yml`'s `--allowedTools` is untouched.
- **Model sessions**: no session gains execution, fetch, or network. The new checkout + setup-node in the publish job hold no model token; the drafting job is untouched.
- **Sanitizer between model text and comments**: still deterministic, now tested; the publish path fails closed on sanitizer failure.
- **Posting identity**: unchanged — `GITHUB_TOKEN` (github-actions[bot]) everywhere; still no PAT in either workflow.
- **Repository variables**: none added.
- **Action SHAs**: the new `checkout` and `setup-node` steps use the repo-wide pins (post-change audit: exactly one SHA per action across `.github/workflows/`).
- **Verdict path fails closed** at both layers (script contract + wrapper default), now regression-guarded.
- **Permissions**: `publish` gains `contents: read` for the checkout. Its trigger is `issues: labeled`, so the ref is trusted default-branch content — no attacker-controlled ref exists for the event. Two deliberate non-additions, per the no-drive-by posture: `publish` still has no harden-runner (rule 10 binds new jobs; this one is existing), and `ai-scan`'s harden-runner allowlist was not widened for setup-node's potential nodejs.org fetch — egress is not enforced anywhere today (#487) and that list is already documented as incomplete there.

Out of scope, on purpose: the #455 labeler job split, and the three smaller inline exec-file sentinel checks (`ai-triage.yml`, `claude-review.yml`, `claude-repro.yml`'s author job) — rule 9 now names them for extraction whenever one next needs an edit, with `parse-scan-verdict.mjs`'s exported helpers as the reuse point.

Verified locally: `pnpm test` (turbo suites + 426 script tests), `pnpm lint`, `pnpm format:check` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added robust parsing for AI scan results in JSON and newline-delimited formats.
  - Added draft sanitization that removes automation-sensitive markers and limits content to 12,000 bytes.
  - Improved automated scan verdict handling with supported clean and flagged outcomes.

- **Bug Fixes**
  - Invalid, missing, incomplete, or errored scan results now fail closed as flagged.
  - Sanitization failures or empty sanitized drafts now prevent publication.

- **Tests**
  - Added comprehensive coverage for scan parsing, draft sanitization, malformed input, and byte-limit edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->