### PR TITLE
refactor(bestax-migrate): extract resolveBooleanish and sweep the six booleanish-literal sites

### DIFF
--- a/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/field-multiline-literals.input.tsx
+++ b/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/field-multiline-literals.input.tsx
@@ -1,0 +1,15 @@
+import { Form } from 'react-bulma-components';
+
+export function Fields({ isMultiline }: { isMultiline: boolean }) {
+  return (
+    <div>
+      <Form.Field multiline={false} />
+      <Form.Field kind="group" multiline={false} />
+      <Form.Field kind="group" align="right" multiline={false} />
+      <Form.Field kind="addons" multiline={false} />
+      <Form.Field multiline={isMultiline} />
+      <Form.Field kind="group" multiline={isMultiline} />
+      <Form.Field kind="addons" multiline={isMultiline} />
+    </div>
+  );
+}

--- a/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/field-multiline-literals.output.tsx
+++ b/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/field-multiline-literals.output.tsx
@@ -1,0 +1,16 @@
+import { Field } from "@allxsmith/bestax-bulma";
+
+export function Fields({ isMultiline }: { isMultiline: boolean }) {
+  // TODO(bestax-migrate): `multiline` has a dynamic value; resolve the bestax `grouped`/`hasAddons` combination by hand
+  return (
+    <div>
+      <Field />
+      <Field grouped />
+      <Field grouped="right" />
+      <Field hasAddons />
+      <Field multiline={isMultiline} />
+      <Field multiline={isMultiline} grouped />
+      <Field multiline={isMultiline} hasAddons />
+    </div>
+  );
+}

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/jsx-utils.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/jsx-utils.test.ts
@@ -8,6 +8,7 @@ import {
   makeAttr,
   plainElement,
   removeAttr,
+  resolveBooleanish,
 } from '../jsx-utils.js';
 
 const j = jscodeshift.withParser('tsx');
@@ -74,6 +75,22 @@ describe('attribute helpers', () => {
     expect(attributesOf(el)).toHaveLength(1);
     removeAttr(el, findAttr(el, 'a'));
     expect(findAttr(el, 'a')).toBeUndefined();
+  });
+});
+
+describe('resolveBooleanish', () => {
+  it("resolves every statically-known literal by truthiness, matching RBC's `!!value`", () => {
+    const el = firstElement(
+      '<X bare a={true} b={false} c="true" d="" e={1} f={0} g={cond} />;'
+    );
+    expect(resolveBooleanish(findAttr(el, 'bare'))).toBe('truthy');
+    expect(resolveBooleanish(findAttr(el, 'a'))).toBe('truthy');
+    expect(resolveBooleanish(findAttr(el, 'b'))).toBe('falsy');
+    expect(resolveBooleanish(findAttr(el, 'c'))).toBe('truthy');
+    expect(resolveBooleanish(findAttr(el, 'd'))).toBe('falsy');
+    expect(resolveBooleanish(findAttr(el, 'e'))).toBe('truthy');
+    expect(resolveBooleanish(findAttr(el, 'f'))).toBe('falsy');
+    expect(resolveBooleanish(findAttr(el, 'g'))).toBe('expression');
   });
 });
 

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/transform.test.ts
@@ -507,6 +507,104 @@ describe('react-bulma-components transform fixtures', () => {
       });
       expect(todos.some(t => t.rule === 'prop:title')).toBe(true);
     });
