### PR TITLE
ci: give auto-close-duplicates an enforced egress policy, and scope #577's claims to the mechanism

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -337,11 +337,14 @@ Copy the full version from any block job — the three shapes above are each loa
 
 - **The `-e` check comes first** because harden-runner has deliberate paths that install nothing
   and still exit 0 (a StepSecurity outage, the `skip-harden-runner` repo property, a container or
-  slim runner). Without it a vendor outage fails every block job at once — twelve of them as of
+  slim runner). Without it a vendor outage fails every block job at once — thirteen of them as of
   the inventory below, not the seven this line said before the `ai-scan`/`ai-triage` job splits —
   with a bare `jq: could not open file`. It still fails, because a job holding a credential must
   not run unprotected, but it says why. Do not hand-maintain that number: it is the count of
-  block-mode jobs, and it has been wrong once already.
+  block-mode jobs, and it has been wrong once already. Derive it, and grep for the **key** rather
+  than the string — `grep -rn "^ *egress-policy: block$"`. A plain `grep egress-policy: block`
+  returns fourteen: `deploy-worker.yml` names the policy in a comment, which is the same way a
+  `node -e` in a comment misclassifies a job below.
 - **The status check polls** rather than testing once. The pre-step waits only for the file to
   _exist_ and gives up after ~9s, while the agent resolves every allow-listed host before writing
   its status, so a cold resolver or a long list can leave it absent or empty at this point.
