### PR TITLE
TEMP: verification probe for #577 (do not merge)

### DIFF
--- a/.github/workflows/ai-scan.yml
+++ b/.github/workflows/ai-scan.yml
@@ -363,3 +363,4 @@ jobs:
           # the step's non-zero exit is what surfaces it.
           gh api -X POST "repos/$REPO/issues/$NUMBER/labels" \
             -f "labels[]=needs-security-review" >/dev/null
+


### PR DESCRIPTION
Throwaway PR whose only purpose is to fire `ai-scan` on `pull_request: opened` with #577's updated workflow, to confirm the firewall actually initializes after the statsig removal. Will be closed as soon as the run reports. Do not merge.