### PR TITLE
chore: drop all three allowBuilds grants

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,11 +19,6 @@ allowBuilds:
   # this may be droppable. Verify before dropping: unlike @swc/core, install.js
   # also validates the binary it resolved.
   esbuild: true
-  # bestax:review 2026-11-13 — quarterly sweep; the strongest drop candidate of
-  # the three. `node postinstall.js` is napi-postinstall's generic fallback and
-  # 22 prebuilt @unrs/resolver-binding-<platform> packages ship as
-  # optionalDependencies — the @swc/core reasoning with nothing else added.
-  unrs-resolver: true
   core-js: false
   # sass → @parcel/watcher: its `install` script wraps its entire body in
   # `if (process.env.npm_config_build_from_source === 'true')`, which we never
@@ -32,6 +27,13 @@ allowBuilds:
   # and only falls back to a locally compiled build/Release/watcher.node, which
   # nothing here produces. Grant dropped in #588.
   '@parcel/watcher': false
+  # jest-resolve → unrs-resolver: `node postinstall.js` is a three-line delegate
+  # to napi-postinstall's generic checkAndPreparePackage, whose only job is
+  # fetching a platform binding when none resolved. index.js tries a locally
+  # built ./resolver.<platform>.node first and then the prebuilt
+  # @unrs/resolver-binding-<platform> package (22 ship as optionalDependencies);
+  # we have never produced the former. Grant dropped in #588.
+  unrs-resolver: false
   # wrangler (CI-only Cloudflare Pages deploy) pulls these native builds; the
   # `pages deploy` static upload doesn't need them, so keep them blocked.
   sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,13 +12,6 @@ packages:
 # scripts. Allow the genuine native builders; deny core-js (its postinstall
 # only prints a funding banner — no build needed).
 allowBuilds:
-  # bestax:review 2026-11-13 — quarterly sweep; grant predates the
-  # platform-binding argument we apply to @swc/core below. esbuild ships 26
-  # prebuilt @esbuild/<platform> packages as optionalDependencies and its
-  # `node install.js` is the fallback that fetches one when none matched, so
-  # this may be droppable. Verify before dropping: unlike @swc/core, install.js
-  # also validates the binary it resolved.
-  esbuild: true
   core-js: false
   # sass → @parcel/watcher: its `install` script wraps its entire body in
   # `if (process.env.npm_config_build_from_source === 'true')`, which we never
@@ -34,6 +27,17 @@ allowBuilds:
   # @unrs/resolver-binding-<platform> package (22 ship as optionalDependencies);
   # we have never produced the former. Grant dropped in #588.
   unrs-resolver: false
+  # vite/webpack/storybook/ts-jest → esbuild: `node install.js` does three
+  # things, none of them required. It resolves a prebuilt @esbuild/<platform>
+  # package (26 ship as optionalDependencies), renames that binary over the JS
+  # shim at bin/esbuild — a process-startup optimisation, not correctness, since
+  # lib/main.js resolves the platform package at runtime either way — and runs
+  # the binary once to check its version. Its remaining paths are fallbacks for
+  # when no platform package matched: downloadDirectlyFromNPM() fetches a
+  # tarball over HTTPS and installUsingNPM() shells out to npm. An install-time
+  # script that can reach the network is the thing this list exists to stop, so
+  # the grant was costing more than the startup it saved. Grant dropped in #588.
+  esbuild: false
   # wrangler (CI-only Cloudflare Pages deploy) pulls these native builds; the
   # `pages deploy` static upload doesn't need them, so keep them blocked.
   sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,17 +19,19 @@ allowBuilds:
   # this may be droppable. Verify before dropping: unlike @swc/core, install.js
   # also validates the binary it resolved.
   esbuild: true
-  # bestax:review 2026-11-13 — quarterly sweep; same question as esbuild. The
-  # script is literally `scripts/build-from-source.js` and 13 prebuilt
-  # @parcel/watcher-<platform> packages ship as optionalDependencies, which is
-  # the @swc/core argument almost verbatim.
-  '@parcel/watcher': true
   # bestax:review 2026-11-13 — quarterly sweep; the strongest drop candidate of
   # the three. `node postinstall.js` is napi-postinstall's generic fallback and
   # 22 prebuilt @unrs/resolver-binding-<platform> packages ship as
   # optionalDependencies — the @swc/core reasoning with nothing else added.
   unrs-resolver: true
   core-js: false
