### PR TITLE
chore: bring allowBuilds under the bypass-expiry gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ Full versioning details (breaking-change footers, tag formats): `VERSIONING.md`.
 
 - Install/postinstall scripts are **blocked by default** — new native deps need an `allowBuilds` entry.
 - `minimumReleaseAge` cooldown: versions younger than 3 days won't install.
-- **Every bypass carries an expiry.** Entries in `overrides`, `minimumReleaseAgeExclude` and
+- **Every bypass carries an expiry.** Entries in `allowBuilds` (grants only — a `pkg: false`
+  denial restates the default and is exempt), `overrides`, `minimumReleaseAgeExclude` and
   `auditConfig.ignoreGhsas` need `# bestax:review YYYY-MM-DD — why` (or `# bestax:permanent — why`
   for standing policy) in the comment above them. `check:conformance --only=bypass-expiry` fails
   on a missing annotation and again once a date arrives, so a temporary bypass can't silently

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,13 @@ the build if an entry has no annotation, and fails again once a review date arri
 reminder to drop it, re-resolve, and leave it out if nothing changed. A standing policy that is not
 debt (the `prettier` pin) uses `# bestax:permanent — why` instead and never expires.
 
+The same annotation is required when you **grant a package its install scripts** — an
+`allowBuilds: pkg: true` entry re-enables the single most consequential default this repo turns
+off, so say why. Only grants need one: a `pkg: false` entry restates the block-by-default rule and
+the gate leaves it alone. Before granting, check whether the package ships a prebuilt binary for
+your platform as an `optionalDependency` — several here do, which can make the build script
+redundant (see the `@swc/core` entry, denied for exactly that reason).
+
 Note that `pnpm all` does **not** run the conformance checks; CI does. Run
 `pnpm check:conformance` yourself after editing `pnpm-workspace.yaml`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ the build if an entry has no annotation, and fails again once a review date arri
 reminder to drop it, re-resolve, and leave it out if nothing changed. A standing policy that is not
 debt (the `prettier` pin) uses `# bestax:permanent — why` instead and never expires.
 
-The same annotation is required when you **grant a package its install scripts** — an
-`allowBuilds: pkg: true` entry re-enables the single most consequential default this repo turns
-off, so say why. Only grants need one: a `pkg: false` entry restates the block-by-default rule and
+The same annotation is required when you **grant a package its install scripts** — a `pkg: true`
+entry under `allowBuilds` re-enables the single most consequential default this repo turns off, so
+say why. Only grants need one: a `pkg: false` entry restates the block-by-default rule and
 the gate leaves it alone. Before granting, check whether the package ships a prebuilt binary for
 your platform as an `optionalDependency` — several here do, which can make the build script
 redundant (see the `@swc/core` entry, denied for exactly that reason).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,22 @@ packages:
 # scripts. Allow the genuine native builders; deny core-js (its postinstall
 # only prints a funding banner — no build needed).
 allowBuilds:
+  # bestax:review 2026-11-13 — quarterly sweep; grant predates the
+  # platform-binding argument we apply to @swc/core below. esbuild ships 26
+  # prebuilt @esbuild/<platform> packages as optionalDependencies and its
+  # `node install.js` is the fallback that fetches one when none matched, so
+  # this may be droppable. Verify before dropping: unlike @swc/core, install.js
+  # also validates the binary it resolved.
   esbuild: true
+  # bestax:review 2026-11-13 — quarterly sweep; same question as esbuild. The
+  # script is literally `scripts/build-from-source.js` and 13 prebuilt
+  # @parcel/watcher-<platform> packages ship as optionalDependencies, which is
+  # the @swc/core argument almost verbatim.
   '@parcel/watcher': true
+  # bestax:review 2026-11-13 — quarterly sweep; the strongest drop candidate of
+  # the three. `node postinstall.js` is napi-postinstall's generic fallback and
+  # 22 prebuilt @unrs/resolver-binding-<platform> packages ship as
+  # optionalDependencies — the @swc/core reasoning with nothing else added.
   unrs-resolver: true
   core-js: false
   # wrangler (CI-only Cloudflare Pages deploy) pulls these native builds; the
@@ -25,10 +39,11 @@ allowBuilds:
   # (@swc/core-darwin-arm64 etc.), so no script needs to run.
   '@swc/core': false
 
-# Every entry in the three bypass lists below (overrides, the cooldown
-# exclusions, and auditConfig.ignoreGhsas) must carry one of these markers in
-# the comment directly above it — `check:conformance --only=bypass-expiry`
-# fails the build without one, and again once a review date arrives (#391):
+# Every entry in this file's four bypass lists — allowBuilds above, plus
+# overrides, the cooldown exclusions, and auditConfig.ignoreGhsas — must carry
+# one of these markers in the comment directly above it —
+# `check:conformance --only=bypass-expiry` fails the build without one, and
+# again once a review date arrives (#391):
 #
 #   # bestax:review YYYY-MM-DD — why this date
 #   # bestax:permanent — why this is not debt
@@ -36,6 +51,11 @@ allowBuilds:
 # The date is a review-by, not a deadline: when it lands, re-check whether the
 # entry still earns its place, then drop it or push the date out with a reason.
 # CONTRIBUTING.md has the runbook for adding one during a live advisory.
+#
+# allowBuilds is the exception to "every entry": only `pkg: true` needs a
+# marker. A `pkg: false` entry restates the block-by-default rule rather than
+# weakening it, so the gate leaves denials alone — a marker demanded for one
+# would be noise, and reflexive markers are worth less than none.
 #
 # The entries below deliberately share ONE sweep date rather than staggered
 # ones. Staggering would spread the same work over more red-gate events, and

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -592,6 +592,34 @@ publicHoistPattern:
   );
 });
 
