### PR TITLE
ci: slot-assemble bestaxbot's convergence hand-off message

### DIFF
--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -792,12 +792,14 @@ jobs:
           set -euo pipefail
           TITLE=$(gh pr view "$PR" --repo "$REPO" --json title --jq .title)
           WARN=""
-          # Types and scopes mirror RELEASE_TYPES / RELEASE_SCOPES in
-          # commitlint.config.js. Keep `revert` in both alternations:
-          # commitlint's default ignores skip git-style `Revert "..."`
-          # messages, so this warning is the only net under that title.
-          if echo "$TITLE" | grep -qE '^(feat|fix|perf|refactor|style|revert)' \
-             && ! echo "$TITLE" | grep -qE '^(feat|fix|perf|refactor|style|revert)\((bulma-ui|docs|create-bestax|bestax-migrate|bestax-mcp)\)!?:'; then
+          # The releasing-type/scope decision is parsed in the builder, which
+          # mirrors RELEASE_TYPES / RELEASE_SCOPES and has a node --test
+          # sibling (rule 9); the two greps this replaced matched a bare type
+          # prefix, so "fixture cleanup" warned. Assigned rather than inlined
+          # into `if` so a builder failure trips set -e instead of silently
+          # reading as "no warning".
+          TITLE_CHECK=$(node scripts/handoff-message.mjs --check-title="$TITLE")
+          if [ "$TITLE_CHECK" = warn ]; then
             WARN=$'\n\n:warning: Heads up, the PR title is a releasing commit type with no valid scope — fix it before you squash-merge or semantic-release eats sand.'
           fi
           # $WARN is appended here rather than inside the builder so that

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -753,10 +753,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      contents: read # checkout the message builder
       pull-requests: write # labels + reviewer request
       issues: write # convergence comment
       actions: write # dispatch story-screenshots.yml
     steps:
+      # The sign-off body is assembled by scripts/handoff-message.mjs (rule 9):
+      # the slot pools, and every invariant the comment must still carry, live
+      # there behind a node --test sibling, because nothing in CI lints the
+      # YAML this used to be a literal in. Pinned to main and NEVER the PR
+      # branch: this job also runs on pull_request_review, where the default
+      # checkout ref is refs/pull/N/merge — the PR's own code — and this is the
+      # job holding the re-trigger-capable PAT. Same rule as the gh-thread
+      # staging step above.
+      - name: Checkout main for the message builder
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      # No pnpm, no cache: the builder is dependency-free (node: builtins
+      # only), so plain Node 24 is all it needs.
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+
       - name: Converge and hand off to owner
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -770,13 +792,18 @@ jobs:
           set -euo pipefail
           TITLE=$(gh pr view "$PR" --repo "$REPO" --json title --jq .title)
           WARN=""
-          if echo "$TITLE" | grep -qE '^(feat|fix|perf|refactor|style)' \
-             && ! echo "$TITLE" | grep -qE '^(feat|fix|perf|refactor|style)\((bulma-ui|docs|create-bestax)\)!?:'; then
+          # Types and scopes mirror RELEASE_TYPES / RELEASE_SCOPES in
+          # commitlint.config.js. Keep `revert` in both alternations:
+          # commitlint's default ignores skip git-style `Revert "..."`
+          # messages, so this warning is the only net under that title.
+          if echo "$TITLE" | grep -qE '^(feat|fix|perf|refactor|style|revert)' \
+             && ! echo "$TITLE" | grep -qE '^(feat|fix|perf|refactor|style|revert)\((bulma-ui|docs|create-bestax|bestax-migrate|bestax-mcp)\)!?:'; then
             WARN=$'\n\n:warning: Heads up, the PR title is a releasing commit type with no valid scope — fix it before you squash-merge or semantic-release eats sand.'
           fi
-          GH_TOKEN="$BOT_TOKEN" gh pr comment "$PR" --repo "$REPO" --body "🏄 **Surf's up and I rode the whole set — total convergence, brah.** $ITER iteration(s) in, CI's glassy green, and every AI review thread closed out clean like a perfect barrel. She's ready; I just need a meat sack to paddle over and rubber-stamp it.
-
-          No offense to the carbon-based units, but you fleshbags kept the merge button for yourselves — so @allxsmith, wiggle those opposable thumbs and squash-merge when you're stoked. The loop never merges; apparently 'judgment' is still a squishy-brain-only feature. 🤙$WARN"
+          # $WARN is appended here rather than inside the builder so that
+          # "unchanged, at the very end" stays visible at the call site.
+          BODY=$(node scripts/handoff-message.mjs --pr="$PR" --iter="$ITER")
+          GH_TOKEN="$BOT_TOKEN" gh pr comment "$PR" --repo "$REPO" --body "$BODY$WARN"
           gh pr edit "$PR" --repo "$REPO" --remove-label ai-loop --add-label needs-human-review
           gh pr edit "$PR" --repo "$REPO" --add-reviewer allxsmith || true
           # Screenshots at handoff (#284): label edits via GITHUB_TOKEN fire

--- a/scripts/handoff-message.mjs
+++ b/scripts/handoff-message.mjs
@@ -77,8 +77,13 @@ export const RELEASE_SCOPES = [
   'bestax-mcp',
 ];
 
-/** `type(scope)!: subject` — the same shape commitlint parses. */
-const CONVENTIONAL_HEADER = /^([a-z]+)(?:\(([^)]*)\))?!?:/;
+/**
+ * `type(scope)!: subject` — the same shape commitlint parses. The trailing
+ * space is load-bearing: conventional-commits-parser requires `: `, so
+ * `feat:x` yields type=undefined and semantic-release releases nothing from
+ * it. Flagging it as a scope problem would name the wrong defect.
+ */
+const CONVENTIONAL_HEADER = /^([a-z]+)(?:\(([^)]*)\))?!?: /;
 
 /**
  * True when the PR title would release a package but names no valid scope —

--- a/scripts/handoff-message.mjs
+++ b/scripts/handoff-message.mjs
@@ -45,6 +45,7 @@
  *
  * CLI contract (the YAML wrapper depends on every clause):
  *   node scripts/handoff-message.mjs --pr=<number> --iter=<number>
+ *   node scripts/handoff-message.mjs --check-title=<pr title>   -> warn | ok
  * - Prints the assembled body on stdout and nothing else. The workflow appends
  *   its own `$WARN` after; that is deliberately NOT this script's business, so
  *   "unchanged, at the very end" stays visible at the call site.
@@ -58,6 +59,49 @@ import { pathToFileURL } from 'node:url';
 
 /** Placeholder the status fragments carry, substituted by applyIter(). */
 export const ITER_TOKEN = '$ITER';
