### PR TITLE
test(bestax-migrate): compile migrated kitchen-sink SCSS with Dart Sass

### DIFF
--- a/bestax-migrate/e2e/kitchen-sink.test.ts
+++ b/bestax-migrate/e2e/kitchen-sink.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { reactBulmaComponents } from '../src/sources/react-bulma-components/index.js';
 import { runTransform } from '../src/runner.js';
 import type { TodoEntry } from '../src/types.js';
+import { compileMigratedScss } from './support/compile-scss.js';
 
 const packageRoot = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -151,6 +152,30 @@ describe('kitchen-sink e2e', () => {
     expect(scss).toContain("@use '@allxsmith/bestax-bulma/scss/extras';");
     expect(scss).not.toContain('@import');
     expect(scss).toContain('.app-shell');
+  });
+
+  it('compiles the migrated SCSS entry with Dart Sass (bestax css mode)', () => {
+    const scss = fs.readFileSync(
+      path.join(tmpDir, 'src', 'styles.scss'),
+      'utf8'
+    );
+    const { status, diagnostics } = compileMigratedScss(scss);
+    expect({ status, diagnostics }).toEqual({ status: 0, diagnostics: '' });
+  });
+
+  it('compiles the migrated SCSS entry with Dart Sass (bulma css mode)', () => {
+    const original = fs.readFileSync(
+      path.join(fixtureDir, 'src', 'styles.scss'),
+      'utf8'
+    );
+    const scss = reactBulmaComponents.transformStyles!(
+      'styles.scss',
+      original,
+      { add: () => {} },
+      { cssMode: 'bulma' }
+    );
+    const { status, diagnostics } = compileMigratedScss(scss ?? original);
+    expect({ status, diagnostics }).toEqual({ status: 0, diagnostics: '' });
   });
 
   it('migrates the package.json dependency set', () => {

--- a/bestax-migrate/e2e/styles-compile.test.ts
+++ b/bestax-migrate/e2e/styles-compile.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Dedicated compile gate for the RBC stylesheet-root path added in #560
+ * (`emitBulmaRoot`, existing-root detection): the kitchen-sink fixture's own
+ * `styles.scss` never exercises it (its root is a plain `bulma/…` @import,
+ * not react-bulma-components's own stylesheet), so it needs coverage here
+ * to be compiled the same way the kitchen-sink e2e compiles its output.
+ */
+import { reactBulmaComponents } from '../src/sources/react-bulma-components/index.js';
+import { compileMigratedScss } from './support/compile-scss.js';
+
+const transform = reactBulmaComponents.transformStyles!;
+
+function migrate(source: string, cssMode: 'bestax' | 'bulma'): string {
+  const output = transform(
+    'styles.scss',
+    source,
+    { add: () => {} },
+    {
+      cssMode,
+    }
+  );
+  return output ?? source;
+}
+
+describe('styles-compile e2e: RBC stylesheet-root path (#560)', () => {
+  it.each(['bestax', 'bulma'] as const)(
+    "compiles when react-bulma-components's own stylesheet is the file's only root (%s mode)",
+    cssMode => {
+      const migrated = migrate(
+        "@import 'react-bulma-components/src/index.sass';\n.app { color: red; }\n",
+        cssMode
+      );
+      const { status, diagnostics } = compileMigratedScss(migrated);
+      expect({ status, diagnostics }).toEqual({ status: 0, diagnostics: '' });
+    }
+  );
+
+  it.each(['bestax', 'bulma'] as const)(
+    "compiles when react-bulma-components's stylesheet is redundant beside an existing bulma root (%s mode)",
+    cssMode => {
+      // Regression coverage for the existing-root detection itself: if the
+      // transform ever emitted a second `@use 'bulma/sass'` here instead of
+      // dropping the RBC line, this would be a hard Dart Sass compile error
+      // ("already a module with namespace"), not just a wrong-looking diff.
+      const migrated = migrate(
+        [
+          "@use 'bulma/sass';",
+          "@import 'react-bulma-components/src/index.sass';",
+          '.app { color: red; }',
+        ].join('\n'),
+        cssMode
+      );
+      const { status, diagnostics } = compileMigratedScss(migrated);
+      expect({ status, diagnostics }).toEqual({ status: 0, diagnostics: '' });
+    }
+  );
+});

--- a/bestax-migrate/e2e/support/compile-scss.ts
+++ b/bestax-migrate/e2e/support/compile-scss.ts
@@ -1,0 +1,85 @@
+/**
+ * Compiles migrated SCSS with real Dart Sass, so the kitchen-sink and
+ * styles-compile e2e suites assert output Dart Sass actually accepts, not
+ * just output that matches a substring (the quote-in-comment case fixed in
+ * PR #557 passed a substring check while failing a real compile).
+ *
+ * This package never declares `sass` (or `bulma`) as its own dependency:
+ * bulma-ui already carries both, vetted, and the isolated linker means a
+ * second declaration here would just be the same versions again. Instead
+ * the compile runs as a `node -e` child process with its cwd set to
+ * bulma-ui's package root — Node resolves `require()` in an eval script
+ * relative to cwd, so `require('sass')` and the `bulma/sass` load path both
+ * resolve against bulma-ui's own node_modules, exactly as if this script
+ * lived there. `@allxsmith/bestax-bulma/…` specifiers are resolved by hand
+ * against bulma-ui's own `src/`: its package.json `exports` map that
+ * subpath onto `src/scss/*` for npm consumers, but Dart Sass's plain
+ * load-path lookup has no notion of the `exports` field, so it needs a
+ * `FileImporter` that mirrors the same rewrite.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..'
+);
+const bulmaUiRoot = path.join(packageRoot, '..', 'bulma-ui');
+const tmpRoot = path.join(packageRoot, '.e2e-tmp');
+
+const COMPILE_SCRIPT = `
+const sass = require('sass');
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+const pkgRoot = process.cwd();
+const source = fs.readFileSync(process.env.BESTAX_MIGRATE_COMPILE_SCSS, 'utf8');
+const bestaxBulmaImporter = {
+  findFileUrl(url) {
+    const prefix = '@allxsmith/bestax-bulma/';
+    if (!url.startsWith(prefix)) return null;
+    let subpath = url.slice(prefix.length);
+    if (subpath === 'scss') subpath = 'scss/extras';
+    return pathToFileURL(path.join(pkgRoot, 'src', subpath) + '.scss');
+  },
+};
+try {
+  sass.compileString(source, {
+    loadPaths: [path.join(pkgRoot, 'node_modules')],
+    importers: [bestaxBulmaImporter],
+    logger: sass.Logger.silent,
+  });
+} catch (err) {
+  process.stderr.write(String((err && err.message) || err));
+  process.exitCode = 1;
+}
+`;
+
+export interface CompileResult {
+  status: number | null;
+  diagnostics: string;
+}
+
+/** Compiles `scss` with Dart Sass; `diagnostics` is empty on success. */
+export function compileMigratedScss(scss: string): CompileResult {
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  const scssPath = fs.mkdtempSync(path.join(tmpRoot, 'compile-scss-'));
+  const scssFile = path.join(scssPath, 'input.scss');
+  try {
+    fs.writeFileSync(scssFile, scss);
+    const result = spawnSync(process.execPath, ['-e', COMPILE_SCRIPT], {
+      cwd: bulmaUiRoot,
+      encoding: 'utf8',
+      env: { ...process.env, BESTAX_MIGRATE_COMPILE_SCSS: scssFile },
+    });
+    return {
+      status: result.status,
+      diagnostics: (result.stderr ?? '').trim(),
+    };
+  } finally {
+    fs.rmSync(scssPath, { recursive: true, force: true });
+  }
+}

--- a/bestax-migrate/e2e/support/compile-scss.ts
+++ b/bestax-migrate/e2e/support/compile-scss.ts
@@ -75,10 +75,18 @@ export function compileMigratedScss(scss: string): CompileResult {
       encoding: 'utf8',
       env: { ...process.env, BESTAX_MIGRATE_COMPILE_SCSS: scssFile },
     });
-    return {
-      status: result.status,
-      diagnostics: (result.stderr ?? '').trim(),
-    };
+    // A launch failure (bad cwd, ENOENT, resource limit) surfaces through
+    // `result.error`/`result.signal`, not stderr — without these a spawn that
+    // never ran would fail the assertion with an empty, unactionable message.
+    const diagnostics = [
+      result.error ? `spawn failed: ${result.error.message}` : '',
+      result.signal ? `terminated by signal ${result.signal}` : '',
+      result.stderr ?? '',
+    ]
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+    return { status: result.status, diagnostics };
   } finally {
     fs.rmSync(scssPath, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

The kitchen-sink e2e asserted the migrated `styles.scss` by substring, which can pass output Dart Sass rejects — the quote-in-comment case fixed in #557 was a live example. This PR adds a real Dart Sass compile check.

- Compiles the migrated stylesheet in the kitchen-sink e2e with Dart Sass, for both `bestax` and `bulma` css modes.
- Adds a dedicated `e2e/styles-compile.test.ts` covering the RBC stylesheet-root path from #560 (`emitBulmaRoot`, existing-root detection) — the kitchen-sink fixture's own `styles.scss` never exercises that path (its root is a plain `bulma/…` `@import`, not react-bulma-components's own stylesheet). One of its cases (an existing `@use 'bulma/sass'` root beside a redundant RBC import) is a direct regression check for the existing-root detection logic: if that logic ever regressed to emitting a second `@use 'bulma/sass'`, this is a hard Dart Sass compile error, not just a wrong-looking diff.

### On the `sass` devDependency question

The issue's scope asked to "decide on `sass` as an approved devDependency" for `bestax-migrate`. This loop runs under a stricter rule than the issue anticipated: never add or upgrade dependencies, and stop to explain if a fix genuinely needs one. So instead of declaring `sass` (and `bulma`, also needed to resolve `@use 'bulma/sass'`) as new devDependencies of `bestax-migrate`, the compile check (`e2e/support/compile-scss.ts`) runs as a `node -e <script>` child process with `cwd` set to `bulma-ui`'s package root. Node resolves `require()` in an eval script relative to `cwd`, so `require('sass')` and the `bulma/sass` load path both resolve against `bulma-ui`'s own `node_modules` — no new dependency declarations anywhere. `@allxsmith/bestax-bulma/…` specifiers are resolved by a small `FileImporter` that mirrors `bulma-ui`'s own `package.json` `exports` map (`./scss/*` → `./src/scss/*`), since Dart Sass's plain load-path lookup has no notion of the `exports` field.

Fixes #562

## Test plan

- [x] `pnpm --filter bestax-migrate run test:coverage` — 277/277 passing, coverage thresholds hold (this only affects `e2e/`, which isn't in the coverage collection set)
- [x] `pnpm --filter bestax-migrate run lint`
- [x] `pnpm --filter bestax-migrate run typecheck`
- [x] `pnpm --filter bestax-migrate run format:check`
- [x] `pnpm run check:conformance`
- [x] `pnpm run gen:catalog:check`
- [x] `pnpm exec turbo run test --filter=bestax-migrate` (confirms the build-then-test ordering works end-to-end)
- [x] Manually verified the compile helper against both a successful compile and a deliberately-broken duplicate-root case (throws as expected) before wiring it into the suite

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage confirming migrated styles compile successfully with Dart Sass.
  * Added regression tests for stylesheet roots in both Bestax and Bulma modes.
  * Verified scenarios with existing Bulma roots and prevented duplicate stylesheet loading.
  * Added compile diagnostics to improve detection of migration-related styling errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->