### PR TITLE
ci: fix a missing preposition in the allowlist comment

### DIFF
--- a/.github/workflows/security-txt-expiry.yml
+++ b/.github/workflows/security-txt-expiry.yml
@@ -84,8 +84,8 @@ jobs:
       # and API-only too, so the list covers both.
       #
       # Do not upgrade that to "these five always resolve" — the list is derived
-      # reach plus observed runs, not a guarantee, and the two failure modes are
-      # not symmetric. A host that fails to resolve at STARTUP makes the agent
+      # from documented reach and confirmed by observed runs, which is not a
+      # guarantee about future ones, and the two failure modes are not symmetric. A host that fails to resolve at STARTUP makes the agent
       # revert the firewall and never write `Initialized`, so the assertion below
       # catches it and the job goes red. A host that stops resolving AFTER
       # initialization does not: `refreshDNSEntries` re-resolves every 30s and on


### PR DESCRIPTION
Post-merge follow-up to #585. Copilot left this on that PR just after it merged, so it never got addressed there.

The comment read "the list is derived reach plus observed runs", which is not a sentence. It now says the list is **derived from documented reach and confirmed by observed runs** — which is also more precise about what those runs actually buy: evidence about past runs, not a guarantee about future ones. That distinction is the whole point of the paragraph it sits in, so the sloppy phrasing was undercutting it.

Comment-only; no behaviour change. YAML parse verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the security workflow’s network allowlist is based on documented reach and observed workflow runs.
  * Noted that the allowlist does not guarantee future DNS resolution, improving accuracy and setting clearer expectations for ongoing maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->