### PR TITLE
docs: restore Built with Docusaurus attribution in footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -280,7 +280,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} Bestax.  <br/>Source code licensed <a href="https://opensource.org/licenses/mit-license.php">MIT</a>. Website content licensed <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>)`,
+        copyright: `Copyright © ${new Date().getFullYear()} Bestax. <br/>Source code licensed <a href="https://opensource.org/licenses/mit-license.php">MIT</a>. Website content licensed <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>.<br/>Built with <a href="https://docusaurus.io/">Docusaurus</a>.`,
       },
       prism: {
         theme: prismThemes.github,


### PR DESCRIPTION
## What

Restores the stock Docusaurus "Built with Docusaurus" attribution to the bestax.io
footer, and cleans up a stray trailing `)` and a double space after "Bestax." that
were sitting in the same `copyright` string.

## Why

Docusaurus does a lot of the heavy lifting for this site and the attribution is
worth giving — it's also a pointer for visitors who want to build something similar.

## Where

`docs/docusaurus.config.js` — `themeConfig.footer.copyright` now reads:

```
Copyright © {year} Bestax. Source code licensed MIT. Website content licensed
CC BY-NC-SA 4.0.
Built with Docusaurus.
```

Verified by building the docs site (`turbo run build --filter=@allxsmith/bestax-docs`)
and inspecting the rendered footer markup in `docs/build/index.html`; the dark
footer styling is unaffected since only the copyright string changed.

## Checklist

- [x] Docs-only change (`docs:` commit, no release)
- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run check:conformance` passes
- [x] `turbo run build --filter=@allxsmith/bestax-docs` passes and rendered footer verified

Fixes #589

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the site footer copyright text for improved formatting.
  * Added a “Built with Docusaurus” link to the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->