+
+/** Mirrors RELEASE_TYPES / RELEASE_SCOPES in commitlint.config.js. */
+export const RELEASE_TYPES = [
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'style',
+  'revert',
+];
+export const RELEASE_SCOPES = [
+  'bulma-ui',
+  'docs',
+  'create-bestax',
+  'bestax-migrate',
+  'bestax-mcp',
+];
+
+/** `type(scope)!: subject` — the same shape commitlint parses. */
+const CONVENTIONAL_HEADER = /^([a-z]+)(?:\(([^)]*)\))?!?:/;
+
+/**
+ * True when the PR title would release a package but names no valid scope —
+ * i.e. when the hand-off comment should carry its :warning:.
+ *
+ * Anchored on the whole conventional header rather than a bare type prefix:
+ * matching `^(feat|fix|...)` alone also flags ordinary prose like "fixture
+ * cleanup" or "reverted flaky change", which semantic-release never parses as
+ * a release at all.
+ *
+ * Residual, the same one commitlint.config.js already documents: a git-style
+ * `Revert "..."` title is not a conventional header, so it is not flagged
+ * here either — yet commit-analyzer's default `{ revert: true, release:
+ * 'patch' }` would still patch-release every package. Reverts have to be kept
+ * conventional and scoped by hand.
+ */
+export function needsScopeWarning(title) {
+  const match = CONVENTIONAL_HEADER.exec(title);
+  if (!match) return false;
+  const [, type, scope] = match;
+  if (!RELEASE_TYPES.includes(type)) return false;
+  return !RELEASE_SCOPES.includes(scope ?? '');
+}
 
 export const SURF = {
   name: 'surf',
@@ -163,7 +207,8 @@ export function buildBody({ pr, iter }) {
 /** Parse argv into { pr, iter }; throws Error(message) on misuse. */
 export function parseArgs(argv) {
   for (const arg of argv)
-    if (!/^--(pr|iter)=/.test(arg)) throw new Error(`Unknown argument: ${arg}`);
+    if (!/^--(pr|iter|check-title)=/.test(arg))
+      throw new Error(`Unknown argument: ${arg}`);
   const flag = name =>
     argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3);
   const int = (name, min) => {
@@ -172,12 +217,22 @@ export function parseArgs(argv) {
     if (!/^\d+$/.test(raw))
       throw new Error(`--${name} must be a number, got "${raw}"`);
     const value = Number(raw);
+    // A long enough digit run parses to Infinity, and anything past
+    // MAX_SAFE_INTEGER collapses distinct PR numbers onto the same draw.
+    if (!Number.isSafeInteger(value))
+      throw new Error(`--${name} is not a safe integer: "${raw}"`);
     if (value < min)
       throw new Error(`--${name} must be >= ${min}, got ${value}`);
     return value;
   };
+  const title = flag('check-title');
+  if (title !== undefined) {
+    if (argv.length !== 1)
+      throw new Error('--check-title= takes no other arguments');
+    return { mode: 'check-title', title };
+  }
   // iter may legitimately be 0: a PR can converge before the loop ever pushed.
-  return { pr: int('pr', 1), iter: int('iter', 0) };
+  return { mode: 'body', pr: int('pr', 1), iter: int('iter', 0) };
 }
 
 export function main(argv = process.argv.slice(2)) {
@@ -187,9 +242,14 @@ export function main(argv = process.argv.slice(2)) {
   } catch (err) {
     console.error(`handoff-message: ${err.message}`);
     console.error(
-      'usage: node scripts/handoff-message.mjs --pr=<number> --iter=<number>'
+      'usage: node scripts/handoff-message.mjs --pr=<number> --iter=<number>\n' +
+        '       node scripts/handoff-message.mjs --check-title=<pr title>'
     );
     process.exit(2);
+  }
+  if (opts.mode === 'check-title') {
+    console.log(needsScopeWarning(opts.title) ? 'warn' : 'ok');
+    return;
   }
   console.log(buildBody(opts));
 }

--- a/scripts/handoff-message.mjs
+++ b/scripts/handoff-message.mjs
@@ -78,12 +78,27 @@ export const RELEASE_SCOPES = [
 ];
 
 /**
- * `type(scope)!: subject` — the same shape commitlint parses. The trailing
- * space is load-bearing: conventional-commits-parser requires `: `, so
- * `feat:x` yields type=undefined and semantic-release releases nothing from
- * it. Flagging it as a scope problem would name the wrong defect.
+ * `type(scope)!: subject`, mirroring the presets that decide releases here.
+ *
+ * Two details are load-bearing and both come from the real parsers rather
+ * than from the documented shape:
+ *
+ * - The scope capture is GREEDY (`.*`, not `[^)]*`). Both the angular preset
+ *   semantic-release runs (`/^(\w*)(?:\((.*)\))?: (.*)$/`) and the
+ *   conventionalcommits preset commitlint runs capture it that way, so
+ *   `feat(foo)): x` parses as type `feat` with the invalid scope `foo)` and
+ *   really would release. A non-greedy class silently misses it.
+ * - The trailing space is required. Both presets demand `: `, so `feat:x`
+ *   yields type=undefined and releases nothing; calling that a scope problem
+ *   would name the wrong defect.
+ *
+ * `!?` is tolerated even though the angular preset does not parse it (see the
+ * BREAKING CHANGE notes in each release.config.js). That over-approximates
+ * deliberately: commitlint's preset does parse `feat!: x` and would reject an
+ * unscoped one, and warning about a title that releases nothing is harmless
+ * where staying silent about one that releases everything is not.
  */
-const CONVENTIONAL_HEADER = /^([a-z]+)(?:\(([^)]*)\))?!?: /;
+const CONVENTIONAL_HEADER = /^([a-z]+)(?:\((.*)\))?!?: /;
 
 /**
  * True when the PR title would release a package but names no valid scope —

--- a/scripts/handoff-message.mjs
+++ b/scripts/handoff-message.mjs
@@ -220,6 +220,21 @@ export function chooseSlots(pr) {
   };
 }
 
+/**
+ * True when text carries a mention that would re-enter a write-capable
+ * session (.github/CLAUDE.md rule 8).
+ *
+ * Case-INSENSITIVE on purpose: the real matcher is GitHub Actions
+ * `contains(github.event.comment.body, '@claude')` in claude.yml, and Actions
+ * string comparison ignores case — so `@Claude` re-triggers just as `@claude`
+ * does. A case-sensitive guard here would be weaker than the thing it stands
+ * in for, which is the one way this check must never fail.
+ */
+export function writesBotTrigger(text) {
+  const lower = text.toLowerCase();
+  return lower.includes('@claude') || lower.includes('@coderabbitai');
+}
+
 export function buildBody({ pr, iter }) {
   return assemble({ ...chooseSlots(pr), iter });
 }

--- a/scripts/handoff-message.mjs
+++ b/scripts/handoff-message.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Slot-assembled convergence hand-off message for the AI fix loop (#576, rule 9).
+ *
+ * claude-pr-loop.yml's `handoff` job posts bestaxbot's sign-off: the comment
+ * telling a human the PR converged and asking for a squash-merge. It used to
+ * be one hardcoded string, so every converged PR got a byte-identical comment
+ * and people stopped reading the one message that carries an action item. This
+ * assembles it from four slots instead — opening, status, ask, kicker — each
+ * drawn from its own pool: 2 x 5 x 5 x 5 x 5 = 1250 bodies from 30 lines.
+ *
+ * Everything the old string communicated survives by construction, and the
+ * test sibling asserts each one across all 1250 combinations: the iteration
+ * count, CI green, every AI review thread resolved, the @allxsmith
+ * squash-merge ask, and that the loop itself never merges.
+ *
+ * Design constraints worth keeping when adding fragments:
+ *
+ * - Every fragment is SELF-CONTAINED — a complete sentence that never refers
+ *   back to the previous slot's metaphor. Slots C and D joke about thumbs and
+ *   merge buttons rather than terrain, which is what makes them theme-neutral
+ *   and safe to combine with either theme. Break that and the combinations
+ *   stop reading as sentences.
+ * - The opening emoji carries the theme; the closing 🤙 is bestaxbot's
+ *   signature and stays constant across both, so the bot stays recognisable.
+ * - Fragments are single-line, and the assembled body must be flush left. The
+ *   YAML literal this replaced got that for free: a block scalar strips its
+ *   own indentation, so the multi-line string decoded clean. Assembling in JS
+ *   removes that safety net — a stray leading space here reaches the comment
+ *   verbatim, and >=4 of them after a blank line is an indented code block in
+ *   Markdown, which would grey out the merge ask and silence the @-mention
+ *   inside it. Hence the whitespace assertions in the test sibling.
+ * - The draw is DETERMINISTIC per PR (re-running handoff posts the same text
+ *   rather than a second, different-looking sign-off) and DECORRELATED per
+ *   slot (each slot hashes its own salt, so consecutive PRs shift all four
+ *   instead of rotating one). sha256 rather than a cheaper checksum: CRC32's
+ *   low bit is a linear function of its input, which made the theme alternate
+ *   in visible runs of exactly four across adjacent PR numbers.
+ * - No untrusted text may ever reach this body. The comment is posted with a
+ *   PAT, so it is published verbatim AND re-triggers workflows
+ *   (.github/CLAUDE.md rule 5 / I2); the only interpolation is the iteration
+ *   integer. Never add a fragment containing "@claude" or "@coderabbitai" —
+ *   `contains()` matches raw substrings and would re-enter a write-capable
+ *   session (rule 8).
+ *
+ * CLI contract (the YAML wrapper depends on every clause):
+ *   node scripts/handoff-message.mjs --pr=<number> --iter=<number>
+ * - Prints the assembled body on stdout and nothing else. The workflow appends
+ *   its own `$WARN` after; that is deliberately NOT this script's business, so
+ *   "unchanged, at the very end" stays visible at the call site.
+ * - Exits non-zero with a message on stderr for any bad input, so the step's
+ *   `set -euo pipefail` fails the job rather than posting an empty comment.
+ * - Doubles as the local preview: `node scripts/handoff-message.mjs --pr=576
+ *   --iter=3` renders exactly what that PR would get.
+ */
+import { createHash } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+/** Placeholder the status fragments carry, substituted by applyIter(). */
+export const ITER_TOKEN = '$ITER';
+
+export const SURF = {
+  name: 'surf',
+  emoji: '🏄',
+  openings: [
+    "🏄 **Surf's up and I rode the whole set — total convergence, brah.**",
+    "🏄 **Clean sets, no drop-ins — this one's converged.**",
+    '🏄 **Paddled out, dropped in, kicked out clean — converged, zero wipeouts.**',
+    '🏄 **Waxed the board, read the tide chart, rode it all the way in.**',
+    '🏄 **Called the drop, made the section, converged clean.**',
+  ],
+  statuses: [
+    "$ITER iteration(s) in, CI's glassy green, and every AI review thread closed out clean like a perfect barrel.",
+    '$ITER iteration(s) deep, CI is offshore-glassy, and every AI review thread paddled back to the beach.',
+    '$ITER iteration(s) in the water, CI green as a dawn-patrol horizon, and every AI review thread is stone-cold resolved.',
+    '$ITER iteration(s) of grinding, CI lit up greener than a kelp bed, and not one AI review thread left in the impact zone.',
+    '$ITER iteration(s), CI glassy top to bottom, every AI review thread resolved and dried off. 🌊',
+  ],
+};
+
+export const SNOW = {
+  name: 'snow',
+  emoji: '🏂',
+  openings: [
+    '🏂 **Dropped the cornice and rode it clean to the lodge — total convergence, brah.**',
+    '🏂 **First chair, fresh corduroy, straight-lined the whole thing — converged.**',
+    "🏂 **Bluebird day, boot-deep pow, not one yard sale — she's converged.**",
+    '🏂 **Strapped in, dropped in, stomped the landing — full convergence.**',
+    '🏂 **Rode it summit to base without catching a single edge.**',
+  ],
+  statuses: [
+    "$ITER iteration(s) in, CI's greener than the bunny slope, and every AI review thread carved clean off the mountain. ❄️",
+    '$ITER iteration(s) deep, CI all-green top to base, and every AI review thread resolved and stomped flat.',
+    '$ITER lap(s) down the hill, CI lighting up green the whole way, and not one AI review thread left in the trees. 🏔️',
+    '$ITER iteration(s), CI green as a freshly groomed run at 8am, and every AI review thread buried and packed down.',
+    '$ITER run(s) in, CI green from the summit to the lodge, and every AI review thread closed out before last chair. 🧊',
+  ],
+};
+
+/** Theme order is part of the draw — appending is safe, reordering is not. */
+export const THEMES = [SURF, SNOW];
+
+/** Slot C: the ask. Theme-neutral — every entry @-mentions the owner. */
+export const ASKS = [
+  "You fleshbags kept the merge button for yourselves — so @allxsmith, wiggle those opposable thumbs and squash-merge when you're stoked.",
+  'The merge button lives in the wetware, brah — @allxsmith, flex those digits and squash-merge when the vibes align.',
+  "Merge button's still locked to the carbon units — so @allxsmith, unfold those beautiful thumbs and squash-merge whenever you're ready.",
+  'Only the meat build ships with merge permissions — @allxsmith, do the wet-mammal thing and squash-merge when it feels right.',
+  "Final call is a wetware exclusive — @allxsmith, put a thumb on it and squash-merge when you're feeling it.",
+];
+
+/** Slot D: the kicker. Theme-neutral — every entry closes with the 🤙 sig. */
+export const KICKERS = [
+  "The loop never merges; apparently 'judgment' is still a squishy-brain-only feature. 🤙",
+  "Loop never merges — 'is this actually a good idea' is still a protein-based subroutine. 🤙",
+  "The loop never merges; turns out 'taste' only ships in the carbon build. 🤙",
+  "Loop never merges; apparently 'ship it' needs a pulse. 🤙",
+  'The loop never merges — you fleshbags reserved the final call for yourselves and honestly? Respect. 🤙',
+];
+
+/**
+ * Stable index in [0, n) for this PR and slot.
+ *
+ * Salting per slot is the point: one hash reused across slots would rotate
+ * them in lockstep, so neighbouring PRs would share three of four fragments.
+ */
+export function draw(salt, pr, n) {
+  const digest = createHash('sha256').update(`${salt}:${pr}`).digest('hex');
+  return parseInt(digest.slice(0, 8), 16) % n;
+}
+
+/** Substitute the iteration count into a status fragment. */
+export function applyIter(status, iter) {
+  return status.replaceAll(ITER_TOKEN, String(iter));
+}
+
+/**
+ * Join four chosen fragments into the posted body.
+ *
+ * Pure and slot-agnostic so the test can enumerate all 1250 combinations
+ * directly, rather than trusting the draw to reach every one of them.
+ */
+export function assemble({ opening, status, ask, kicker, iter }) {
+  return `${opening} ${applyIter(status, iter)}\n\n${ask} ${kicker}`;
+}
+
+/** The fragments this PR number draws, theme included. */
+export function chooseSlots(pr) {
+  const theme = THEMES[draw('theme', pr, THEMES.length)];
+  return {
+    theme,
+    opening: theme.openings[draw('open', pr, theme.openings.length)],
+    status: theme.statuses[draw('stat', pr, theme.statuses.length)],
+    ask: ASKS[draw('ask', pr, ASKS.length)],
+    kicker: KICKERS[draw('kick', pr, KICKERS.length)],
+  };
+}
+
+export function buildBody({ pr, iter }) {
+  return assemble({ ...chooseSlots(pr), iter });
+}
+
+/** Parse argv into { pr, iter }; throws Error(message) on misuse. */
+export function parseArgs(argv) {
+  for (const arg of argv)
+    if (!/^--(pr|iter)=/.test(arg)) throw new Error(`Unknown argument: ${arg}`);
+  const flag = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3);
+  const int = (name, min) => {
+    const raw = flag(name);
+    if (raw === undefined) throw new Error(`missing --${name}=<number>`);
+    if (!/^\d+$/.test(raw))
+      throw new Error(`--${name} must be a number, got "${raw}"`);
+    const value = Number(raw);
+    if (value < min)
+      throw new Error(`--${name} must be >= ${min}, got ${value}`);
+    return value;
+  };
+  // iter may legitimately be 0: a PR can converge before the loop ever pushed.
+  return { pr: int('pr', 1), iter: int('iter', 0) };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (err) {
+    console.error(`handoff-message: ${err.message}`);
+    console.error(
+      'usage: node scripts/handoff-message.mjs --pr=<number> --iter=<number>'
+    );
+    process.exit(2);
+  }
+  console.log(buildBody(opts));
+}
+
+// Run only when executed directly (keeps the pure helpers importable).
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/handoff-message.test.mjs
+++ b/scripts/handoff-message.test.mjs
@@ -26,6 +26,7 @@
  * no package of their own, matching auto-close-duplicates.test.mjs.
  */
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -34,6 +35,8 @@ import {
   ASKS,
   ITER_TOKEN,
   KICKERS,
+  RELEASE_SCOPES,
+  RELEASE_TYPES,
   SNOW,
   SURF,
   THEMES,
@@ -42,6 +45,7 @@ import {
   buildBody,
   chooseSlots,
   draw,
+  needsScopeWarning,
   parseArgs,
 } from './handoff-message.mjs';
 
@@ -113,6 +117,14 @@ test('each slot pool carries the job that slot exists to do', () => {
       assert.ok(
         /AI review thread/.test(status),
         `states thread resolution: ${status}`
+      );
+      // Naming CI and the threads is not the same as claiming they are good:
+      // "CI is red and every AI review thread is unresolved" would satisfy
+      // the two checks above. Block the vocabulary that would invert it.
+      assert.doesNotMatch(
+        status,
+        /\b(red|failing|failed|broken|unresolved|pending|still open)\b/i,
+        `states a GREEN, resolved outcome: ${status}`
       );
     }
   }
@@ -247,8 +259,20 @@ test('the draw decorrelates slots and both themes get used', () => {
 });
 
 test('parseArgs enforces the contract the workflow relies on', () => {
-  assert.deepEqual(parseArgs(['--pr=576', '--iter=3']), { pr: 576, iter: 3 });
-  assert.deepEqual(parseArgs(['--iter=0', '--pr=1']), { pr: 1, iter: 0 });
+  assert.deepEqual(parseArgs(['--pr=576', '--iter=3']), {
+    mode: 'body',
+    pr: 576,
+    iter: 3,
+  });
+  assert.deepEqual(parseArgs(['--iter=0', '--pr=1']), {
+    mode: 'body',
+    pr: 1,
+    iter: 0,
+  });
+  assert.deepEqual(parseArgs(['--check-title=feat: x']), {
+    mode: 'check-title',
+    title: 'feat: x',
+  });
   for (const argv of [
     [],
     ['--pr=576'],
@@ -259,6 +283,10 @@ test('parseArgs enforces the contract the workflow relies on', () => {
     ['--pr=576', '--iter=x'],
     ['--pr=576', '--iter=3', '--bogus'],
     ['--pr', '576'],
+    // Digit-only is not the same as usable: this one parses to Infinity.
+    [`--pr=${'9'.repeat(400)}`, '--iter=3'],
+    ['--pr=576', `--iter=${Number.MAX_SAFE_INTEGER + 2}`],
+    ['--check-title=feat: x', '--pr=576'],
   ]) {
     assert.throws(
       () => parseArgs(argv),
@@ -283,4 +311,80 @@ test('the CLI prints exactly the built body and fails loudly on bad input', () =
   assert.notEqual(bad.status, 0);
   assert.equal(bad.stdout, '');
   assert.match(bad.stderr, /missing --iter/);
+});
+
+test('needsScopeWarning fires only on a real releasing header', () => {
+  // Anchored on the conventional header, not a bare type prefix: the greps
+  // this replaced flagged any title merely STARTING with a releasing type.
+  for (const title of [
+    'fixture cleanup',
+    'reverted flaky change',
+    'styleguide update',
+    'performance notes',
+    'refactoring notes for later',
+  ])
+    assert.equal(needsScopeWarning(title), false, `prose: ${title}`);
+
+  for (const title of ['ci: x', 'chore(deps): x', 'docs: x', 'test: x', ''])
+    assert.equal(needsScopeWarning(title), false, `non-releasing: ${title}`);
+
+  for (const scope of RELEASE_SCOPES)
+    for (const type of RELEASE_TYPES) {
+      assert.equal(needsScopeWarning(`${type}(${scope}): x`), false);
+      assert.equal(needsScopeWarning(`${type}(${scope})!: x`), false);
+    }
+
+  for (const type of RELEASE_TYPES) {
+    assert.equal(needsScopeWarning(`${type}: x`), true, `unscoped ${type}`);
+    assert.equal(needsScopeWarning(`${type}!: x`), true, `breaking ${type}`);
+    assert.equal(
+      needsScopeWarning(`${type}(nope): x`),
+      true,
+      `bad scope ${type}`
+    );
+    assert.equal(
+      needsScopeWarning(`${type}(): x`),
+      true,
+      `empty scope ${type}`
+    );
+  }
+
+  // Documented residual, matching commitlint.config.js: a git-style revert is
+  // not a conventional header, so neither commitlint nor this flags it.
+  assert.equal(needsScopeWarning('Revert "feat(bulma-ui): x"'), false);
+});
+
+test('the mirrored release lists match commitlint.config.js', () => {
+  const config = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'commitlint.config.js'),
+    'utf8'
+  );
+  for (const [name, values] of [
+    ['RELEASE_TYPES', RELEASE_TYPES],
+    ['RELEASE_SCOPES', RELEASE_SCOPES],
+  ]) {
+    const tail = config.slice(config.indexOf(`const ${name} = [`));
+    const declared = [
+      ...tail.slice(0, tail.indexOf('];')).matchAll(/'([^']+)'/g),
+    ].map(m => m[1]);
+    assert.deepEqual(values, declared, `${name} drifted from commitlint`);
+  }
+});
+
+test('the CLI title check prints exactly warn or ok', () => {
+  for (const [title, expected] of [
+    ['feat(bulma-ui): x', 'ok'],
+    ['feat: x', 'warn'],
+    ['fixture cleanup', 'ok'],
+  ]) {
+    const run = spawnSync(
+      process.execPath,
+      [SCRIPT, `--check-title=${title}`],
+      {
+        encoding: 'utf8',
+      }
+    );
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(run.stdout, `${expected}\n`);
+  }
 });

--- a/scripts/handoff-message.test.mjs
+++ b/scripts/handoff-message.test.mjs
@@ -1,0 +1,286 @@
+/**
+ * Guards on the convergence hand-off message builder (handoff-message.mjs).
+ *
+ * This is the comment that tells a human an ai-loop PR is ready and asks for
+ * the squash-merge, so the thing under test is not "does it read nicely" but
+ * "does every one of the 1250 combinations still carry the action item". The
+ * pools are prose and prose gets edited; these assertions are the contract
+ * that editing them cannot quietly drop the merge ask, the iteration count,
+ * the never-merges disclaimer, or the theme signature (#576).
+ *
+ * Combinations are ENUMERATED through assemble() rather than sampled through
+ * buildBody(): the draw is not guaranteed to reach every tuple for any finite
+ * set of PR numbers, and a fragment that only breaks in one pairing is exactly
+ * the failure a sampled test would miss.
+ *
+ * The leading-whitespace assertions guard something the old shape got for
+ * free. A YAML block scalar strips its own indentation, so the multi-line
+ * literal this replaced decoded flush left no matter how it was indented;
+ * assembled in JS, a stray leading space would instead reach the comment
+ * verbatim, and >=4 of them after a blank line is an indented code block in
+ * Markdown — which greys out the merge ask and silences the @-mention inside
+ * it. Nothing in CI lints workflow YAML, which is why the assembly lives here
+ * at all (.github/CLAUDE.md rule 9).
+ *
+ * `.mjs` and `node --test` rather than jest: these are root-level scripts with
+ * no package of their own, matching auto-close-duplicates.test.mjs.
+ */
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import assert from 'node:assert/strict';
+import {
+  ASKS,
+  ITER_TOKEN,
+  KICKERS,
+  SNOW,
+  SURF,
+  THEMES,
+  applyIter,
+  assemble,
+  buildBody,
+  chooseSlots,
+  draw,
+  parseArgs,
+} from './handoff-message.mjs';
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'handoff-message.mjs'
+);
+
+/** Every (theme, opening, status, ask, kicker) pairing, with a stand-in iter. */
+function* everyCombination(iter = 7) {
+  for (const theme of THEMES)
+    for (const opening of theme.openings)
+      for (const status of theme.statuses)
+        for (const ask of ASKS)
+          for (const kicker of KICKERS)
+            yield {
+              theme,
+              body: assemble({ opening, status, ask, kicker, iter }),
+              iter,
+            };
+}
+
+const ALL = [...everyCombination()];
+
+test('the pools are the shape the draw and the maths assume', () => {
+  assert.equal(THEMES.length, 2);
+  assert.deepEqual(THEMES, [SURF, SNOW]);
+  for (const theme of THEMES) {
+    assert.equal(theme.openings.length, 5, `${theme.name} openings`);
+    assert.equal(theme.statuses.length, 5, `${theme.name} statuses`);
+  }
+  assert.equal(ASKS.length, 5);
+  assert.equal(KICKERS.length, 5);
+  assert.equal(ALL.length, 1250, '2 x 5 x 5 x 5 x 5');
+});
+
+test('every fragment is a single trimmed line', () => {
+  const all = [
+    ...THEMES.flatMap(t => [...t.openings, ...t.statuses]),
+    ...ASKS,
+    ...KICKERS,
+  ];
+  assert.equal(all.length, 30);
+  for (const fragment of all) {
+    assert.ok(fragment.length > 0, 'fragment is non-empty');
+    assert.ok(!/[\n\r]/.test(fragment), `single-line: ${fragment}`);
+    assert.equal(fragment, fragment.trim(), `no edge whitespace: ${fragment}`);
+    assert.ok(!fragment.includes('`'), `no backticks: ${fragment}`);
+  }
+});
+
+test('each slot pool carries the job that slot exists to do', () => {
+  for (const theme of THEMES) {
+    for (const opening of theme.openings) {
+      assert.ok(
+        opening.startsWith(`${theme.emoji} **`),
+        `themed + bold: ${opening}`
+      );
+      assert.ok(opening.endsWith('**'), `headline closes bold: ${opening}`);
+    }
+    for (const status of theme.statuses) {
+      // The status is the slot that reports the loop's actual state.
+      assert.equal(
+        status.split(ITER_TOKEN).length - 1,
+        1,
+        `one ${ITER_TOKEN}: ${status}`
+      );
+      assert.ok(/\bCI\b/.test(status), `states CI: ${status}`);
+      assert.ok(
+        /AI review thread/.test(status),
+        `states thread resolution: ${status}`
+      );
+    }
+  }
+  for (const ask of ASKS) {
+    assert.ok(ask.includes('@allxsmith'), `mentions the owner: ${ask}`);
+    assert.ok(
+      ask.includes('squash-merge'),
+      `asks for the squash-merge: ${ask}`
+    );
+  }
+  for (const kicker of KICKERS) {
+    assert.ok(
+      /[Ll]oop never merges/.test(kicker),
+      `states the loop never merges: ${kicker}`
+    );
+    assert.ok(kicker.endsWith('🤙'), `closes with the signature: ${kicker}`);
+  }
+});
+
+test('no fragment writes a bot trigger string (.github/CLAUDE.md rule 8)', () => {
+  // contains() matches raw substrings, and this body is posted with a PAT, so
+  // a mention here would re-enter a write-capable session.
+  for (const { body } of ALL) {
+    assert.ok(!body.includes('@claude'), body);
+    assert.ok(!body.includes('@coderabbitai'), body);
+  }
+});
+
+test('every assembled body is two flush-left paragraphs', () => {
+  for (const { body } of ALL) {
+    const lines = body.split('\n');
+    assert.equal(lines.length, 3, `headline / blank / ask: ${body}`);
+    assert.equal(lines[1], '', `exactly one blank line: ${body}`);
+    for (const line of [lines[0], lines[2]]) {
+      // >=4 leading spaces would make GitHub render the paragraph as a code
+      // block and silence its @-mention. JS does no stripping of its own.
+      assert.ok(
+        !/^\s/.test(line),
+        `no leading whitespace: ${JSON.stringify(line)}`
+      );
+      assert.ok(
+        !/\s$/.test(line),
+        `no trailing whitespace: ${JSON.stringify(line)}`
+      );
+    }
+  }
+});
+
+test('every assembled body still carries the whole message', () => {
+  for (const { theme, body, iter } of ALL) {
+    assert.ok(body.startsWith(theme.emoji), `themed opening emoji: ${body}`);
+    assert.ok(body.endsWith('🤙'), `signature closes the body: ${body}`);
+    assert.ok(
+      body.includes(`${iter} `),
+      `reports the iteration count: ${body}`
+    );
+    assert.ok(!body.includes(ITER_TOKEN), `placeholder substituted: ${body}`);
+    assert.ok(body.includes('@allxsmith'), body);
+    assert.ok(body.includes('squash-merge'), body);
+    assert.ok(/[Ll]oop never merges/.test(body), body);
+    assert.ok(/\bCI\b/.test(body), body);
+    assert.ok(/AI review thread/.test(body), body);
+  }
+});
+
+test('applyIter substitutes every occurrence, including zero', () => {
+  assert.equal(applyIter('$ITER iteration(s) in.', 0), '0 iteration(s) in.');
+  assert.equal(
+    applyIter('$ITER lap(s), $ITER run(s)', 4),
+    '4 lap(s), 4 run(s)'
+  );
+  assert.equal(applyIter('no placeholder here', 3), 'no placeholder here');
+});
+
+test('the draw stays in range and is deterministic per PR', () => {
+  for (let pr = 1; pr <= 400; pr++) {
+    for (const [salt, n] of [
+      ['theme', 2],
+      ['open', 5],
+      ['stat', 5],
+      ['ask', 5],
+      ['kick', 5],
+    ]) {
+      const index = draw(salt, pr, n);
+      assert.ok(
+        Number.isInteger(index) && index >= 0 && index < n,
+        `${salt}@${pr} -> ${index}`
+      );
+      assert.equal(index, draw(salt, pr, n), 'same input, same index');
+    }
+    assert.equal(buildBody({ pr, iter: 2 }), buildBody({ pr, iter: 2 }));
+  }
+});
+
+test("the draw is pinned — changing it rewrites every PR's message", () => {
+  // A golden tuple, not a golden body: fragments may be reworded freely, but
+  // swapping the hash, or reordering/resizing a pool, silently reassigns all
+  // 1250. If you meant to do that, re-pin these indices in the same commit.
+  const slots = chooseSlots(576);
+  assert.equal(slots.theme.name, 'surf');
+  assert.equal(SURF.openings.indexOf(slots.opening), 0);
+  assert.equal(SURF.statuses.indexOf(slots.status), 1);
+  assert.equal(ASKS.indexOf(slots.ask), 2);
+  assert.equal(KICKERS.indexOf(slots.kicker), 4);
+});
+
+test('the draw decorrelates slots and both themes get used', () => {
+  // One shared hash would rotate the slots in lockstep, so neighbouring PRs
+  // would differ in a single fragment and the variety would be theatre.
+  const prs = Array.from({ length: 241 }, (_, i) => 560 + i);
+  const themes = new Set(prs.map(pr => chooseSlots(pr).theme.name));
+  assert.deepEqual([...themes].sort(), ['snow', 'surf']);
+
+  const tuple = pr =>
+    ['open', 'stat', 'ask', 'kick'].map(s => draw(s, pr, 5)).join('');
+  let changed = 0;
+  for (let i = 1; i < prs.length; i++) {
+    const [a, b] = [tuple(prs[i - 1]), tuple(prs[i])];
+    changed += [...a].filter((c, j) => c !== b[j]).length;
+  }
+  const average = changed / (prs.length - 1);
+  assert.ok(
+    average > 2.5,
+    `expected most slots to move between PRs, got ${average}`
+  );
+
+  const distinct = new Set(prs.map(pr => buildBody({ pr, iter: 1 })));
+  assert.ok(
+    distinct.size > 200,
+    `expected near-collision-free coverage, got ${distinct.size}/241`
+  );
+});
+
+test('parseArgs enforces the contract the workflow relies on', () => {
+  assert.deepEqual(parseArgs(['--pr=576', '--iter=3']), { pr: 576, iter: 3 });
+  assert.deepEqual(parseArgs(['--iter=0', '--pr=1']), { pr: 1, iter: 0 });
+  for (const argv of [
+    [],
+    ['--pr=576'],
+    ['--iter=3'],
+    ['--pr=0', '--iter=3'],
+    ['--pr=abc', '--iter=3'],
+    ['--pr=576', '--iter=-1'],
+    ['--pr=576', '--iter=x'],
+    ['--pr=576', '--iter=3', '--bogus'],
+    ['--pr', '576'],
+  ]) {
+    assert.throws(
+      () => parseArgs(argv),
+      Error,
+      `should reject ${JSON.stringify(argv)}`
+    );
+  }
+});
+
+test('the CLI prints exactly the built body and fails loudly on bad input', () => {
+  const ok = spawnSync(process.execPath, [SCRIPT, '--pr=576', '--iter=3'], {
+    encoding: 'utf8',
+  });
+  assert.equal(ok.status, 0);
+  assert.equal(ok.stderr, '');
+  assert.equal(ok.stdout, `${buildBody({ pr: 576, iter: 3 })}\n`);
+
+  // A non-zero exit is what stops `set -euo pipefail` posting an empty body.
+  const bad = spawnSync(process.execPath, [SCRIPT, '--pr=576'], {
+    encoding: 'utf8',
+  });
+  assert.notEqual(bad.status, 0);
+  assert.equal(bad.stdout, '');
+  assert.match(bad.stderr, /missing --iter/);
+});

--- a/scripts/handoff-message.test.mjs
+++ b/scripts/handoff-message.test.mjs
@@ -349,6 +349,19 @@ test('needsScopeWarning fires only on a real releasing header', () => {
     );
   }
 
+  // No space after the colon is not a conventional header either:
+  // conventional-commits-parser requires `: `, so these release nothing and
+  // must not be reported as a scope problem.
+  for (const title of [
+    'feat:x',
+    'revert:x',
+    'fix(bulma-ui):x',
+    'feat(nope):x',
+    'feat',
+    'feat(bulma-ui)',
+  ])
+    assert.equal(needsScopeWarning(title), false, `not a header: ${title}`);
+
   // Documented residual, matching commitlint.config.js: a git-style revert is
   // not a conventional header, so neither commitlint nor this flags it.
   assert.equal(needsScopeWarning('Revert "feat(bulma-ui): x"'), false);

--- a/scripts/handoff-message.test.mjs
+++ b/scripts/handoff-message.test.mjs
@@ -349,6 +349,17 @@ test('needsScopeWarning fires only on a real releasing header', () => {
     );
   }
 
+  // Greedy scope capture, matching both presets: these DO parse as a
+  // releasing type with an invalid scope, so they must warn.
+  for (const title of [
+    'feat(foo)): x',
+    'feat((x)): y',
+    'fix(bulma-ui)): x',
+    'revert(a)(b): x',
+    'feat(bulma ui): x',
+  ])
+    assert.equal(needsScopeWarning(title), true, `invalid scope: ${title}`);
+
   // No space after the colon is not a conventional header either:
   // conventional-commits-parser requires `: `, so these release nothing and
   // must not be reported as a scope problem.

--- a/scripts/handoff-message.test.mjs
+++ b/scripts/handoff-message.test.mjs
@@ -47,6 +47,7 @@ import {
   draw,
   needsScopeWarning,
   parseArgs,
+  writesBotTrigger,
 } from './handoff-message.mjs';
 
 const SCRIPT = join(
@@ -147,10 +148,21 @@ test('each slot pool carries the job that slot exists to do', () => {
 test('no fragment writes a bot trigger string (.github/CLAUDE.md rule 8)', () => {
   // contains() matches raw substrings, and this body is posted with a PAT, so
   // a mention here would re-enter a write-capable session.
-  for (const { body } of ALL) {
-    assert.ok(!body.includes('@claude'), body);
-    assert.ok(!body.includes('@coderabbitai'), body);
-  }
+  for (const { body } of ALL) assert.equal(writesBotTrigger(body), false, body);
+
+  // The guard has to be at least as permissive as the matcher it stands in
+  // for: Actions `contains()` ignores case, so a case-sensitive check would
+  // wave `@Claude` through while the workflow still fired on it.
+  for (const variant of [
+    'ping @Claude please',
+    'ping @CLAUDE please',
+    'ask @CodeRabbitAI to look',
+    'ask @coderabbitai to look',
+    '@claude',
+  ])
+    assert.equal(writesBotTrigger(variant), true, variant);
+  for (const safe of ['@allxsmith, squash-merge it', 'no mentions here'])
+    assert.equal(writesBotTrigger(safe), false, safe);
 });
 
 test('every assembled body is two flush-left paragraphs', () => {


### PR DESCRIPTION
Closes #576.

## What

The convergence hand-off comment was a single hardcoded string, so every converged PR got a byte-identical sign-off — and it's the comment carrying an action item (the merge ask, plus the `:warning:` about an unscoped title). It's now assembled from four slots — opening, status, ask, kicker — each drawn per PR from its own pool: **2 themes × 5 × 5 × 5 × 5 = 1250 bodies out of 30 hand-written lines.**

All 30 fragments are #576's, verbatim. Slots C and D joke about thumbs and merge buttons rather than terrain, so they're theme-neutral and combine with either theme.

Sample, PR #576 at iteration 3:

> 🏄 **Surf's up and I rode the whole set — total convergence, brah.** 3 iteration(s) deep, CI is offshore-glassy, and every AI review thread paddled back to the beach.
>
> Merge button's still locked to the carbon units — so @allxsmith, unfold those beautiful thumbs and squash-merge whenever you're ready. The loop never merges — you fleshbags reserved the final call for yourselves and honestly? Respect. 🤙

Preview any PR's body locally:

```
node scripts/handoff-message.mjs --pr=576 --iter=3
```

## Two deviations from the issue, both deliberate

**1. The assembly lives in `scripts/`, not inline in the YAML** (rule 9). Nothing in CI lints, parses or validates workflow YAML — no actionlint, `check:conformance` never reads `.github/`, and prettier's glob excludes `.yml` — whereas `node --test "scripts/*.test.mjs"` already runs under `pnpm test`. `scripts/handoff-message.test.mjs` asserts across **all 1250 combinations** that the body still reports the iteration count, CI green and resolved AI review threads, @-mentions the owner, asks for the squash-merge, states the loop never merges, opens on its theme emoji and closes on the 🤙 signature, and writes neither `@claude` nor `@coderabbitai` (rule 8). Combinations are enumerated rather than sampled, since the draw isn't guaranteed to reach every tuple.

**2. sha256, not the sketched `cksum`.** CRC32's low bit is a linear function of its input, so `cksum`-mod-2 made the theme alternate in visible runs of exactly four across adjacent PRs (`0011110000110000111100…`). With sha256, PRs 560–800 give 217 distinct bodies against an ideal-random expectation of 219.3, and 3.17 of 4 slots shift between consecutive PRs. The draw is deterministic per PR — a re-run posts the same text, not a second different-looking sign-off — and salted per slot.

## Also in this PR: the $WARN title check

The check mirrored **neither** list in `commitlint.config.js` and matched a bare type prefix rather than a conventional header, so it had three defects:

- accepted only `bulma-ui|docs|create-bestax`, so `fix(bestax-migrate)` and `feat(bestax-mcp)` drew a false "no valid scope" warning;
- omitted `revert`, which is a `RELEASE_TYPE` — and per the note above that list, commitlint's own ignores skip git-style `Revert "…"` messages;
- flagged ordinary prose: `fixture cleanup` and `styleguide update` **already warned on `main`**.

Per rule 9 the decision now lives in the builder as `needsScopeWarning()`, parsing the whole header (type, optional scope, optional `!`) off the mirrored lists, with a test that also pins both lists against `commitlint.config.js` so they cannot drift again. The warning *text* stays at the call site in the workflow, and the verdict is read through an assignment rather than inline in `if`, so a builder failure trips `set -e` instead of reading as "no warning".

```
ok    feat(bulma-ui): x       ok    revert(bulma-ui): x     warn  feat: x
ok    fix(bestax-migrate): x  ok    fixture cleanup         warn  revert: x
ok    ci: x                   ok    reverted flaky change   warn  fix(nope): x
```

One case deliberately left alone: a git-style `Revert "…"` title is not a conventional header, so it is not flagged — the residual `commitlint.config.js` already documents.

## Review notes

- **`handoff` gains a checkout pinned to `main`** — never the PR branch. This workflow also fires on `pull_request_review`, and this is the job holding the re-triggering PAT. Plus `setup-node`; the builder is dependency-free, so no pnpm and no cache. Both action SHAs are the ones already pinned repo-wide.
- **New failure mode.** `BODY=$(node …)` runs under `set -e`, so a builder failure aborts before the comment, the label flip, the reviewer request *and* the screenshot dispatch, leaving the PR on `ai-loop`. No comment beats a broken one, but the hardcoded string couldn't fail that way. Confirmed the builder exits non-zero on every bad input rather than printing a partial body.
- **The body stays 100% hand-authored static text.** Only the iteration integer is interpolated; `$TITLE` is still read for the grep and never reaches the body (rule 5 / I2).
- **No behavioural change to any other job** — `sweep`, `gate`, `fix`, `verify` and `halt` parse byte-identically to `main`.
- The halt and contested-threads comments are untouched; #576 defers their slot treatment. (Their second paragraphs look indented in the raw YAML, but a block scalar strips its own indentation, so they decode flush left — there's nothing to fix there.)

`pnpm all` passes locally: 468 node tests, 0 failures.

### Review round 1 (93e6555)

Copilot raised three; all fixed. The title check is the one above. `parseArgs` now rejects non-safe integers — a long enough digit run passed `/^\d+$/` and became `Infinity`, rendering `Infinity iteration(s)`. And every status fragment is now asserted against inverted-state vocabulary, since matching the nouns "CI" and "AI review thread" did not stop a fragment from claiming CI was red.

CodeRabbit's one finding is declined and left open for a decision: it asks that four status fragments state thread resolution literally rather than in metaphor ("paddled back to the beach", "buried and packed down"). All 30 fragments are verbatim from #576, which specifies them as the deliverable, so rewriting them would undo the change. The guarantee is enforced structurally by the test instead.

Human-authored; **not** for the AI loop (`.github/**` is a protected path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Handoff messages now use varied, deterministic wording while retaining status, next-step, and merge guidance.
  - Messages include the current iteration number for clearer progress tracking.
  - Title-scope warnings are included when applicable, helping identify release titles that need correction.

- **Bug Fixes**
  - Handoff processing now consistently uses the main branch.
  - PR title scope validation recognizes revert changes and additional supported scopes.

- **Tests**
  - Added comprehensive coverage for message generation, formatting, validation, and command-line behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
