### PR TITLE
feat(bestax-mcp): surface CSS variables from get_component's default answer

### DIFF
--- a/bestax-mcp/src/__tests__/format.test.ts
+++ b/bestax-mcp/src/__tests__/format.test.ts
@@ -85,3 +85,32 @@ describe('renderComponent link line', () => {
     );
   });
 });
+
+describe('renderComponent CSS variable pointer', () => {
+  // Issue #501: get_css_variables reached 1/10 MCP-only builders in an eval arm where
+  // every run themed the site by hand. The routing fix is a pointer at `include`, not a
+  // separate tool call the builder has to already know to make.
+  it('names the count and points at include when cssVars is not requested', async () => {
+    const record = await loadComponent('Button');
+    const out = renderComponent(record, ['props']);
+    expect(out).not.toContain('## CSS Variables');
+    expect(out).toContain(
+      `\`Button\` has ${record.cssVars.length} CSS variables for theming`
+    );
+    expect(out).toContain('include: ["cssVars"]');
+  });
+
+  it('says nothing when cssVars is already included', async () => {
+    const record = await loadComponent('Button');
+    const out = renderComponent(record, ['props', 'cssVars']);
+    expect(out).toContain('## CSS Variables');
+    expect(out).not.toContain('for theming — pass');
+  });
+
+  it('says nothing for a component with no CSS variables', async () => {
+    const record = await loadComponent('Block');
+    expect(record.cssVars).toHaveLength(0);
+    const out = renderComponent(record, ['props']);
+    expect(out).not.toContain('CSS variable');
+  });
+});

--- a/bestax-mcp/src/__tests__/server.test.ts
+++ b/bestax-mcp/src/__tests__/server.test.ts
@@ -362,6 +362,35 @@ describe('get_component', () => {
     expect(out).toMatch(/Docs: https:\/\/\S+\?utm_source=bestax-mcp/);
     expect(out).toMatch(/Storybook: https:\/\/\S+&utm_source=bestax-mcp/);
   });
+
+  // Issue #501: get_css_variables reached 1/10 MCP-only builders in an eval arm where
+  // every run themed the site. get_component can already serve the variables on the call
+  // being made (`include: ["cssVars"]`), so the default answer names the count and points
+  // there instead of requiring a builder to already know a second tool exists.
+  describe('surfaces CSS variables without a second tool call', () => {
+    it('names the count and the include option by default', async () => {
+      const out = text(await call('get_component', { name: 'Button' }));
+      expect(out).toMatch(/`Button` has \d+ CSS variables? for theming/);
+      expect(out).toContain('include: ["cssVars"]');
+      expect(out).not.toContain('## CSS Variables');
+    });
+
+    it('says nothing once cssVars is already included', async () => {
+      const out = text(
+        await call('get_component', {
+          name: 'Button',
+          include: ['props', 'cssVars'],
+        })
+      );
+      expect(out).toContain('## CSS Variables');
+      expect(out).not.toContain('for theming — pass');
+    });
+
+    it('says nothing for a component with no CSS variables', async () => {
+      const out = text(await call('get_component', { name: 'Block' }));
+      expect(out).not.toContain('CSS variable');
+    });
+  });
 });
 
 describe('get_props', () => {

--- a/bestax-mcp/src/format.ts
+++ b/bestax-mcp/src/format.ts
@@ -168,6 +168,16 @@ export function renderComponent(
   }
   if (include.includes('cssVars') && record.cssVars.length) {
     out.push('## CSS Variables', renderCssVars(record.cssVars));
+  } else if (record.cssVars.length) {
+    // Routing, not a second tool call: get_component can already serve this on the
+    // call being made, so the fix is a pointer at `include`, not at get_css_variables.
+    // A 20-run eval (issue #501) found get_css_variables reached 1/10 MCP-only builders
+    // in an arm where every one themed the site by hand instead.
+    out.push(
+      `\`${record.name}\` has ${record.cssVars.length} CSS variable${
+        record.cssVars.length === 1 ? '' : 's'
+      } for theming — pass \`include: ["cssVars"]\` to see them.`
+    );
   }
   if (include.includes('accessibility') && record.accessibility) {
     out.push('## Accessibility', record.accessibility);

--- a/docs/docs/guides/llms/index.md
+++ b/docs/docs/guides/llms/index.md
@@ -121,7 +121,9 @@ Start with `list_components` — its output names the tool to call next. Reach f
 
 It also exposes each skill as an MCP **prompt** (`theming`, `form`, `layout-scaffold`, …) and
 serves `bestax://catalog`, `bestax://components/{name}` and `bestax://skills/{name}` as
-**resources**.
+**resources** — useful in clients where the _user_ attaches context (`@`-mentioning a
+resource), rather than a channel the model reaches for mid-task the way it does the tools
+above.
 
 ### Offline, and pinned to a version
 


### PR DESCRIPTION
## Summary

Two decisions from #501's adoption data (`eval/agent-loop/runs-v2/aggregate.md`, 20-run campaign):

**1. Routing fix: `get_component` now surfaces CSS variables without a second tool call.** `get_css_variables` reached 1/10 MCP-only builders in an arm where every run themed the site by hand — nine of ten never learned which `--bulma-*` variables a component reads. `get_component` already accepts `include: ["cssVars"]`; the missing piece was that its default answer never mentioned the option existed. It now names the variable count and points at `include: ["cssVars"]` when that section wasn't requested. Per the issue author's follow-up comment, this is deliberately a pointer at the existing `include` option rather than a footer naming `get_css_variables` as a second call — the builder's need is the variables, and `get_component` can already serve them on the call it's making.

**2. Docs framing: resources corrected, not dropped.** `bestax://catalog`, `bestax://components/{name}` and `bestax://skills/{name}` got zero reads across all twenty runs. That's explained structurally — in Claude Code, resources are user-attached (`@`-mention), not pulled by the model mid-task — which says nothing about clients where a user does attach them. `docs/docs/guides/llms/index.md` previously read as though tools, prompts and resources were three equal ways in; it now says resources are for clients where the user attaches context.

Re-measurement is left for a later campaign, opportunistically — not a blocker here.

## Changes

- `bestax-mcp/src/format.ts` — `renderComponent` names the CSS variable count and points at `include: ["cssVars"]` when that section isn't included but the component has variables
- `bestax-mcp/src/__tests__/format.test.ts`, `bestax-mcp/src/__tests__/server.test.ts` — tests for the new pointer, its absence once `cssVars` is included, and its absence for a component with no variables
- `docs/docs/guides/llms/index.md` — reframes the resources sentence

## Test plan

- [x] `pnpm --filter bestax-mcp run lint`
- [x] `pnpm --filter bestax-mcp run typecheck`
- [x] `pnpm --filter bestax-mcp run test:coverage` (215 tests, coverage above thresholds)
- [x] `pnpm run format:check`
- [x] `pnpm run gen:catalog:check`
- [x] `pnpm run gen:mcp:check`
- [x] `pnpm run check:conformance`

Fixes #501

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Component details now indicate when CSS variables are available but not included.
  - Added guidance to request CSS variables using `include: ["cssVars"]`.
  - CSS variable sections remain hidden unless requested, avoiding unnecessary output.

- **Documentation**
  - Clarified how catalog, component, and skill resources can be attached as context in supported clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->