+test('a nested allowBuilds key does not satisfy the top-level block', () => {
+  // Raised on review as a fail-open, and it is not one today — `^allowBuilds:`
+  // is already anchored to column zero, so an indented decoy cannot mark the
+  // block seen. Pinned anyway, because the invariant is one keystroke from
+  // being broken: relaxing the header to `/^\s*allowBuilds:\s*$/` — the kind of
+  // "be lenient about indentation" change that looks harmless — would let the
+  // decoy satisfy blocksSeen while a real top-level flow mapping stays
+  // unparsed, and the gate would go green over a live unannotated grant.
+  //
+  // The flow mapping matches neither `header` nor `empty`, which is correct:
+  // an unsupported shape must leave the block UNSEEN so the missing-block
+  // check fires, rather than being read as an empty one.
+  const { entries, problems, blocksSeen } = parseBypassEntries(`
+otherConfig:
+  allowBuilds:
+    harmless: false
+
+allowBuilds: { unannotated-grant: true }
+`);
+  assert.equal(
+    blocksSeen.has('allowBuilds'),
+    false,
+    'a nested decoy must not mark the block as seen'
+  );
+  assert.deepEqual(entries, []);
+  assert.deepEqual(problems, []);
+});
+
 test('an explicitly emptied block counts as seen, per collection type', () => {
   // Pruning the last entry must not require editing BYPASS_BLOCKS: removing a
   // block definition would unpolice that surface permanently, so an entry

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -75,8 +75,11 @@ overrides:
   assert.equal(entries[0].review, null);
 });
 
-test('covers all three bypass lists, including the nested one', () => {
+test('covers all four bypass lists, including the nested one', () => {
   const { entries } = parseBypassEntries(`
+allowBuilds:
+  # bestax:permanent — native builder
+  somebuilder: true
 minimumReleaseAgeExclude:
   # bestax:permanent — deterministic formatting
   - prettier
@@ -90,10 +93,127 @@ auditConfig:
 `);
   assert.deepEqual(
     entries.map(e => e.label),
-    ['minimumReleaseAgeExclude', 'overrides', 'auditConfig.ignoreGhsas']
+    [
+      'allowBuilds',
+      'minimumReleaseAgeExclude',
+      'overrides',
+      'auditConfig.ignoreGhsas',
+    ]
   );
+  assert.equal(byName(entries, 'somebuilder').permanent, true);
   assert.equal(byName(entries, 'prettier').permanent, true);
   assert.equal(byName(entries, 'GHSA-aaaa-bbbb-cccc').review, '2026-11-13');
+});
+
+// --- allowBuilds (#516). The only block whose entries carry a value, so it is
+// the only one where the parser has to decide what IS a bypass. Every test
+// below pins a way that decision could fail open: a grant that needs a marker
+// slipping through as a denial, or a denial's comment leaking onto a grant.
+
+test('an allowBuilds grant with no marker is unannotated', () => {
+  const { entries } = parseBypassEntries(`
+allowBuilds:
+  somepkg: true
+`);
+  assert.equal(entries.length, 1);
+  const { unannotated } = findExpired(entries, '2026-08-28');
+  assert.deepEqual(
+    unannotated.map(e => e.name),
+    ['somepkg']
+  );
+});
+
+test('an allowBuilds denial needs no marker, and is not an entry at all', () => {
+  // Absent from `entries` rather than merely unflagged: a `false` entry
+  // restates the block-by-default rule, so it is not a bypass to police.
+  // Reporting it would make the gate noise, and noise trains reflexive markers.
+  const { entries, problems } = parseBypassEntries(`
+allowBuilds:
+  somepkg: false
+`);
+  assert.deepEqual(entries, []);
+  assert.deepEqual(problems, []);
+});
+
+test('flipping a grant to a denial stops requiring a marker', () => {
+  const granted = parseBypassEntries('allowBuilds:\n  somepkg: true\n');
+  assert.equal(
+    findExpired(granted.entries, '2026-08-28').unannotated.length,
+    1
+  );
+
+  const denied = parseBypassEntries('allowBuilds:\n  somepkg: false\n');
+  assert.equal(findExpired(denied.entries, '2026-08-28').unannotated.length, 0);
+});
+
+test('a denial does not pass its comment block down to the next grant', () => {
+  // The fail-open specific to this block. A denial is skipped, and skipping it
+  // WITHOUT consuming its comment block would let that block annotate the next
+  // entry — so an unannotated grant beneath a commented denial would read as
+  // annotated, and the gate would go green over a live unexplained bypass.
+  const { entries } = parseBypassEntries(`
+allowBuilds:
+  # bestax:permanent — why this package is denied
+  denied: false
+  granted: true
+`);
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['granted']
+  );
+  assert.equal(byName(entries, 'granted').permanent, false);
+  assert.equal(byName(entries, 'granted').review, null);
+});
+
+test('an unparseable line in allowBuilds does not leak its comment either', () => {
+  const { entries, problems } = parseBypassEntries(`
+allowBuilds:
+  # bestax:permanent — belongs to the broken line, not to what follows
+  : nonsense
+  granted: true
+`);
+  assert.equal(problems.length, 1);
+  assert.equal(byName(entries, 'granted').permanent, false);
+});
+
+test('YAML boolean aliases are grants, not silently non-bypasses', () => {
+  // `=== 'true'` would read every one of these as NOT a bypass, leaving a live
+  // grant unannotated and unpoliced — the fail-open this classifier exists for.
+  for (const value of ['true', 'TRUE', 'True', 'yes', 'on']) {
+    const { entries } = parseBypassEntries(
+      `allowBuilds:\n  somepkg: ${value}\n`
+    );
+    assert.equal(entries.length, 1, `${value} should be a grant`);
+  }
+  for (const value of ['false', 'FALSE', 'no', 'off']) {
+    const { entries } = parseBypassEntries(
+      `allowBuilds:\n  somepkg: ${value}\n`
+    );
+    assert.deepEqual(entries, [], `${value} should be a denial`);
+  }
+});
+
+test('an unrecognised allowBuilds value is reported, not assumed', () => {
+  // Neither verdict is safe for a value the parser does not understand, and
+  // guessing "denial" would be the fail-open. Report it and let the run go red.
+  const { entries, problems } = parseBypassEntries(`
+allowBuilds:
+  somepkg: mabye
+`);
+  assert.deepEqual(entries, []);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0].why, /unrecognised value/);
+  assert.match(problems[0].why, /somepkg/);
+});
+
+test('an inline comment is not read as part of the value', () => {
+  const { entries } = parseBypassEntries(`
+allowBuilds:
+  # bestax:permanent — a real reason
+  somepkg: true # still a grant
+`);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].permanent, true);
 });
 
 test('does not mistake a later top-level key for a bypass entry', () => {

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -21,6 +21,7 @@ import {
   parseBypassEntries,
   findExpired,
 } from './lib/bypass-annotations.mjs';
+import { expiryRemediation } from './check-conformance.mjs';
 
 const REPO = join(import.meta.dirname, '..');
 const byName = (entries, name) => entries.find(e => e.name === name);
@@ -596,6 +597,54 @@ publicHoistPattern:
     ['thing@1'],
     'publicHoistPattern entries must not be mistaken for bypasses'
   );
+});
+
+// --- The remediation message. This is the entire product of an expiry firing:
+// the whole mechanism exists to put these words in front of someone on the day
+// the date arrives. A wrong one sends them to run a check that cannot see the
+// thing it is meant to prove, and they believe the answer.
+
+test('an expired allowBuilds grant gets install evidence, not audit advice', () => {
+  const msg = expiryRemediation('allowBuilds');
+  // The from-scratch requirement is the load-bearing half: an in-place install
+  // reuses what the package built while the grant was live, so the build can
+  // pass over artifacts a fresh machine would never have, and the entry gets
+  // retired on evidence that proves nothing.
+  assert.match(msg, /FROM SCRATCH/);
+  assert.match(msg, /node_modules/);
+  assert.match(msg, /--frozen-lockfile/);
+  assert.match(msg, /every platform we build on/);
+  // And it must NOT hand over the dependency-resolution advice: dropping a
+  // lifecycle grant changes no resolution and no audit output, so a clean
+  // `pnpm audit` here is not evidence of anything.
+  assert.doesNotMatch(msg, /re-resolve/);
+  assert.doesNotMatch(msg, /audit-level=high/);
+});
+
+test('every other surface keeps the original re-resolve remediation', () => {
+  // The branch must not leak the allowBuilds wording onto the three blocks
+  // #514 shipped — for those, re-resolving and a clean audit ARE the evidence.
+  for (const label of [
+    'overrides',
+    'minimumReleaseAgeExclude',
+    'auditConfig.ignoreGhsas',
+  ]) {
+    const msg = expiryRemediation(label);
+    assert.match(msg, /re-resolve/, `${label} keeps the resolution advice`);
+    assert.match(msg, /audit-level=high/, `${label} keeps the audit advice`);
+    assert.doesNotMatch(msg, /FROM SCRATCH/, `${label} is not an install case`);
+  }
+});
+
+test('every policed block has a remediation that names a real check', () => {
+  // Guards the branch against a block being added later and silently falling
+  // through to advice that does not apply to it — the defect this pair of
+  // messages was split apart to fix.
+  for (const block of BYPASS_BLOCKS) {
+    const msg = expiryRemediation(block.label);
+    assert.match(msg, /bestax:review/, `${block.label} says how to defer`);
+    assert.ok(msg.length > 80, `${block.label} says what to actually do`);
+  }
 });
 
 test('a nested allowBuilds key does not satisfy the top-level block', () => {

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -176,21 +176,42 @@ allowBuilds:
   assert.equal(byName(entries, 'granted').permanent, false);
 });
 