+
+    it('resolves a truthy string `booleanToProp` literal instead of taking the dynamic-TODO branch', () => {
+      const source = [
+        "import { Button } from 'react-bulma-components';",
+        'export const A = () => <Button rounded="true">Save</Button>;',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(transform, 'button-rounded.tsx', source, {
+        add: entry => todos.push(entry),
+      });
+      expect(output).toContain('isRounded');
+      expect(output).not.toContain('rounded=');
+      expect(todos.some(t => t.rule === 'prop:rounded')).toBe(false);
+    });
+
+    it('drops a falsy string `booleanToProp` literal instead of taking the dynamic-TODO branch', () => {
+      const source = [
+        "import { Button } from 'react-bulma-components';",
+        'export const A = () => <Button rounded="">Save</Button>;',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(
+        transform,
+        'button-unrounded.tsx',
+        source,
+        {
+          add: entry => todos.push(entry),
+        }
+      );
+      expect(output).not.toContain('rounded');
+      expect(output).not.toContain('isRounded');
+      expect(todos.some(t => t.rule === 'prop:rounded')).toBe(false);
+    });
+
+    it('resolves a static string/number Panel.Tabs.Tab `active` by truthiness, not a TODO', () => {
+      const source = [
+        "import { Panel } from 'react-bulma-components';",
+        'export const A = () => (',
+        '  <Panel>',
+        '    <Panel.Tabs>',
+        '      <Panel.Tabs.Tab active="true">All</Panel.Tabs.Tab>',
+        '      <Panel.Tabs.Tab active={0}>None</Panel.Tabs.Tab>',
+        '    </Panel.Tabs>',
+        '  </Panel>',
+        ');',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(transform, 'panel-tabs.tsx', source, {
+        add: entry => todos.push(entry),
+      });
+      expect(output).toContain('className="is-active">All');
+      expect(output).toContain('>None</a>');
+      expect(todos.some(t => t.rule === 'prop:active')).toBe(false);
+    });
+
+    it('resolves a static string Breadcrumb.Item `active` by truthiness, not a TODO', () => {
+      const source = [
+        "import { Breadcrumb } from 'react-bulma-components';",
+        'export const A = () => (',
+        '  <Breadcrumb>',
+        '    <Breadcrumb.Item active="true" href="/here">Here</Breadcrumb.Item>',
+        '  </Breadcrumb>',
+        ');',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(transform, 'breadcrumb.tsx', source, {
+        add: entry => todos.push(entry),
+      });
+      expect(output).toContain('<li className="is-active">');
+      expect(todos.some(t => t.rule === 'prop:active')).toBe(false);
+    });
+
+    it('drops a falsy `multiline={false}` by value instead of by presence', () => {
+      const source = [
+        "import { Form } from 'react-bulma-components';",
+        'export const A = () => <Form.Field multiline={false} />;',
+      ].join('\n');
+      const { output } = runTransform(transform, 'field-false.tsx', source);
+      // Presence-only classification would wrongly grant `grouped="multiline"`
+      // to a falsy value; resolving by value drops it like an absent prop.
+      expect(output).toContain('<Field />');
+      expect(output).not.toContain('grouped');
+    });
+
+    it('keeps a dynamic Field `multiline` on the element with a TODO instead of dropping it', () => {
+      const source = [
+        "import { Form } from 'react-bulma-components';",
+        'export const A = ({ wrap }: { wrap: boolean }) => (',
+        '  <Form.Field kind="group" multiline={wrap} />',
+        ');',
+      ].join('\n');
+      const todos: TodoEntry[] = [];
+      const { output } = runTransform(transform, 'field-dynamic.tsx', source, {
+        add: entry => todos.push(entry),
+      });
+      expect(output).toContain('multiline={wrap}');
+      expect(todos.some(t => t.rule === 'prop:multiline')).toBe(true);
+    });
   });
 
   describe('stylesheet imports', () => {

--- a/bestax-migrate/src/sources/react-bulma-components/jsx-utils.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/jsx-utils.ts
@@ -116,6 +116,23 @@ export function literalValueOf(attr: any): LiteralValue {
   return { kind: 'expression' };
 }
 
+export type Booleanish = 'truthy' | 'falsy' | 'expression';
+
+/**
+ * Classify a JSX attribute by the truthiness RBC evaluates it with at
+ * runtime (`!!value`): every statically-known literal (boolean, string, or
+ * number) resolves to `'truthy'`/`'falsy'`; only a genuine expression is
+ * `'expression'`. This is the single place the six call sites that branch on
+ * a "booleanish" prop (Button `remove`, Heading `heading`/`subtitle`,
+ * `booleanToProp`, the `active` ladders, Field `multiline`) agree on what
+ * counts as resolvable, so they can't drift out of sync with each other.
+ */
+export function resolveBooleanish(attr: any): Booleanish {
+  const literal = literalValueOf(attr);
+  if (literal.kind === 'expression') return 'expression';
+  return literal.value ? 'truthy' : 'falsy';
+}
+
 /** Create `name` (bare boolean) or `name="value"` attribute. */
 export function makeAttr(j: JSCodeshift, name: string, value?: string): any {
   return j.jsxAttribute(

--- a/bestax-migrate/src/sources/react-bulma-components/props.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/props.ts
@@ -14,6 +14,7 @@ import {
   literalValueOf,
   makeAttr,
   removeAttr,
+  resolveBooleanish,
   type TransformContext,
 } from './jsx-utils.js';
 
@@ -110,11 +111,12 @@ export function applyPropAction(
 
   if (action.booleanToProp) {
     const { name, value } = action.booleanToProp;
-    if (literal.kind === 'boolean' && literal.value === true) {
+    const resolved = resolveBooleanish(attr);
+    if (resolved === 'truthy') {
       removeAttr(element, attr);
       addConverted(ctx, path, element, originalName, name, value);
       ctx.dirty = true;
-    } else if (literal.kind === 'boolean' && literal.value === false) {
+    } else if (resolved === 'falsy') {
       removeAttr(element, attr);
       ctx.dirty = true;
     } else if (value === undefined) {

--- a/bestax-migrate/src/sources/react-bulma-components/specials.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/specials.ts
@@ -20,6 +20,7 @@ import {
   makeAttr,
   plainElement,
   removeAttr,
+  resolveBooleanish,
   type TransformContext,
 } from './jsx-utils.js';
 
@@ -213,14 +214,14 @@ const SPECIALS: Record<string, SpecialHandler> = {
   button(ctx, path, element) {
     const attr = findAttr(element, 'remove');
     if (!attr) return {};
-    const literal = literalValueOf(attr);
-    if (literal.kind !== 'expression') {
+    const resolved = resolveBooleanish(attr);
+    if (resolved !== 'expression') {
       // A statically-known value always renders the same at runtime: truthy
       // (`remove`, `remove={true}`, `remove="true"`) → `<Delete />`; falsy
       // (`remove={false}`, `remove=""`, `remove={0}`) → just drop the prop.
       removeAttr(element, attr);
       ctx.dirty = true;
-      return literal.value ? { target: 'Delete' } : {};
+      return resolved === 'truthy' ? { target: 'Delete' } : {};
     }
     addTodo(
       ctx,
@@ -250,16 +251,18 @@ const SPECIALS: Record<string, SpecialHandler> = {
   heading(ctx, path, element) {
     const headingAttr = findAttr(element, 'heading');
     const subtitleAttr = findAttr(element, 'subtitle');
-    const headingLit = headingAttr ? literalValueOf(headingAttr) : undefined;
-    const subtitleLit = subtitleAttr ? literalValueOf(subtitleAttr) : undefined;
-    const headingDynamic = headingLit?.kind === 'expression';
-    const subtitleDynamic = subtitleLit?.kind === 'expression';
+    const headingResolved = headingAttr
+      ? resolveBooleanish(headingAttr)
+      : undefined;
+    const subtitleResolved = subtitleAttr
+      ? resolveBooleanish(subtitleAttr)
+      : undefined;
+    const headingDynamic = headingResolved === 'expression';
+    const subtitleDynamic = subtitleResolved === 'expression';
     // A resolvable literal (boolean/string/number) collapses to its runtime
     // truthiness; an expression stays dynamic.
-    const headingTruthy =
-      !!headingLit && headingLit.kind !== 'expression' && !!headingLit.value;
-    const subtitleTruthy =
-      !!subtitleLit && subtitleLit.kind !== 'expression' && !!subtitleLit.value;
+    const headingTruthy = headingResolved === 'truthy';
+    const subtitleTruthy = subtitleResolved === 'truthy';
 
     // Dynamic values can't be resolved to a target: leave the prop on the
     // element (so its expression survives for hand-splitting) plus a TODO.
@@ -317,12 +320,12 @@ const SPECIALS: Record<string, SpecialHandler> = {
     // A resolvable literal `heading` that didn't collapse (falsy, or truthy
     // but blocked by a dynamic subtitle) behaves as if the prop were absent —
     // drop it. A dynamic `heading` stays put (its TODO is already filed above).
-    if (headingLit && !headingDynamic) {
+    if (headingAttr && !headingDynamic) {
       removeAttr(element, headingAttr);
       ctx.dirty = true;
     }
 
-    if (subtitleLit && !subtitleDynamic) {
+    if (subtitleAttr && !subtitleDynamic) {
       removeAttr(element, subtitleAttr);
       ctx.dirty = true;
       return { target: subtitleTruthy ? 'SubTitle' : 'Title' };
@@ -481,22 +484,49 @@ const SPECIALS: Record<string, SpecialHandler> = {
         'prop:kind',
         'dynamic Field kind/align; map to the bestax `grouped` / `hasAddons` props by hand'
       );
-      return {};
+      // This handler owns `multiline` end-to-end; without this, the mapping's
+      // fallback `multiline: { drop: true }` prop action would silently strip
+      // a dynamic `multiline` the moment kind/align themselves are dynamic.
+      return { handledProps: ['multiline'] };
     }
 
-    for (const attr of [kindAttr, alignAttr, multilineAttr]) {
+    // `multiline` is a value, not just presence: a falsy literal drops it
+    // (same as it being absent) and a dynamic value must survive on the
+    // element — so, unlike `kind`/`align`, it's only stripped once resolved.
+    const multilineResolved = multilineAttr
+      ? resolveBooleanish(multilineAttr)
+      : null;
+    const multilineDynamic = multilineResolved === 'expression';
+    const multilineTruthy = multilineResolved === 'truthy';
+
+    const kindOrAlignPresent = Boolean(kindAttr || alignAttr);
+    for (const attr of [kindAttr, alignAttr]) {
       if (attr) removeAttr(element, attr);
     }
-    ctx.dirty = true;
+    if (multilineAttr && !multilineDynamic) {
+      removeAttr(element, multilineAttr);
+    }
+    if (kindOrAlignPresent || (multilineAttr && !multilineDynamic)) {
+      ctx.dirty = true;
+    }
 
     const alignValue =
       align && align.kind === 'string'
         ? { center: 'centered', right: 'right' }[align.value]
         : undefined;
 
+    if (multilineDynamic) {
+      addTodo(
+        ctx,
+        path,
+        'prop:multiline',
+        '`multiline` has a dynamic value; resolve the bestax `grouped`/`hasAddons` combination by hand'
+      );
+    }
+
     if (kind && kind.kind === 'string' && kind.value === 'addons') {
       addAttr(element, makeAttr(ctx.j, 'hasAddons', alignValue));
-      if (multilineAttr) {
+      if (multilineTruthy) {
         addTodo(
           ctx,
           path,
@@ -504,10 +534,10 @@ const SPECIALS: Record<string, SpecialHandler> = {
           "`multiline` only combines with kind='group' in Bulma; dropped from this addons Field"
         );
       }
-      return {};
+      return { handledProps: ['multiline'] };
     }
     // kind='group' (or a stray multiline/align without kind)
-    if (multilineAttr) {
+    if (multilineTruthy) {
       addAttr(element, makeAttr(ctx.j, 'grouped', 'multiline'));
       if (alignValue) {
         addTodo(
@@ -518,10 +548,10 @@ const SPECIALS: Record<string, SpecialHandler> = {
             alignValue
         );
       }
-    } else {
+    } else if (kindOrAlignPresent) {
       addAttr(element, makeAttr(ctx.j, 'grouped', alignValue));
     }
-    return {};
+    return { handledProps: ['multiline'] };
   },
 
   /** Form.Label → plain <label className="label">. */
@@ -707,21 +737,18 @@ const SPECIALS: Record<string, SpecialHandler> = {
     const activeAttr = findAttr(element, 'active');
     let className: string | undefined;
     if (activeAttr) {
-      const literal = literalValueOf(activeAttr);
-      if (literal.kind === 'boolean' && literal.value === true) {
+      const resolved = resolveBooleanish(activeAttr);
+      if (resolved === 'truthy') {
         className = 'is-active';
-        removeAttr(element, activeAttr);
-      } else if (literal.kind === 'boolean') {
-        removeAttr(element, activeAttr);
-      } else {
+      } else if (resolved === 'expression') {
         addTodo(
           ctx,
           path,
           'prop:active',
           "dynamic Panel.Tabs.Tab active; set className={active ? 'is-active' : undefined} by hand"
         );
-        removeAttr(element, activeAttr);
       }
+      removeAttr(element, activeAttr);
     }
     className = mergeClassName(ctx, path, element, className, 'Panel.Tabs.Tab');
     const rest = stripModifierProps(
@@ -743,10 +770,9 @@ const SPECIALS: Record<string, SpecialHandler> = {
     const activeAttr = findAttr(element, 'active');
     let liClass: string | undefined;
     if (activeAttr) {
-      const literal = literalValueOf(activeAttr);
-      if (literal.kind === 'boolean' && literal.value === true)
-        liClass = 'is-active';
-      else if (literal.kind !== 'boolean') {
+      const resolved = resolveBooleanish(activeAttr);
+      if (resolved === 'truthy') liClass = 'is-active';
+      else if (resolved === 'expression') {
         addTodo(
           ctx,
           path,


### PR DESCRIPTION
## Summary

Introduces `resolveBooleanish(attr)` in `jsx-utils.ts`, returning `'truthy' | 'falsy' | 'expression'` by resolving every statically-known literal by truthiness (matching RBC's runtime `!!value`), and rewires all six sites onto it so the classification lives in exactly one place:

1. Button `remove` (`specials.ts`) — drop-in classification swap.
2. Heading `heading` (`specials.ts`) — drop-in classification swap.
3. Heading `subtitle` (`specials.ts`) — drop-in classification swap.
4. `booleanToProp` (`props.ts`) — fixes drift #4: a truthy string literal (e.g. `rounded="true"`) previously fell into the dynamic-TODO branch instead of resolving; now it resolves like every other site.
5. `panel-tab` / `breadcrumb-item` `active` ladders (`specials.ts`) — same classification now shared; a static string/number literal (e.g. `active="true"`) resolves instead of being misclassified as dynamic.
6. `field` `multiline` (`specials.ts`) — the presence-vs-value bug: `multiline={false}` and `multiline={expr}` both used to silently become `grouped="multiline"`. Restructured per the issue's trap notes:
   - the attr-strip loop is now conditional — a dynamic `multiline` survives on the element instead of always being stripped
   - falsy `multiline` with no `kind`/`align` now emits nothing (previously fell through to a bare `grouped` attribute)
   - the addons "dropped from this addons Field" TODO only fires for the resolved-truthy case; falsy gets no TODO; dynamic gets a generic "resolve the `grouped`/`hasAddons` combination by hand" TODO
   - `ctx.dirty` is only set when something in the element actually changed
   - every return path now includes `handledProps: ['multiline']` — without it, the mapping's fallback `multiline: { drop: true }` prop action was silently stripping the dynamic attr right after the special handler decided to keep it (caught this via the new test fixture)

For the open question in the issue's site-6 notes (dynamic `multiline` on an addons Field), went with keeping the attr + a TODO — matching how the `heading` handler treats its own dynamic case — rather than dropping it with the incompatibility TODO.

## Test plan

- [x] New fixture pair `__testfixtures__/field-multiline-literals.{input,output}.tsx` covering the falsy/dynamic × group/addons matrix for site 6
- [x] Direct unit test for `resolveBooleanish` in `jsx-utils.test.ts`
- [x] New unit tests in `transform.test.ts` for the `booleanToProp` drift fix (site 4) and the `active`-ladder classification fix (site 5)
- [x] Confirmed all existing fixtures (`edge-cases-2`, `form`) are byte-identical — no churn
- [x] `pnpm --filter bestax-migrate run lint` — pass
- [x] `pnpm --filter bestax-migrate run typecheck` — pass
- [x] `pnpm --filter bestax-migrate run test:coverage` — pass (271 tests)
- [x] `pnpm run format:check` — pass
- [x] `pnpm run gen:catalog:check` — pass
- [x] `pnpm run check:conformance` — pass

Fixes #563

Generated with [Claude Code](https://claude.ai/code)