@@ -471,7 +474,8 @@ jobs (`ci.yml`, `deploy.yml`, `test-deploy.yml`, `visual-regression.yml`, `story
 - **Enforcing and asserted** — all three `ai-scan` jobs (`gate`, `scan`, `label`), all four
   `ai-triage` jobs (`gate`, `triage`, `publish`, `cleanup`), `claude-repro` (`author` **only**),
   `deploy-worker` (`deploy`), `supply-chain` (`consumer-sbom` and `sign-sbom`),
-  `security-txt-expiry` (`check`). Twelve jobs; the command below is the check.
+  `security-txt-expiry` (`check`), `auto-close-duplicates` (`auto-close`). Thirteen jobs; the
+  command below is the check.
 - **Audit, deliberately, pending a measured allowlist** — `claude`, `claude-implement`,
   `claude-pr-loop` (`fix` and `verify`), `claude-review`, `bestaxbot-reply`. These run repo code
   with a model token; their block flip is the follow-up this rule owes, tracked in #578.
@@ -481,14 +485,15 @@ jobs (`ci.yml`, `deploy.yml`, `test-deploy.yml`, `visual-regression.yml`, `story
     `close-stale-bestaxbot-prs`, `stale`; `claude-repro`'s `prepare` and `cleanup`;
     `claude-pr-loop`'s `sweep`, `gate` and `halt`; `supply-chain`'s `attach-sbom` (it moves
     release artifacts and runs nothing).
-  - _They check out and EXECUTE repository code_ — `auto-close-duplicates`
-    (`scripts/auto-close-duplicates.mjs`), `claude-repro`'s `publish`
+  - _They check out and EXECUTE repository code_ — `claude-repro`'s `publish`
     (`scripts/sanitize-repro-draft.mjs`, over attacker-influenced text while holding
     `issues: write`), `claude-pr-loop`'s `handoff` (`scripts/handoff-message.mjs`), and
     `supply-chain`'s `sbom` (installs the monorepo, runs SBOM generators) and
     `verify-provenance` (installs published packages, runs verification scripts). Calling any of
     these API-only — as this list did twice — understates the unmonitored execution and egress
-    surface in the one inventory meant to state it precisely.
+    surface in the one inventory meant to state it precisely. `auto-close-duplicates` was the
+    fifth here until it was given an enforced policy; it is now in the first group, and it is the
+    only one of the five that has moved.
 
 Do not maintain any of this by hand; it has now been wrong three times, and each time the error
 moved a code-executing job into the harmless-looking group. Derive it:

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -373,25 +373,37 @@ Both exceptions were previously "resolved" by simply leaving the assertion off t
 go back to that: an unasserted block job is indistinguishable from an enforcing one, which is the
 whole failure #487 was.
 
-**A related trap, one step earlier: harden-runner is step 0, so if the ACTION fails the job dies
-before emitting anything.** In `ai-scan` that skipped the fail-closed labeler, because its guard
-reads `needs.gate.outputs.run`. A vendor outage, not an attacker, and the assertion cannot help —
-it never runs. The fix is `continue-on-error: true` on that harden-runner so the gate step still
-emits its outputs, with the assertion immediately after to fail the job and set
+**A related trap, one step earlier: harden-runner is step 0, so if it fails the job can die before
+emitting anything.** In `ai-scan` that skipped the fail-closed labeler, because its guard reads
+`needs.gate.outputs.run`. The fix is `continue-on-error: true` on that harden-runner so the gate
+step still emits its outputs, with the assertion immediately after to fail the job and set
 `enforcement=failed`. Non-blocking there is not "unprotected and ignored": the job still goes red,
 it just gets to record why first. Whenever a downstream `always()` job keys off an upstream job's
 **outputs** rather than only its `result`, check what happens if step 0 dies.
 
-Worth tracing the whole matrix when touching any of this, because five of these paths look alike
-and only three should flag:
+**That fix covers RUNTIME failure only, and the distinction is not pedantic.** Action resolution
+and download happen during **job initialization**, before any step is added to the job. A failure
+there fails the job with no step ever running, so `continue-on-error` — a step property — never
+applies and the assertion never executes. Do not describe the flag as covering "download" or
+"bootstrap" failures; an earlier revision of this section did, and it was wrong.
 
-| What fails in `ai-scan`      | `label` runs?                              | Correct outcome                                    |
-| ---------------------------- | ------------------------------------------ | -------------------------------------------------- |
-| harden-runner action (gate)  | yes, via `enforcement=failed`              | flag — nothing was enforcing                       |
-| the assertion (gate or scan) | yes                                        | flag — nothing was enforcing                       |
-| the `scan` job               | yes (`result` is `failure`, not `skipped`) | flag — empty verdict hits the enum default         |
-| the gate's budget read       | no                                         | **no flag** — counter trouble fails open (rule 4)  |
-| budget spent, or bot author  | no                                         | no flag — nothing was scanned and nothing is wrong |
+> **Residual, stated rather than papered over.** If `harden-runner` cannot be prepared at all, the
+> item goes unscanned and unflagged, and **no guard can fix it**: every job that would carry the
+> flag pins the same action, so `label` fails initialization too. This is vendor-availability
+> shaped rather than attacker-reachable — the pin is a SHA served from GitHub's own CDN — but it
+> is a genuine hole in the fail-closed path and it should be named when the posture is described.
+
+Worth tracing the whole matrix when touching any of this, because these paths look alike and only
+some should flag:
+
+| What fails in `ai-scan`         | `label` runs?                              | Correct outcome                                    |
+| ------------------------------- | ------------------------------------------ | -------------------------------------------------- |
+| harden-runner at runtime (gate) | yes, via `enforcement=failed`              | flag — nothing was enforcing                       |
+| harden-runner **preparation**   | no — `label` cannot initialize either      | residual above; nothing reaches it                 |
+| the assertion (gate or scan)    | yes                                        | flag — nothing was enforcing                       |
+| the `scan` job                  | yes (`result` is `failure`, not `skipped`) | flag — empty verdict hits the enum default         |
+| the gate's budget read          | no                                         | **no flag** — counter trouble fails open (rule 4)  |
+| budget spent, or bot author     | no                                         | no flag — nothing was scanned and nothing is wrong |
 
 **Both lines are required; either alone is a false pass.** `agent.json` holds the policy the
 pre-step _decided_, serialized after every policy decision, so it catches a downgrade — which is

--- a/.github/workflows/ai-scan.yml
+++ b/.github/workflows/ai-scan.yml
@@ -175,20 +175,27 @@ jobs:
       # from every sibling for no operational gain is one more thing to chase.
       #
       # continue-on-error for the same family of reason as `label`'s, one step
-      # earlier in the chain. If the ACTION itself fails — download, bootstrap,
-      # a StepSecurity outage that errors rather than no-opping — this step is
-      # step 0, so the job dies before the gate emits anything. `label` requires
-      # `needs.gate.outputs.run == 'true'`, so an empty `run` skips the
-      # fail-closed labeler and the item goes unscanned AND unflagged. That is
-      # the rule-4 fail-open this PR exists to close, reachable by a vendor
-      # outage rather than by anything an attacker does — but reachable.
+      # earlier in the chain. This step is step 0, so if it fails at RUNTIME —
+      # its pre-step erroring, a StepSecurity outage that returns an error rather
+      # than no-opping — the job would otherwise die before the gate emits
+      # anything. `label` requires `needs.gate.outputs.run == 'true'`, so an
+      # empty `run` skips the fail-closed labeler and the item goes unscanned
+      # AND unflagged. Non-blocking lets the gate step emit `run` first; the
+      # assertion below then finds no agent.json, records `enforcement=failed`
+      # and fails the job, which is what activates the labeler. The cost is
+      # bounded: one authenticated READ of the tracking issue runs with no
+      # firewall. `label` already accepts the same trade for a WRITE.
       #
-      # Non-blocking here does NOT mean unprotected-and-ignored: the assertion
-      # below still runs, finds no agent.json, records `enforcement=failed` and
-      # fails the job, which is exactly what activates the labeler. What the
-      # flag buys is that the gate step gets to emit `run` first. The cost is
-      # honest and bounded: one authenticated READ of the tracking issue runs
-      # with no firewall. `label` already accepts the same trade for a WRITE.
+      # SCOPE IT HONESTLY — an earlier revision of this comment said "download,
+      # bootstrap", and that is wrong. Action RESOLUTION and DOWNLOAD happen
+      # during job initialization, before any step is added to the job, so a
+      # failure there fails the job with no step ever running: `continue-on-error`
+      # is a step property and cannot apply, and the assertion never executes.
+      # That case is NOT covered here and cannot be covered here — it also takes
+      # down `label`, which pins the same action, so no guard on `label` reaches
+      # it either. Recorded as a residual in rule 10 rather than papered over.
+      # It is vendor-availability shaped, not attacker-reachable: the pin is a
+      # SHA on GitHub's own CDN.
       - name: Harden runner
         continue-on-error: true
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -57,6 +57,76 @@ jobs:
       issues: write # comment on + close duplicate issues
       contents: read # checkout to run the script
     steps:
+      # Rule 10 (.github/CLAUDE.md): `block` rather than `audit`, because this
+      # job runs on `schedule`/`workflow_dispatch` — outside the
+      # untrusted-trigger class whose broken cache probe caused #487's
+      # fail-open, where block was already observed arming on the nearest
+      # sibling (security-txt-expiry.yml, run 31952287389).
+      #
+      # The list is this job's needs, and it is deliberately the same five hosts
+      # that sibling allows: checkout and setup-node reach GitHub and nodejs.org,
+      # and scripts/auto-close-duplicates.mjs is dependency-free (node: builtins
+      # + global fetch) against api.github.com and nothing else. Adding no new
+      # host is what keeps the NXDOMAIN failure mode off this change — the agent
+      # aborts and REVERTS the firewall when an allow-listed domain does not
+      # resolve, while the pre-step still exits 0. Resolve anything you add here.
+      #
+      # Derived from what the steps below documentedly reach rather than from a
+      # measured run; widen it from a StepSecurity report if one is ever refused.
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            nodejs.org:443
+
+      # Asserts the policy the pre-step decided (agent.json) AND that the agent
+      # actually came up (agent.status, written only once the firewall rules are
+      # installed). Either alone is a false pass: #487 was the first kind, and an
+      # unresolvable host in an allowlist is the second.
+      #
+      # Scope it honestly: this proves enforcement was armed AT THIS STEP. It does
+      # NOT prove the policy stays armed — the agent writes `Initialized` and then
+      # serves, and a later runtime error makes it revert the firewall with both
+      # files still reading exactly as they do here. Rule 10 in .github/CLAUDE.md
+      # carries the mechanism and what to check when a run looks wrong.
+      #
+      # Placement is rule 10's default (immediately after harden-runner): nothing
+      # `always()`-guarded keys off this job's outputs, and the job is not itself
+      # a fail-closed path, so neither placement exception applies.
+      #
+      # Linux-only paths (macOS uses /opt/step-security); all runners are ubuntu-latest.
+      - name: Assert egress policy is enforced
+        run: |
+          set -uo pipefail
+          # harden-runner has several deliberate "install nothing, exit 0" paths
+          # (StepSecurity unavailable, the skip-harden-runner repo property, a
+          # container or slim runner). None of them writes agent.json, so name
+          # that case rather than leaving a bare jq "could not open file".
+          if [ ! -e /home/agent/agent.json ]; then
+            echo "::error::harden-runner installed no agent, so nothing is enforcing egress. Usual causes: a StepSecurity outage (its pre-step returns green without installing), the skip-harden-runner repo property, or a container/slim runner. This job holds issues: write and will not run unprotected (#487)."
+            exit 1
+          fi
+          if ! jq -e '.egress_policy == "block"' /home/agent/agent.json; then
+            echo "::error::effective egress policy is not block — harden-runner downgraded it (#487)."
+            exit 1
+          fi
+          # Poll rather than test once: the pre-step waits only for the file to
+          # EXIST and gives up after ~9s, while the agent resolves every
+          # allow-listed host before writing its status, so a cold resolver or a
+          # long list can leave the file absent or still empty here.
+          for _ in $(seq 1 30); do
+            if grep -q '^Initialized' /home/agent/agent.status 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::agent.json reads block but the agent never reported Initialized — the firewall is not up. Check the agent log for 'Reverted changes' (usually an unresolvable allow-listed host)."
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false

--- a/.github/workflows/bestaxbot-reply.yml
+++ b/.github/workflows/bestaxbot-reply.yml
@@ -180,15 +180,19 @@ jobs:
         # telemetry on would put the Datadog host in that report, inviting whoever
         # reads it to allow-list a host we have just decided to deny.
         #
-        # A step `env:` rather than the action's `settings:` input. `settings:` is
-        # written to the USER-level ~/.claude/settings.json, which a project-level
-        # .claude/settings.json in the workspace overrides. This job does NOT check
-        # out PR-branch code, so nothing in its workspace is attacker-controlled
-        # today — state that accurately rather than borrowing a sibling's threat
-        # model. The env form is used so the control does not DEPEND on that:
-        # claude-review.yml and claude-pr-loop.yml do check out PR branches and
-        # share this shape, and a checkout change here would silently move this job
-        # into their class. Do not move this back under `with:`.
+        # A step `env:` rather than the action's `settings:` input, and here that
+        # is load-bearing rather than tidiness: `settings:` is written to the
+        # USER-level ~/.claude/settings.json, which a project-level
+        # .claude/settings.json in the workspace OVERRIDES.
+        #
+        # Be exact about why that matters here, because two earlier revisions of
+        # this comment were not. The checkout below passes no `ref:`, so it takes
+        # `github.ref` — and on this workflow's `pull_request_review` and
+        # `pull_request_review_comment` triggers that resolves to
+        # `refs/pull/N/merge`. The workspace therefore holds PR-CONTROLLED code on
+        # those events, and that file is attacker-controlled. A process environment
+        # variable is not overridable that way. Do not move this back under
+        # `with:`.
         env:
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1

--- a/.github/workflows/bestaxbot-reply.yml
+++ b/.github/workflows/bestaxbot-reply.yml
@@ -186,7 +186,7 @@ jobs:
         # .claude/settings.json in the workspace OVERRIDES.
         #
         # Be exact about why that matters here, because two earlier revisions of
-        # this comment were not. The checkout below passes no `ref:`, so it takes
+        # this comment were not. The checkout above passes no `ref:`, so it takes
         # `github.ref` — and on this workflow's `pull_request_review` and
         # `pull_request_review_comment` triggers that resolves to
         # `refs/pull/N/merge`. The workspace therefore holds PR-CONTROLLED code on

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -132,7 +132,7 @@ jobs:
         # .claude/settings.json in the workspace OVERRIDES.
         #
         # Be exact about why that matters here, because two earlier revisions of
-        # this comment were not. The checkout below passes no `ref:`, so it takes
+        # this comment were not. The checkout above passes no `ref:`, so it takes
         # `github.ref` — and on this workflow's `pull_request_review` and
         # `pull_request_review_comment` triggers that resolves to
         # `refs/pull/N/merge`. The workspace therefore holds PR-CONTROLLED code on

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -126,15 +126,19 @@ jobs:
         # telemetry on would put the Datadog host in that report, inviting whoever
         # reads it to allow-list a host we have just decided to deny.
         #
-        # A step `env:` rather than the action's `settings:` input. `settings:` is
-        # written to the USER-level ~/.claude/settings.json, which a project-level
-        # .claude/settings.json in the workspace overrides. This job does NOT check
-        # out PR-branch code, so nothing in its workspace is attacker-controlled
-        # today — state that accurately rather than borrowing a sibling's threat
-        # model. The env form is used so the control does not DEPEND on that:
-        # claude-review.yml and claude-pr-loop.yml do check out PR branches and
-        # share this shape, and a checkout change here would silently move this job
-        # into their class. Do not move this back under `with:`.
+        # A step `env:` rather than the action's `settings:` input, and here that
+        # is load-bearing rather than tidiness: `settings:` is written to the
+        # USER-level ~/.claude/settings.json, which a project-level
+        # .claude/settings.json in the workspace OVERRIDES.
+        #
+        # Be exact about why that matters here, because two earlier revisions of
+        # this comment were not. The checkout below passes no `ref:`, so it takes
+        # `github.ref` — and on this workflow's `pull_request_review` and
+        # `pull_request_review_comment` triggers that resolves to
+        # `refs/pull/N/merge`. The workspace therefore holds PR-CONTROLLED code on
+        # those events, and that file is attacker-controlled. A process environment
+        # variable is not overridable that way. Do not move this back under
+        # `with:`.
         env:
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1

--- a/.github/workflows/security-txt-expiry.yml
+++ b/.github/workflows/security-txt-expiry.yml
@@ -78,10 +78,12 @@ jobs:
       #
       # The list itself is still derived from what the steps below documentedly
       # reach rather than from a measured run; widen it from a StepSecurity
-      # report if one is ever refused. Note the nearest sibling
-      # (auto-close-duplicates.yml, also a scheduled issue-writer) carries no
-      # harden-runner at all; it predates the rule and is tracked in #578 rather
-      # than settled here.
+      # report if one is ever refused. The nearest sibling
+      # (auto-close-duplicates.yml, also a scheduled issue-writer) now carries
+      # the same policy and the same five hosts — its script is dependency-free
+      # and API-only too, so the list covers both. That shared list is the reason
+      # it is safe to leave alone: these five are proven to resolve on every run
+      # of either job, and an entry that stops resolving turns the firewall off.
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block

--- a/.github/workflows/security-txt-expiry.yml
+++ b/.github/workflows/security-txt-expiry.yml
@@ -81,9 +81,16 @@ jobs:
       # report if one is ever refused. The nearest sibling
       # (auto-close-duplicates.yml, also a scheduled issue-writer) now carries
       # the same policy and the same five hosts — its script is dependency-free
-      # and API-only too, so the list covers both. That shared list is the reason
-      # it is safe to leave alone: these five are proven to resolve on every run
-      # of either job, and an entry that stops resolving turns the firewall off.
+      # and API-only too, so the list covers both.
+      #
+      # Do not upgrade that to "these five always resolve" — the list is derived
+      # reach plus observed runs, not a guarantee, and the two failure modes are
+      # not symmetric. A host that fails to resolve at STARTUP makes the agent
+      # revert the firewall and never write `Initialized`, so the assertion below
+      # catches it and the job goes red. A host that stops resolving AFTER
+      # initialization does not: `refreshDNSEntries` re-resolves every 30s and on
+      # failure only logs, leaving both assertion lines passing. Rule 10 carries
+      # the mechanism.
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: block


### PR DESCRIPTION
Two commits, both #577 follow-ups. Neither touches the six audit-mode AI jobs — that flip is still #578 and still blocked, for the reason at the bottom.

## `a041dab` — scope the continue-on-error claim to runtime, and fix two threat models

Review findings from #577's last round, which merged before the round landed. `continue-on-error` does **not** cover action download: resolution and download happen during job initialization, before any step is added to the job, so a failure there fails the job with no step running and the assertion never executes. The merged comment said "download, bootstrap", which is wrong — the flag covers runtime failure of the pre-step only. The preparation case is a real residual and cannot be closed, since `label` pins the same action and fails initialization too; it is now recorded in rule 10 and its failure matrix rather than papered over.

## `ef50ac0` — the smaller half of #578

`auto-close-duplicates` was the last job in this directory that checks out and **executes** repository code with no harden-runner at all. It holds `issues: write` and runs `scripts/auto-close-duplicates.mjs`; nothing was watching its egress. `security-txt-expiry.yml` recorded that as deferred rather than decided. This decides it.

**`block`, not `audit`.** The untrusted-trigger class whose broken cache probe caused #487's silent downgrade does not include `schedule`/`workflow_dispatch`, and block was already observed arming on the nearest sibling (run 31952287389). Assertion at rule 10's default placement — neither exception applies, since nothing `always()`-guarded keys off this job's outputs and the job is not itself a fail-closed path.

**The allowlist is the sibling's five hosts, unchanged and deliberately so.** The script is dependency-free (`node:` builtins + global `fetch`) against `api.github.com`; checkout and setup-node cover the rest. Adding no new host is what keeps the NXDOMAIN mode off this change — an allow-listed domain that fails to resolve makes the agent revert the firewall while the pre-step still exits 0, which is how `statsig.anthropic.com` turned enforcement off on #577's first run.

### Verified on a real run, not just parsed

Dispatched against this branch ([run 33221210633](https://github.com/allxsmith/bestax/actions/runs/33221210633), `AI_TRIAGE_AUTOCLOSE=dry-run`, so nothing was closed):

- agent config reads `"egress_policy":"block"`, and the agent wrote `Initialized` — no `Reverted changes`, no `timed out`
- `Assert egress policy is enforced` green on that evidence rather than vacuously
- the script completed under the firewall: `scanned=15 would-close=0`, i.e. 15 API calls actually passed through it

### Inventory

Updated for the job moving groups, derived rather than incremented — and the derivation caught its own trap. A plain `grep "egress-policy: block"` returns **fourteen**, because `deploy-worker.yml` names the policy in a comment; the key count is **thirteen**. That caveat is now written next to the number, since it is the same failure mode as the `node -e`-in-a-comment misclassification the rule already warns about. A YAML parse confirms all thirteen block jobs carry the assertion, and that the six remaining audit jobs are exactly the ones #578 tracks.

## What is NOT here

The six-job block flip. #578 step 1 requires each job's endpoint list from StepSecurity reports in audit mode, and no audit-mode run has produced one yet — since #577 merged, `claude-pr-loop`'s `fix`/`verify` have been skipped on every run, and `claude` / `claude-review` / `bestaxbot-reply` are skipped or `action_required`. Guessing an allowlist is the mistake #487 documents in reverse. #578 stays open for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network egress restrictions and enforcement checks to the duplicate-cleanup workflow.
  * The workflow now permits only five approved endpoints and verifies successful policy initialization.

* **Documentation**
  * Updated security guidance, failure scenarios, workflow behavior, and enforcement inventories.
  * Clarified checkout and configuration behavior for review-triggered automation workflows.
  * Documented the shared security policy applied across related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->