+  # sass → @parcel/watcher: its `install` script wraps its entire body in
+  # `if (process.env.npm_config_build_from_source === 'true')`, which we never
+  # set, so the script is a no-op rather than a build. index.js requires the
+  # prebuilt @parcel/watcher-<platform> package (13 ship as optionalDependencies)
+  # and only falls back to a locally compiled build/Release/watcher.node, which
+  # nothing here produces. Grant dropped in #588.
+  '@parcel/watcher': false
   # wrangler (CI-only Cloudflare Pages deploy) pulls these native builds; the
   # `pages deploy` static upload doesn't need them, so keep them blocked.
   sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,10 +8,17 @@ packages:
 
 # --- Supply-chain hardening ---
 
-# Block-by-default: only these dependencies may run install/build lifecycle
-# scripts. Allow the genuine native builders; deny core-js (its postinstall
-# only prints a funding banner — no build needed).
+# Block-by-default: no dependency here may run install/build lifecycle scripts.
+# Every entry is a denial, and #588 retired the last three grants — esbuild,
+# @parcel/watcher and unrs-resolver — after showing each one resolves a prebuilt
+# platform binary with its script blocked. The list is not redundant with the
+# default: each entry records *why* that package's script is unnecessary, so the
+# next person to hit `pnpm approve-builds` finds the argument already made. A
+# new grant is still possible, and would need a marker (see below); it should
+# also have to explain why the platform-binding argument used here does not
+# apply to it.
 allowBuilds:
+  # core-js: its postinstall only prints a funding banner — no build needed.
   core-js: false
   # sass → @parcel/watcher: its `install` script wraps its entire body in
   # `if (process.env.npm_config_build_from_source === 'true')`, which we never


### PR DESCRIPTION
Closes #588.

All three `allowBuilds` grants are dropped. `allowBuilds` now carries no grants
at all — every entry is a denial, so nothing is left holding a review date and
`check:conformance --only=bypass-expiry` passes. No `bestax:permanent` marker
was needed, because nothing broke.

| Grant | Verdict | What its script actually did |
| --- | --- | --- |
| `@parcel/watcher` | dropped | Entire body behind an `npm_config_build_from_source === 'true'` guard we never set — a no-op |
| `unrs-resolver` | dropped | Three-line delegate to napi-postinstall; fetches a binding only when none resolved |
| `esbuild` | dropped | Renames the platform binary over the JS shim (a startup optimisation) and runs a version check |

Each was flipped on its own commit, so a break names its own package.

## Evidence

Per grant: wipe `node_modules` across all seven workspace projects,
`pnpm install --frozen-lockfile`, then the full `pnpm all` gate — 27 turbo
tasks, 4,719 tests, bulma-ui coverage 99.62/99.13/99.75/99.82 against its 99%
floor.

Two of these are barely exercised by a build (`sass` only uses
`@parcel/watcher` in watch mode, which the gate never enters), so each was also
checked functionally:

- `@parcel/watcher` — resolved from `sass`'s own `node_modules`, loads a live
  native binding; no `build/` directory is produced.
- `unrs-resolver` — resolved from `jest-resolve`'s path, `ResolverFactory` is a
  function; no local `resolver.<platform>.node` exists, so the prebuilt package
  is what answers.
- `esbuild` — `bin/esbuild` is back to being the JS shim rather than a Mach-O
  binary, while the CLI reports `0.28.1` and the Node API still transforms
  TypeScript.

Local runs are darwin-arm64; CI covers linux-x64. Those are the two platforms we
build on, and this PR should not be merged on the local pass alone — the esbuild
commit is the one where the two platforms resolve different packages.

## A gap in the procedure this issue prescribed

Worth flagging for the reviewer, because it affects how the evidence above was
produced. pnpm's side-effects cache replays a package's *built* directory from
the store, so "wipe `node_modules`, reinstall" — the recipe in #588, and the one
#586 wrote into the expiry gate's own remediation message — can pass without the
install script ever running.

Demonstrated both ways on esbuild: with the cache on, `install.js` never appears
in the install log yet `bin/esbuild` is a 10MB Mach-O binary; with
`--config.side-effects-cache=false`, the script runs. Following the documented
steps would have shown "esbuild is clean" from an install that tested nothing.

Every result in this PR used `--config.side-effects-cache=false`, so the
evidence holds. The instructions that produced it do not, and that text is not
touched here — a gate whose remediation cannot fail is #391's own problem one
level up, so it wants its own change rather than a quiet rider on this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation settings to prevent unnecessary build scripts from running for selected packages.
  * Documented the rationale for allowing prebuilt platform binaries to be used instead of running fallback build steps.
  * Retained existing restrictions for core-js installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->