-test('YAML boolean aliases are grants, not silently non-bypasses', () => {
-  // `=== 'true'` would read every one of these as NOT a bypass, leaving a live
-  // grant unannotated and unpoliced — the fail-open this classifier exists for.
-  for (const value of ['true', 'TRUE', 'True', 'yes', 'on']) {
-    const { entries } = parseBypassEntries(
+test('only the literal true and false are classified', () => {
+  const grant = parseBypassEntries('allowBuilds:\n  somepkg: true\n');
+  assert.equal(grant.entries.length, 1);
+  const denial = parseBypassEntries('allowBuilds:\n  somepkg: false\n');
+  assert.deepEqual(denial.entries, []);
+  assert.deepEqual(denial.problems, []);
+});
+
+test('YAML 1.1 boolean habits are reported, never read as denials', () => {
+  // These four were accepted as aliases in the first version of this parser,
+  // and that was a fail-open. pnpm reads this file as YAML 1.2, where `no` is
+  // the STRING "no" — truthy, so pnpm grants the build. Calling it a denial
+  // would wave through, with no annotation, an entry that is live in pnpm.
+  // `TRUE`/`False` are the same story: strings, and the uppercase one is
+  // truthy.
+  for (const value of ['yes', 'no', 'on', 'off', 'TRUE', 'False']) {
+    const { entries, problems } = parseBypassEntries(
       `allowBuilds:\n  somepkg: ${value}\n`
     );
-    assert.equal(entries.length, 1, `${value} should be a grant`);
+    assert.deepEqual(entries, [], `${value} must not be classified`);
+    assert.equal(problems.length, 1, `${value} must be reported`);
   }
-  for (const value of ['false', 'FALSE', 'no', 'off']) {
-    const { entries } = parseBypassEntries(
-      `allowBuilds:\n  somepkg: ${value}\n`
-    );
-    assert.deepEqual(entries, [], `${value} should be a denial`);
-  }
+});
+
+test('a value glued to a # is the whole scalar, not a value plus a comment', () => {
+  // YAML opens an inline comment only at ` #`, so `false#note` is the single
+  // string "false#note" — truthy, and a live grant in pnpm. Matching the
+  // `#note` as a comment handed the classifier a tidy "false" and the gate
+  // asked for no annotation: a fail-open on a grant.
+  const { entries, problems } = parseBypassEntries(`
+allowBuilds:
+  somepkg: false#note
+`);
+  assert.deepEqual(entries, []);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0].why, /false#note/);
 });
 
 test('an unrecognised allowBuilds value is reported, not assumed', () => {

--- a/scripts/bypass-annotations.test.mjs
+++ b/scripts/bypass-annotations.test.mjs
@@ -184,13 +184,17 @@ test('only the literal true and false are classified', () => {
   assert.deepEqual(denial.problems, []);
 });
 
-test('YAML 1.1 boolean habits are reported, never read as denials', () => {
-  // These four were accepted as aliases in the first version of this parser,
-  // and that was a fail-open. pnpm reads this file as YAML 1.2, where `no` is
-  // the STRING "no" — truthy, so pnpm grants the build. Calling it a denial
-  // would wave through, with no annotation, an entry that is live in pnpm.
-  // `TRUE`/`False` are the same story: strings, and the uppercase one is
-  // truthy.
+test('noncanonical boolean spellings are reported, not classified', () => {
+  // Canonical-spelling rule, and the two halves fail differently — an earlier
+  // version of this comment claimed both were live grants, which was wrong:
+  //
+  // - `TRUE`/`False` ARE real booleans (YAML 1.2 resolves all three
+  //   capitalisations), so `TRUE` is a genuine live grant. Reporting it is what
+  //   keeps a live grant from going unannotated.
+  // - `yes`/`no`/`on`/`off` are plain strings, and pnpm's allowBuild switch has
+  //   only `case true:` / `case false:` — a string matches neither, so the
+  //   entry is DROPPED. Inert rather than dangerous, but an ignored entry is a
+  //   policy not in force with nothing to tell you, which is its own problem.
   for (const value of ['yes', 'no', 'on', 'off', 'TRUE', 'False']) {
     const { entries, problems } = parseBypassEntries(
       `allowBuilds:\n  somepkg: ${value}\n`
@@ -202,9 +206,11 @@ test('YAML 1.1 boolean habits are reported, never read as denials', () => {
 
 test('a value glued to a # is the whole scalar, not a value plus a comment', () => {
   // YAML opens an inline comment only at ` #`, so `false#note` is the single
-  // string "false#note" — truthy, and a live grant in pnpm. Matching the
-  // `#note` as a comment handed the classifier a tidy "false" and the gate
-  // asked for no annotation: a fail-open on a grant.
+  // string "false#note", not the boolean `false` plus a note. Matching the
+  // `#note` as a comment handed the classifier a tidy "false", so the gate
+  // called the line a deliberate denial while pnpm — which switches on real
+  // booleans — dropped the entry as unreadable. Two different readings of the
+  // same line, and neither party says so.
   const { entries, problems } = parseBypassEntries(`
 allowBuilds:
   somepkg: false#note

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2510,27 +2510,6 @@ async function checkBypassExpiry() {
     );
   }
 
-  // The remediation differs by surface, and the generic one is actively wrong
-  // for `allowBuilds`: dropping a lifecycle-script grant changes no resolution
-  // and no audit output, so "re-resolve and check audit" passes cleanly while
-  // the install or a fallback native build is broken. Telling someone to run
-  // the wrong check is worse than telling them nothing.
-  const remediation = label =>
-    label === 'allowBuilds'
-      ? `. For each: set it to \`false\`, then reinstall FROM SCRATCH — remove ` +
-        `node_modules and run \`pnpm install --frozen-lockfile\` — and run the ` +
-        `full build and test gate. Installing in place proves nothing: ` +
-        `node_modules still holds what the package built while the grant was ` +
-        `live, so the build can pass over artifacts a fresh machine would ` +
-        `never have. A grant is only droppable if the package resolves a ` +
-        `prebuilt binary on every platform we build on, which is why CI is the ` +
-        `real check here and \`pnpm audit\` is not. Still needed? Push its ` +
-        `\`# bestax:review\` date out and say why in the same comment.`
-      : `. For each: drop it, re-resolve, and leave it out if the resolved ` +
-        `version is unchanged and \`pnpm audit --audit-level=high\` stays ` +
-        `clean. Still load-bearing? Push its \`# bestax:review\` date out and ` +
-        `say why in the same comment.`;
-
   for (const label of new Set(expired.map(e => e.label))) {
     const due = expired.filter(e => e.label === label);
     violations.push(
@@ -2538,7 +2517,7 @@ async function checkBypassExpiry() {
         due.length === 1 ? 'y is' : 'ies are'
       } due for review as of ${today} — ` +
         due.map(e => `${e.name} (line ${e.line}, ${e.review})`).join(', ') +
-        remediation(label)
+        expiryRemediation(label)
     );
   }
 
@@ -2555,6 +2534,35 @@ async function checkBypassExpiry() {
 
   return violations;
 }
+
+/**
+ * What to actually DO about an expired bypass, which differs by surface.
+ *
+ * The generic advice is actively wrong for `allowBuilds`: dropping a
+ * lifecycle-script grant changes no resolution and no audit output, so
+ * "re-resolve and check audit" passes cleanly while the install or a fallback
+ * native build is broken. Telling someone to run the wrong check is worse than
+ * telling them nothing, because they will believe the answer.
+ *
+ * Exported, and separated from `checkBypassExpiry`, so the branch is testable:
+ * this message is the entire product of an expiry firing, and a wrong one
+ * retires a live grant on false evidence.
+ */
+export const expiryRemediation = label =>
+  label === 'allowBuilds'
+    ? `. For each: set it to \`false\`, then reinstall FROM SCRATCH — remove ` +
+      `node_modules and run \`pnpm install --frozen-lockfile\` — and run the ` +
+      `full build and test gate. Installing in place proves nothing: ` +
+      `node_modules still holds what the package built while the grant was ` +
+      `live, so the build can pass over artifacts a fresh machine would ` +
+      `never have. A grant is only droppable if the package resolves a ` +
+      `prebuilt binary on every platform we build on, which is why CI is the ` +
+      `real check here and \`pnpm audit\` is not. Still needed? Push its ` +
+      `\`# bestax:review\` date out and say why in the same comment.`
+    : `. For each: drop it, re-resolve, and leave it out if the resolved ` +
+      `version is unchanged and \`pnpm audit --audit-level=high\` stays ` +
+      `clean. Still load-bearing? Push its \`# bestax:review\` date out and ` +
+      `say why in the same comment.`;
 
 // --- skills-roster -----------------------------------------------------------
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2500,6 +2500,23 @@ async function checkBypassExpiry() {
     );
   }
 
+  // The remediation differs by surface, and the generic one is actively wrong
+  // for `allowBuilds`: dropping a lifecycle-script grant changes no resolution
+  // and no audit output, so "re-resolve and check audit" passes cleanly while
+  // the install or a fallback native build is broken. Telling someone to run
+  // the wrong check is worse than telling them nothing.
+  const remediation = label =>
+    label === 'allowBuilds'
+      ? `. For each: set it to \`false\`, run \`pnpm install\` and then the ` +
+        `full build and test gate — a grant is only droppable if the package ` +
+        `resolves a prebuilt binary for every platform we build on, so a clean ` +
+        `install here is the evidence, not \`pnpm audit\`. Still needed? Push ` +
+        `its \`# bestax:review\` date out and say why in the same comment.`
+      : `. For each: drop it, re-resolve, and leave it out if the resolved ` +
+        `version is unchanged and \`pnpm audit --audit-level=high\` stays ` +
+        `clean. Still load-bearing? Push its \`# bestax:review\` date out and ` +
+        `say why in the same comment.`;
+
   for (const label of new Set(expired.map(e => e.label))) {
     const due = expired.filter(e => e.label === label);
     violations.push(
@@ -2507,10 +2524,7 @@ async function checkBypassExpiry() {
         due.length === 1 ? 'y is' : 'ies are'
       } due for review as of ${today} — ` +
         due.map(e => `${e.name} (line ${e.line}, ${e.review})`).join(', ') +
-        `. For each: drop it, re-resolve, and leave it out if the resolved ` +
-        `version is unchanged and \`pnpm audit --audit-level=high\` stays ` +
-        `clean. Still load-bearing? Push its \`# bestax:review\` date out and ` +
-        `say why in the same comment.`
+        remediation(label)
     );
   }
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2445,11 +2445,15 @@ async function checkPublishableManifests() {
 }
 
 /**
- * Supply-chain bypasses expire (#391). `overrides`, `minimumReleaseAgeExclude`
- * and `auditConfig.ignoreGhsas` each weaken a default we otherwise hold, and
- * every one of them is written as temporary — but nothing made that observable,
- * so entries outlived their stated reason until an unrelated PR happened to
- * audit the file.
+ * Supply-chain bypasses expire (#391). `allowBuilds`, `overrides`,
+ * `minimumReleaseAgeExclude` and `auditConfig.ignoreGhsas` each weaken a
+ * default we otherwise hold, and every one of them is written as temporary —
+ * but nothing made that observable, so entries outlived their stated reason
+ * until an unrelated PR happened to audit the file.
+ *
+ * In `allowBuilds` only `pkg: true` counts (#516): a `false` entry restates the
+ * block-by-default rule rather than weakening it. The parser makes that call —
+ * see `classifyAllowBuild` in scripts/lib/bypass-annotations.mjs.
  *
  * Two failure modes, and the second is what gives this teeth: a review date
  * that has arrived, and an entry with no annotation at all. Without the latter,

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2471,17 +2471,27 @@ async function checkBypassExpiry() {
 
   // Per block, not merely in total: one block going silent while the other two
   // keep the count nonzero is the same fail-open the parser guards against.
+  //
+  // This is also where a whole-block FLOW mapping lands (`allowBuilds: { pkg:
+  // true }`): the parser reads line-oriented block style only, so a flow form
+  // matches neither `header` nor `empty` and the block reads as absent. That is
+  // the right outcome — red, nothing policed silently — but the message has to
+  // name it, or the one authoring mistake that triggers it sends you looking for
+  // a rename that never happened.
   const missing = BYPASS_BLOCKS.filter(b => !blocksSeen.has(b.key));
   if (missing.length) {
     return missing.map(
       b =>
         `pnpm-workspace.yaml: the \`${b.label}\` block was not found, so ` +
-        `nothing in it is policed. If it moved or was renamed, fix its ` +
-        `pattern in scripts/lib/bypass-annotations.mjs. If you pruned its ` +
-        `last entry, keep the key and write \`${b.emptyLiteral}\` rather than ` +
-        `deleting it — dropping a block from BYPASS_BLOCKS unpolices that ` +
-        `surface permanently, so entries would sail through unannotated if ` +
-        `the list ever came back.`
+        `nothing in it is policed. Three things do this. If you wrote it in ` +
+        `FLOW style (\`${b.key}: { … }\` or \`[ … ]\` on one line), use block ` +
+        `style instead — this parser is line-oriented and cannot read the flow ` +
+        `form. If it moved or was renamed, fix its pattern in ` +
+        `scripts/lib/bypass-annotations.mjs. If you pruned its last entry, keep ` +
+        `the key and write \`${b.emptyLiteral}\` rather than deleting it — ` +
+        `dropping a block from BYPASS_BLOCKS unpolices that surface ` +
+        `permanently, so entries would sail through unannotated if the list ` +
+        `ever came back.`
     );
   }
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2507,11 +2507,15 @@ async function checkBypassExpiry() {
   // the wrong check is worse than telling them nothing.
   const remediation = label =>
     label === 'allowBuilds'
-      ? `. For each: set it to \`false\`, run \`pnpm install\` and then the ` +
-        `full build and test gate — a grant is only droppable if the package ` +
-        `resolves a prebuilt binary for every platform we build on, so a clean ` +
-        `install here is the evidence, not \`pnpm audit\`. Still needed? Push ` +
-        `its \`# bestax:review\` date out and say why in the same comment.`
+      ? `. For each: set it to \`false\`, then reinstall FROM SCRATCH — remove ` +
+        `node_modules and run \`pnpm install --frozen-lockfile\` — and run the ` +
+        `full build and test gate. Installing in place proves nothing: ` +
+        `node_modules still holds what the package built while the grant was ` +
+        `live, so the build can pass over artifacts a fresh machine would ` +
+        `never have. A grant is only droppable if the package resolves a ` +
+        `prebuilt binary on every platform we build on, which is why CI is the ` +
+        `real check here and \`pnpm audit\` is not. Still needed? Push its ` +
+        `\`# bestax:review\` date out and say why in the same comment.`
       : `. For each: drop it, re-resolve, and leave it out if the resolved ` +
         `version is unchanged and \`pnpm audit --audit-level=high\` stays ` +
         `clean. Still load-bearing? Push its \`# bestax:review\` date out and ` +

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -39,16 +39,26 @@
  * demanding a marker for one would make the gate noise — which trains people to
  * add markers reflexively, and a reflexive marker is worth less than none.
  *
- * ONLY the literal `true` and `false` are recognised. Everything else — a typo,
- * or a YAML 1.1 habit like `yes`/`no`/`on`/`off` — is `null` and gets reported.
+ * ONLY the literal lowercase `true` and `false` are recognised. Everything else
+ * — a typo, an uppercase `TRUE`, or a YAML 1.1 habit like `yes`/`no`/`on`/`off`
+ * — is `null` and gets reported. This is a CANONICAL-SPELLING rule, and the two
+ * things it catches are different, so do not collapse them:
  *
- * Treating those four as aliases was the first version of this function and it
- * was a fail-open, which is worth recording so nobody helpfully adds them back.
- * pnpm reads this file as YAML 1.2, where the boolean vocabulary is exactly
- * `true`/`false` and `no` is the plain STRING "no" — and a non-empty string is
- * truthy, so pnpm grants the build. Classifying `no` as a denial would have had
- * the gate wave through, unannotated, an entry that is live in pnpm. The safe
- * reading of an unrecognised value is not "probably a denial", it is "stop".
+ * - `TRUE`/`True` (and `FALSE`/`False`) are real booleans: YAML 1.2's core
+ *   schema resolves all three capitalisations, so `esbuild: TRUE` is a genuine,
+ *   live grant. Reporting it is what stops a live grant going unannotated.
+ * - `yes`/`no`/`on`/`off` are plain STRINGS under YAML 1.2, and pnpm's
+ *   `createAllowBuildFunction` switches on the actual booleans — `case true:` /
+ *   `case false:`, nothing else — so a string matches neither arm and the entry
+ *   is simply DROPPED. It is inert: it neither grants nor denies, and whatever
+ *   the author meant by it silently did not happen.
+ *
+ * That second half corrects what an earlier revision of this comment claimed.
+ * It said a string value is truthy and therefore grants the build. It does not:
+ * pnpm never coerces it, and an entry it cannot read is one it ignores. The
+ * reason to reject those spellings is that an ignored entry is a policy not in
+ * force with nothing to tell you, not that it is a live bypass. Verified in the
+ * pinned pnpm 11.9.0 rather than assumed — see the switch in dist/pnpm.mjs.
  */
 const classifyAllowBuild = value => {
   if (value === 'true') return 'bypass';
@@ -72,11 +82,13 @@ export const BYPASS_BLOCKS = [
     //
     // The comment tail requires LEADING WHITESPACE, which is not cosmetic. YAML
     // starts an inline comment only at ` #`, so `pkg: false#note` is the single
-    // scalar string "false#note" — truthy, and therefore a live grant in pnpm.
-    // An earlier `(?:#.*)?` here matched the `#note` as a comment and handed
-    // `classify` a tidy "false", so the gate called it a denial and asked for no
-    // annotation: a fail-open on a grant. Now the whole malformed scalar reaches
-    // `classify`, fails to match either literal, and is reported.
+    // scalar string "false#note" — not the boolean `false` plus a note. An
+    // earlier `(?:#.*)?` here matched the `#note` as a comment and handed
+    // `classify` a tidy "false", so the gate read the line as a denial and asked
+    // for no annotation, while pnpm reads a string it cannot switch on and drops
+    // the entry entirely. The gate said "policy, deliberate"; the file said
+    // nothing at all. Now the whole malformed scalar reaches `classify` and is
+    // reported.
     entry: /^\s+(.+?):[ \t]*(\S+)(?:[ \t]+#.*)?[ \t]*$/,
     list: false,
     label: 'allowBuilds',
@@ -356,9 +368,12 @@ export function parseBypassEntries(yaml) {
             `inside \`${active.label}\`, ${JSON.stringify(
               unquote(item[1].trim())
             )} has the unrecognised value ${JSON.stringify(item[2] ?? '')}. ` +
-            `Write \`true\` or \`false\` — a value this parser cannot classify ` +
-            `is treated as neither a grant nor a denial, which would leave a ` +
-            `live grant unpoliced.`,
+            `Write lowercase \`true\` or \`false\`. pnpm switches on the real ` +
+            `booleans and drops anything else, so this entry is inert — it ` +
+            `neither grants nor denies, and nothing reports that whatever you ` +
+            `meant by it did not happen. (\`TRUE\` is the exception that makes ` +
+            `this fail closed rather than merely tidy: YAML resolves it to a ` +
+            `real boolean, so it IS a live grant.)`,
         });
         comments = [];
         continue;

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -39,17 +39,20 @@
  * demanding a marker for one would make the gate noise — which trains people to
  * add markers reflexively, and a reflexive marker is worth less than none.
  *
- * Unrecognized values are `null` rather than falling back to either verdict,
- * and that is the whole reason this is a function instead of `v === 'true'`.
- * YAML's boolean vocabulary is wider than one word: under a `=== 'true'` test
- * `esbuild: yes` reads as NOT-a-bypass, so a live grant would sit unannotated
- * and unpoliced — a silent fail-open in the gate whose entire job is failing
- * closed. Anything unrecognized is reported instead, so a typo is loud.
+ * ONLY the literal `true` and `false` are recognised. Everything else — a typo,
+ * or a YAML 1.1 habit like `yes`/`no`/`on`/`off` — is `null` and gets reported.
+ *
+ * Treating those four as aliases was the first version of this function and it
+ * was a fail-open, which is worth recording so nobody helpfully adds them back.
+ * pnpm reads this file as YAML 1.2, where the boolean vocabulary is exactly
+ * `true`/`false` and `no` is the plain STRING "no" — and a non-empty string is
+ * truthy, so pnpm grants the build. Classifying `no` as a denial would have had
+ * the gate wave through, unannotated, an entry that is live in pnpm. The safe
+ * reading of an unrecognised value is not "probably a denial", it is "stop".
  */
 const classifyAllowBuild = value => {
-  const v = value.toLowerCase();
-  if (v === 'true' || v === 'yes' || v === 'on') return 'bypass';
-  if (v === 'false' || v === 'no' || v === 'off') return 'denial';
+  if (value === 'true') return 'bypass';
+  if (value === 'false') return 'denial';
   return null;
 };
 
@@ -65,12 +68,16 @@ export const BYPASS_BLOCKS = [
     empty: /^allowBuilds:[ \t]*\{[ \t]*\}[ \t]*$/,
     emptyLiteral: 'allowBuilds: {}',
     // Group 2 is the VALUE, which only this block needs: `classify` reads it to
-    // tell a grant from a denial. The `(?:#.*)?` tail keeps an inline comment
-    // out of the captured value — without it `esbuild: true # note` captures
-    // "true" only because `\S+` stops at the space, which is luck rather than
-    // intent, and `esbuild: true# note` would capture "true#" and classify as
-    // null.
-    entry: /^\s+(.+?):[ \t]*(\S+?)[ \t]*(?:#.*)?$/,
+    // tell a grant from a denial.
+    //
+    // The comment tail requires LEADING WHITESPACE, which is not cosmetic. YAML
+    // starts an inline comment only at ` #`, so `pkg: false#note` is the single
+    // scalar string "false#note" — truthy, and therefore a live grant in pnpm.
+    // An earlier `(?:#.*)?` here matched the `#note` as a comment and handed
+    // `classify` a tidy "false", so the gate called it a denial and asked for no
+    // annotation: a fail-open on a grant. Now the whole malformed scalar reaches
+    // `classify`, fails to match either literal, and is reported.
+    entry: /^\s+(.+?):[ \t]*(\S+)(?:[ \t]+#.*)?[ \t]*$/,
     list: false,
     label: 'allowBuilds',
     classify: classifyAllowBuild,

--- a/scripts/lib/bypass-annotations.mjs
+++ b/scripts/lib/bypass-annotations.mjs
@@ -1,13 +1,20 @@
 /**
  * Parse the dated annotations on pnpm-workspace.yaml's supply-chain bypasses.
  *
- * Three lists in that file weaken a default we otherwise hold: `overrides`
- * forces a transitive version, `minimumReleaseAgeExclude` waives the cooldown,
- * and `auditConfig.ignoreGhsas` waives the audit gate itself. Each entry is
- * meant to be temporary — it stops being load-bearing once the ecosystem
- * catches up — but nothing made that expiry observable, so entries outlived
- * their own stated reason and were only ever noticed by an unrelated PR that
- * happened to audit the file (#391).
+ * Four lists in that file weaken a default we otherwise hold: `allowBuilds`
+ * re-enables install/postinstall lifecycle scripts, `overrides` forces a
+ * transitive version, `minimumReleaseAgeExclude` waives the cooldown, and
+ * `auditConfig.ignoreGhsas` waives the audit gate itself.
+ *
+ * Each entry is meant to be temporary — it stops being load-bearing once the
+ * ecosystem catches up — but nothing made that expiry observable, so entries
+ * outlived their own stated reason and were only ever noticed by an unrelated
+ * PR that happened to audit the file (#391).
+ *
+ * `allowBuilds` is the odd one, and why it arrived a release later than the
+ * other three (#516): its entries carry a value, and only `pkg: true` is a
+ * bypass. A `pkg: false` entry restates the block-by-default rule, so requiring
+ * a marker on one would be noise. See `classifyAllowBuild`.
  *
  * The contract this parser reads: every entry carries either
  *
@@ -23,8 +30,51 @@
  * one to police the cooldown would itself be subject to the cooldown.
  */
 
+/**
+ * Which `allowBuilds` values are grants, which are denials, and which are
+ * neither. Returns 'bypass' | 'denial' | null.
+ *
+ * `allowBuilds` is the one block whose entries are not uniformly bypasses:
+ * `pkg: false` RESTATES the block-by-default rule rather than weakening it, and
+ * demanding a marker for one would make the gate noise — which trains people to
+ * add markers reflexively, and a reflexive marker is worth less than none.
+ *
+ * Unrecognized values are `null` rather than falling back to either verdict,
+ * and that is the whole reason this is a function instead of `v === 'true'`.
+ * YAML's boolean vocabulary is wider than one word: under a `=== 'true'` test
+ * `esbuild: yes` reads as NOT-a-bypass, so a live grant would sit unannotated
+ * and unpoliced — a silent fail-open in the gate whose entire job is failing
+ * closed. Anything unrecognized is reported instead, so a typo is loud.
+ */
+const classifyAllowBuild = value => {
+  const v = value.toLowerCase();
+  if (v === 'true' || v === 'yes' || v === 'on') return 'bypass';
+  if (v === 'false' || v === 'no' || v === 'off') return 'denial';
+  return null;
+};
+
 /** Lists we police, in file order, with the vocabulary each violation uses. */
 export const BYPASS_BLOCKS = [
+  {
+    key: 'allowBuilds',
+    // First in this array because the array is file order and `allowBuilds:`
+    // sits above `overrides:`. Nothing depends on the order, but a reader
+    // checking coverage against the file should not have to jump around.
+    header: /^allowBuilds:\s*$/,
+    // A mapping, so `{}` — see the note on `overrides` below.
+    empty: /^allowBuilds:[ \t]*\{[ \t]*\}[ \t]*$/,
+    emptyLiteral: 'allowBuilds: {}',
+    // Group 2 is the VALUE, which only this block needs: `classify` reads it to
+    // tell a grant from a denial. The `(?:#.*)?` tail keeps an inline comment
+    // out of the captured value — without it `esbuild: true # note` captures
+    // "true" only because `\S+` stops at the space, which is luck rather than
+    // intent, and `esbuild: true# note` would capture "true#" and classify as
+    // null.
+    entry: /^\s+(.+?):[ \t]*(\S+?)[ \t]*(?:#.*)?$/,
+    list: false,
+    label: 'allowBuilds',
+    classify: classifyAllowBuild,
+  },
   {
     key: 'overrides',
     // `overrides:` sits at column 0; its entries are `key: value` pairs. The
@@ -279,6 +329,39 @@ export function parseBypassEntries(yaml) {
       // onto the following entry and report the wrong defect there.
       comments = [];
       continue;
+    }
+
+    // Value-dependent blocks (`allowBuilds`): only a grant is a bypass. Blocks
+    // without `classify` keep the original contract — every entry is one.
+    //
+    // BOTH early exits below clear `comments`, and that is load-bearing rather
+    // than tidiness. A comment block belongs to exactly one entry (see above),
+    // so leaving it set would let the prose above `core-js: false` — or above a
+    // typo'd line — carry down onto the NEXT entry, and an unannotated grant
+    // beneath a denial would read as annotated. That is the same leak the
+    // unparsed-line path guards against below, and it fails open.
+    if (active.classify) {
+      const verdict = active.classify(item[2] ?? '');
+      if (verdict === null) {
+        problems.push({
+          line: i + 1,
+          why:
+            `inside \`${active.label}\`, ${JSON.stringify(
+              unquote(item[1].trim())
+            )} has the unrecognised value ${JSON.stringify(item[2] ?? '')}. ` +
+            `Write \`true\` or \`false\` — a value this parser cannot classify ` +
+            `is treated as neither a grant nor a denial, which would leave a ` +
+            `live grant unpoliced.`,
+        });
+        comments = [];
+        continue;
+      }
+      if (verdict === 'denial') {
+        // A denial restates the safe default; it needs no annotation and is
+        // deliberately absent from `entries` rather than merely unflagged.
+        comments = [];
+        continue;
+      }
     }
 
     entries.push({


### PR DESCRIPTION
Closes #516.

#514 gave `overrides`, `minimumReleaseAgeExclude` and `auditConfig.ignoreGhsas` a gate that fails on an unannotated bypass. `allowBuilds` is a fourth surface with the same shape and had no coverage — each `true` entry re-enables install/postinstall lifecycle scripts, the most consequential default this repo turns off, and nothing recorded why any of the three grants existed.

## Why it needed its own PR

Its entries carry a **value**, and only `pkg: true` is a bypass. A `pkg: false` entry restates the block-by-default rule; demanding a marker for one would make the gate noise, and noise trains people to add markers reflexively — a reflexive marker is worth less than none. None of the existing three blocks had value-dependent logic.

## What the classifier does

Recognises **only lowercase `true` and `false`**. Everything else — a typo, `TRUE`, or a YAML 1.1 habit like `yes`/`no`/`on`/`off` — is reported as an unrecognised value and fails the gate.

This is a **canonical-spelling rule**, and its two halves fail differently. Both were established by checking pnpm 11.9.0 and js-yaml 4, after two earlier revisions of this PR asserted the wrong mechanism:

- **`TRUE`/`True` are real booleans.** YAML 1.2's core schema resolves all three capitalisations, so `esbuild: TRUE` is a genuine live grant. Reporting it is what keeps a live grant from going unannotated — this half fails closed.
- **`yes`/`no`/`on`/`off` are plain strings, and pnpm drops them.** `createAllowBuildFunction` switches on the real booleans (`case true:` / `case false:`, `dist/pnpm.mjs:154435`); a string matches neither arm, so the entry is inert. Not a live grant — a **policy not in force**, with nothing to tell the author their line did nothing.

An earlier revision claimed strings were truthy and therefore granted the build. They are not: pnpm never coerces the value. That claim has been corrected in the code, the tests, and the diagnostic message.

Two other parser details, both about the comment block belonging to exactly one entry:

- **Both non-bypass paths consume it.** Skipping a denial without clearing `comments` would let the prose above `core-js: false` annotate the entry below it.
- **The inline-comment tail requires leading whitespace.** YAML opens a comment only at ` #`, so `pkg: false#note` is the single string `"false#note"`. Matching `#note` as a comment handed the classifier a tidy `"false"` — the gate read a deliberate denial while pnpm read an unusable value and dropped the entry.

Blocks that omit `classify` keep the original contract — every entry is a bypass — so the other three surfaces are untouched.

## The three grants get review dates, not `permanent`

A change from what the issue expected, on evidence collected while writing the reasons. Each ships prebuilt platform packages as `optionalDependencies` alongside a fallback build script:

| Package | Script | Prebuilt platform packages |
| --- | --- | --- |
| `esbuild` | `node install.js` | 26 |
| `@parcel/watcher` | `node scripts/build-from-source.js` | 13 |
| `unrs-resolver` | `node postinstall.js` (napi-postinstall) | 22 |

That is the same argument this file already uses to **deny** `@swc/core` — "the platform binary ships as an optional dependency… so no script needs to run." So all three may be droppable.

**Not dropping them here.** That is a dependency-behaviour change and wants its own PR with a real install and a full build. The review dates are what force the question, which is the point of the gate. `unrs-resolver` is the strongest candidate: its postinstall is napi-postinstall's generic fallback with nothing else added.

## Verification

Against the gate itself, not only the unit tests — a gate that cannot fail is the failure this issue is about. Each case run through `pnpm check:conformance --only=bypass-expiry`:

- unannotated grant → fails, naming the package and the fix
- unannotated **denial** → passes
- `somepkg: mabye` → fails as an unrecognised value
- a grant placed directly beneath the commented `'@swc/core': false` entry → correctly reported as unannotated, so nothing leaked
- an expired `allowBuilds` grant → renders the `allowBuilds` remediation; an expired `overrides` entry → still renders the original one

**44 tests pass (11 added, from a baseline of 33).** Full `pnpm check:conformance` green across all 18 checks; lint and format clean. No `pnpm install` needed — no dependency resolution changes.

## Review history

Four rounds, each finding something real, which is the pattern #514 set over its seven:

1. Copilot: boolean aliases, the `#` comment tail, and dependency-resolution advice in the `allowBuilds` remediation
2. CodeRabbit: a nested-decoy header — **refuted with evidence** (`^allowBuilds:` is already column-zero anchored), with a regression test added anyway, since relaxing that anchor would make the attack real
3. Copilot: an invalid YAML example in CONTRIBUTING.md, and a remediation that could pass on stale build artifacts from an in-place install
4. Copilot: the pnpm/YAML semantics above, and this description being stale