### PR TITLE
ci: pin, guard and de-duplicate the consumer-closure SBOM

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -403,6 +403,24 @@ jobs:
             sleep $((attempt * 10))
           done
 
+          # A scan directory holding ONLY the lockfile (#530 item 5). syft used
+          # to be pointed at the consumer tree and recursively walked every file
+          # under node_modules — thousands of them for bestax-migrate's
+          # 98-package closure, twice per matrix leg — to satisfy a cataloger
+          # that reads the root lockfile and nothing else.
+          #
+          # A copied directory rather than the lockfile itself, and that is not
+          # fussiness. Passing the lockfile as sbom-action's `file` input DOES
+          # work and DOES remove the walk, but it changes the source type, and a
+          # file source made syft emit the scanned file as a component of its
+          # own: every CycloneDX document came out carrying
+          # `/home/runner/work/_temp/consumer/package-lock.json`. That is the
+          # exact runner-path leak #529 fixed for SPDX, reintroduced in the
+          # other format. Scanning a directory keeps the document shape #529
+          # measured and validated; the directory just has nothing else in it.
+          mkdir -p "$RUNNER_TEMP/scan"
+          cp package-lock.json "$RUNNER_TEMP/scan/package-lock.json"
+
           cd "$GITHUB_WORKSPACE"
           if [ -n "$EXPECT" ]; then
             node scripts/consumer-sbom-meta.mjs stamp \
@@ -469,13 +487,11 @@ jobs:
           # failure class on #529's branch, after the github-actions cataloger
           # and the javascript group.
           #
-          # As of #530 item 5 the scan targets the lockfile directly rather
-          # than the directory, which makes this exclusion STRUCTURALLY
-          # unnecessary rather than merely correct — there is no tree left to
-          # walk. It stays because it costs nothing and because the failure
-          # class above is worth keeping written down next to the thing that
-          # closes it; if the path ever goes back to being a directory, this is
-          # already right.
+          # As of #530 item 5 the scan directory holds only a copy of the
+          # lockfile, so this exclusion is STRUCTURALLY unnecessary rather than
+          # merely correct — there is no node_modules under it to walk. It
+          # stays because it costs nothing and because the failure class above
+          # is worth keeping written down next to the thing that closes it.
           exclude:
             - './node_modules/**'
           source:
@@ -484,16 +500,18 @@ jobs:
           YAML
           cat "$RUNNER_TEMP/syft.yaml"
 
-      # `file:`, not `path:` — the LOCKFILE rather than the directory (#530
-      # item 5). Pointed at the tree, syft recursively walked every file under
-      # node_modules — thousands of them for bestax-migrate's 98-package
-      # closure, twice per matrix leg — to satisfy a cataloger that only ever
-      # reads the root lockfile.
+      # `path` is the lockfile-only scan directory built in the install step,
+      # not the consumer tree (#530 item 5) — see that step for why it is a
+      # copied directory rather than the lockfile itself.
       #
-      # It has to be the `file` input specifically, and this cost a dispatch to
-      # learn: sbom-action prefixes whatever `path` receives with syft's `dir:`
-      # scheme, so a lockfile passed there fails with `not a directory source`
-      # rather than being scanned. Do not "simplify" this back to `path`.
+      # Two dead ends this cost two dispatches to rule out, recorded so nobody
+      # re-walks them:
+      #   - `path: …/package-lock.json` fails outright. sbom-action prefixes
+      #     whatever `path` receives with syft's `dir:` scheme, so a file
+      #     produces `not a directory source` on every matrix leg.
+      #   - `file: …/package-lock.json` works and is the input built for it,
+      #     but a file source makes syft emit the scanned file as a component,
+      #     putting the runner's absolute path into every CycloneDX document.
       #
       # `artifact-name` and `output-file` come from one step output rather than
       # being spelled out four times (#530 item 4). Be precise about what that
@@ -505,7 +523,7 @@ jobs:
       - name: Generate SPDX consumer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          file: ${{ runner.temp }}/consumer/package-lock.json
+          path: ${{ runner.temp }}/scan
           format: spdx-json
           config: ${{ runner.temp }}/syft.yaml
           artifact-name: ${{ steps.install.outputs.basename }}.spdx.json
@@ -516,7 +534,7 @@ jobs:
       - name: Generate CycloneDX consumer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          file: ${{ runner.temp }}/consumer/package-lock.json
+          path: ${{ runner.temp }}/scan
           format: cyclonedx-json
           config: ${{ runner.temp }}/syft.yaml
           artifact-name: ${{ steps.install.outputs.basename }}.cdx.json
@@ -536,26 +554,33 @@ jobs:
       # else's release having found nothing wrong — the cry-wolf failure this
       # repository has already fixed twice (#391, #525).
       #
-      # What it asserts instead: every catalogued package resolves to
-      # registry.npmjs.org (catches inflation by its cause — a github-actions
-      # entry or a nested yarn.lock dev closure has no npm download location),
-      # plus a floor that catches the document collapsing to nothing. Neither
-      # knows a count, so growth never reds this. Rule 9: the logic and its
-      # reasoning live in scripts/check-consumer-sbom.mjs with a node --test
-      # sibling that replays both #529 regressions.
+      # What it asserts instead: every catalogued entry came from the npm
+      # registry (SPDX says so with a downloadLocation, CycloneDX with a
+      # `pkg:npm/` purl — a github-actions entry, a nested yarn.lock dev
+      # closure and a bare file component all fail it), that the package the
+      # document names is actually in it at the stamped version, and a floor.
+      # None knows a count, so growth never reds this. Rule 9: the logic and
+      # its reasoning live in scripts/check-consumer-sbom.mjs with a node
+      # --test sibling that replays all three regressions.
       #
-      # SPDX only. The two documents describe the same closure from the same
-      # syft run, and downloadLocation is the SPDX field the lock cataloger's
-      # `resolved` maps to.
-      - name: Assert the document is still a consumer closure
+      # BOTH documents, not just SPDX, and that is not belt-and-braces. They
+      # come from two separate sbom-action invocations, and an SPDX-only guard
+      # has already passed a broken CycloneDX document on this branch: a file
+      # source put `/home/runner/work/_temp/consumer/package-lock.json` into
+      # every .cdx.json while every .spdx.json checked out clean. Both get
+      # signed and attached, so both get read.
+      - name: Assert the documents are still a consumer closure
         env:
           PACKAGE: ${{ matrix.package }}
           SLUG: ${{ matrix.slug }}
+          VERSION: ${{ steps.install.outputs.version }}
           BASENAME: ${{ steps.install.outputs.basename }}
         run: |
-          node scripts/check-consumer-sbom.mjs \
-            --file "$BASENAME.spdx.json" \
-            --package "$PACKAGE" --slug "$SLUG"
+          for format in spdx cdx; do
+            node scripts/check-consumer-sbom.mjs \
+              --file "$BASENAME.$format.json" \
+              --package "$PACKAGE" --slug "$SLUG" --version "$VERSION"
+          done
 
   # Scorecard's Signed-Releases check reads GitHub *release assets* and nothing
   # else. The npm provenance we already publish is invisible to it, so releases

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -475,6 +475,13 @@ jobs:
           PACKAGE: ${{ matrix.package }}
           VERSION: ${{ steps.install.outputs.version }}
         run: |
+          # NO BACKTICKS BELOW THIS LINE. The heredoc is unquoted, because it
+          # interpolates $PACKAGE and $VERSION, so backticks are command
+          # substitution rather than punctuation. Until #530 the comment about
+          # yarn.lock said "a files: field" in backticks and the runner
+          # cheerfully executed 'files:' and pasted the empty result — the
+          # generated config read "publishing without  field". Harmless inside
+          # a YAML comment, but the next phrase somebody backticks might not be.
           cat > "$RUNNER_TEMP/syft.yaml" <<YAML
           default-catalogers:
             - javascript-lock-cataloger
@@ -482,7 +489,7 @@ jobs:
           # **/pnpm-lock.yaml, so a directory scan also reads lockfiles that
           # dependencies ship inside their own tarballs. npm always excludes
           # package-lock.json from a tarball but NOT yarn.lock, so one dep
-          # publishing without a `files:` field would inject its entire dev
+          # publishing without a files: field would inject its entire dev
           # closure into this document. That was the third instance of this
           # failure class on #529's branch, after the github-actions cataloger
           # and the javascript group.
@@ -494,6 +501,29 @@ jobs:
           # is worth keeping written down next to the thing that closes it.
           exclude:
             - './node_modules/**'
+          # No file cataloging. Not an optimisation — it closes a leak that has
+          # been shipping since #529, and that the guard below caught on its
+          # first run reading CycloneDX.
+          #
+          # File metadata is cataloged independently of default-catalogers,
+          # which is why restricting that to the lock cataloger did not stop
+          # it. syft emitted the scanned lockfile as an artifact in its own
+          # right, and the two exporters disagreed about how to name it: SPDX
+          # put a RELATIVE package-lock.json in its files array, while
+          # CycloneDX put a type: file component named with the ABSOLUTE path.
+          # So every published .cdx.json carried
+          # /home/runner/work/_temp/consumer/package-lock.json — the same
+          # runner-path leak #529 fixed for SPDX, in the format nobody read.
+          #
+          # Pre-existing, not introduced here: confirmed against run
+          # 32706731377, a scheduled run on main from before this branch.
+          #
+          # Nothing is lost. The file entry describes the scan container, not
+          # the closure; the evidence this document exists to carry is the
+          # package list and its registry URLs.
+          file:
+            metadata:
+              selection: none
           source:
             name: "consumer-closure:$PACKAGE"
             version: "$VERSION"

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -543,21 +543,35 @@ jobs:
       #     but a file source makes syft emit the scanned file as a component,
       #     putting the runner's absolute path into every CycloneDX document.
       #
-      # `artifact-name` and `output-file` come from one step output rather than
-      # being spelled out four times (#530 item 4). Be precise about what that
-      # fixes: `sign-sbom` and `attach-sbom` glob on these names from their own
-      # jobs and cannot read a step output across a job boundary, so this
-      # collapses four occurrences to one, not eight. What keeps those globs
-      # honest is that the prefix is now a single exported constant
-      # (ARTIFACT_PREFIX in scripts/consumer-sbom-meta.mjs) pinned by a test.
+      # `output-file` comes from one step output rather than being spelled out
+      # four times (#530 item 4). `sign-sbom` and `attach-sbom` still glob these
+      # names from their own jobs and cannot read a step output across a job
+      # boundary — what keeps those globs honest is that the prefix is a single
+      # exported constant (ARTIFACT_PREFIX in scripts/consumer-sbom-meta.mjs)
+      # pinned by a test.
+      #
+      # `upload-artifact: false` on BOTH, with one explicit upload after the
+      # guard. This is what makes the guard a GATE rather than a detector, and
+      # the distinction is not academic: the action generates and uploads in a
+      # single step, so with its default the artifact existed before anything
+      # had looked at it — and `sign-sbom`/`attach-sbom` deliberately do not
+      # require `consumer-sbom` to have succeeded, so on a real release they
+      # would download that artifact by glob and sign and permanently attach a
+      # document the guard had already rejected. The run went red and the bad
+      # SBOM shipped anyway.
+      #
+      # Deferring the upload preserves the degradation #529 designed for: a leg
+      # that fails, for any reason, simply produces no artifact, the globs
+      # downstream expand to nothing, and `attach-sbom` emits its ::warning::
+      # while the repository SBOMs still ship.
       - name: Generate SPDX consumer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: ${{ runner.temp }}/scan
           format: spdx-json
           config: ${{ runner.temp }}/syft.yaml
-          artifact-name: ${{ steps.install.outputs.basename }}.spdx.json
           output-file: ${{ steps.install.outputs.basename }}.spdx.json
+          upload-artifact: false
           # Same reason as the repository SBOM: one deterministic uploader.
           upload-release-assets: false
 
@@ -567,8 +581,8 @@ jobs:
           path: ${{ runner.temp }}/scan
           format: cyclonedx-json
           config: ${{ runner.temp }}/syft.yaml
-          artifact-name: ${{ steps.install.outputs.basename }}.cdx.json
           output-file: ${{ steps.install.outputs.basename }}.cdx.json
+          upload-artifact: false
           upload-release-assets: false
 
       # The guard #529 deferred (#530 item 2). Nothing asserted anything about
@@ -595,10 +609,14 @@ jobs:
       #
       # BOTH documents, not just SPDX, and that is not belt-and-braces. They
       # come from two separate sbom-action invocations, and an SPDX-only guard
-      # has already passed a broken CycloneDX document on this branch: a file
-      # source put `/home/runner/work/_temp/consumer/package-lock.json` into
-      # every .cdx.json while every .spdx.json checked out clean. Both get
-      # signed and attached, so both get read.
+      # demonstrably passes a broken CycloneDX one: every published .cdx.json
+      # since #529 carried `/home/runner/work/_temp/consumer/package-lock.json`
+      # while every .spdx.json checked out clean (run 32706731377, a scheduled
+      # run on main). Both get signed and attached, so both get read.
+      #
+      # This step runs BEFORE the upload below, which is what makes it a gate.
+      # A failure here means no artifact is ever published, so nothing
+      # downstream can sign or attach a document that did not check out.
       - name: Assert the documents are still a consumer closure
         env:
           PACKAGE: ${{ matrix.package }}
@@ -611,6 +629,26 @@ jobs:
               --file "$BASENAME.$format.json" \
               --package "$PACKAGE" --slug "$SLUG" --version "$VERSION"
           done
+
+      # One artifact per matrix leg carrying both formats, replacing the two
+      # the action used to upload for itself. The NAME has to keep matching
+      # `bestax-*sbom*`, which is what `sign-sbom` and `attach-sbom` pass to
+      # download-artifact — the basename does, by construction. The file names
+      # inside are unchanged, so the globs in those jobs need no change either.
+      #
+      # No `if:`, deliberately. This step is reached only when every step above
+      # it succeeded, which is exactly the gate described above.
+      - name: Upload the consumer SBOMs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.install.outputs.basename }}
+          path: |
+            ${{ steps.install.outputs.basename }}.spdx.json
+            ${{ steps.install.outputs.basename }}.cdx.json
+          # Fail rather than warn: reaching this step means the documents
+          # checked out, so a missing file is a bug in this job and not a
+          # degradation to absorb quietly.
+          if-no-files-found: error
 
   # Scorecard's Signed-Releases check reads GitHub *release assets* and nothing
   # else. The npm provenance we already publish is invisible to it, so releases

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -207,6 +207,31 @@ jobs:
           echo "::error::agent.json reads block but the agent never reported Initialized — the firewall is not up. Check the agent log for 'Reverted changes' (usually an unresolvable allow-listed host)."
           exit 1
 
+      # New in #530: this job now runs two scripts from scripts/, per rule 9 —
+      # the install/stamp logic and the closure guard — so it needs the
+      # repository on disk. That adds a third-party action to a job that had
+      # none, which is the honest cost rather than something to elide: it is on
+      # the repo-wide pin (rule 1) and `persist-credentials: false` means no
+      # token reaches the runner's git config. The job's `allowed-endpoints`
+      # needs no change — checkout reaches github.com, api.github.com and
+      # objects.githubusercontent.com, all already listed above.
+      #
+      # The EVENT ref, deliberately, and NOT `ref: main` as `verify-provenance`
+      # uses. That job reads a verifier which must not come from the tag it is
+      # verifying; this one asserts a property of a document THIS JOB JUST
+      # GENERATED, so there is no third party whose claim the checked-out code
+      # could be made to rubber-stamp. The reasoning does not transfer.
+      #
+      # It also matters practically: this job is only ever exercised by a
+      # `workflow_dispatch` on a branch (it never runs on a PR), and pinning to
+      # `main` would read the guard from `main` — which, for the PR introducing
+      # it, does not have one. That is rule 9's bootstrap gap, and here it would
+      # make the change unverifiable by the only means available.
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
       # nodejs.org is in the list above because `setup-node` falls back to
       # downloading from nodejs.org/dist when the runner's tool cache misses the
       # requested version — exactly the kind of host a guessed allowlist omits.
@@ -283,34 +308,62 @@ jobs:
       # that exists nowhere. Naming it for what it is makes the root entry
       # self-evidently the scan container instead of a phantom dependency.
       #
-      # The install resolves the mutable `latest` dist-tag, and the version it
-      # lands on is recorded as a step output so it can be stamped into the
-      # artifact name. Without that stamp an SBOM attached to a release would
-      # not say which version it describes, and a later publish would make the
-      # document silently disagree with the release it hangs off.
+      # WHICH VERSION gets installed is decided by consumer-sbom-meta.mjs
+      # (#530 item 1), not by resolving `latest` for all four legs as this
+      # step used to.
       #
-      # An earlier version of this comment said pinning to the release's own
-      # version is "not possible". That was too strong. `release.tag_name` is
-      # `<pkg>@X.Y.Z` (VERSIONING.md), so for the ONE package a release names,
-      # the exact version is available and pinnable. What is not possible is
-      # pinning the other three, which that release says nothing about.
+      # For the ONE package a release names, `release.tag_name` is `<pkg>@X.Y.Z`
+      # (VERSIONING.md, and the `tagFormat` in each release.config.js), so the
+      # exact version is available and is pinned. Two failure modes that fixes,
+      # both real rather than theoretical:
       #
-      # Two failure modes follow from resolving `latest` for the released
-      # package, and they are real rather than theoretical: the event fires
-      # immediately after `npm publish`, so a CDN-cached packument can resolve
-      # the PREVIOUS version and stamp the SBOM with it; and a re-run days later
-      # resolves a newer `latest`, producing a different filename that
-      # `--clobber` cannot replace, leaving the release carrying two
-      # contradictory consumer SBOMs for the same package.
+      #   - `release: published` fires immediately after `npm publish`, so a
+      #     CDN-cached packument could resolve the PREVIOUS version and stamp
+      #     release 5.12.0 with an SBOM describing 5.11.1.
+      #   - A re-run days later resolved a newer `latest` and produced a
+      #     different filename, which `gh release upload --clobber` cannot
+      #     replace — leaving the release permanently carrying two
+      #     contradictory consumer SBOMs for the same package.
       #
-      # Tracked rather than fixed here: doing it properly means matching the tag
-      # to its matrix leg and pinning only that one, which is a behaviour change
-      # worth its own review rather than a drive-by in this PR.
+      # The other three legs necessarily stay on `latest`: a release says
+      # nothing about them, and a consumer SBOM describes what a consumer
+      # installs today. That asymmetry is why the decision is a script with a
+      # test rather than an expression here — the tag has to be matched to its
+      # matrix leg, and only that leg pinned.
+      #
+      # The read-back and its validation moved to the same script (rule 9).
+      # The validation is the reason: it guards a value that comes out of a
+      # published tarball — the one input here an attacker would control if a
+      # package were compromised — and that value flows into $GITHUB_OUTPUT and
+      # into the syft config heredoc below, where a newline would define
+      # arbitrary extra step outputs and inject config keys. That is logic worth
+      # testing, and it could not be tested where it lived.
+      #
+      # `--expect` is new leverage the pin buys: when a version was asked for,
+      # the tree must carry it, or the job fails rather than quietly describing
+      # a different release than the one it is attached to.
+      - name: Decide which version to install
+        id: spec
+        env:
+          PACKAGE: ${{ matrix.package }}
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+        # Writes `spec` and `expect` itself. `expect` is empty for the three
+        # legs no release names, and the workflow does no parsing of its own —
+        # deriving the version from the spec here would reimplement the
+        # last-`@` split in untested YAML, one character from being wrong for
+        # the one scoped package.
+        run: |
+          node scripts/consumer-sbom-meta.mjs spec \
+            --package "$PACKAGE" --event "$EVENT" --tag "$TAG"
+
       - name: Install the published package as a consumer would
         id: install
         env:
           PACKAGE: ${{ matrix.package }}
           SLUG: ${{ matrix.slug }}
+          SPEC: ${{ steps.spec.outputs.spec }}
+          EXPECT: ${{ steps.spec.outputs.expect }}
         run: |
           mkdir -p "$RUNNER_TEMP/consumer"
           cd "$RUNNER_TEMP/consumer"
@@ -322,35 +375,35 @@ jobs:
             "description": "Scan container: the installed closure of $PACKAGE"
           }
           JSON
-          npm install --ignore-scripts "$PACKAGE"
 
-          # Read back what was installed rather than re-resolving it, so the
-          # stamp cannot disagree with the tree that was scanned.
-          version=$(jq -r .version "node_modules/$PACKAGE/package.json")
-
-          # Validated against semver rather than merely checked for emptiness.
-          # This value comes out of a published tarball — the one input here
-          # that an attacker would control if a package were compromised — and
-          # it flows into $GITHUB_OUTPUT and into a YAML heredoc below. A value
-          # containing a newline would define arbitrary extra step outputs and
-          # inject syft config keys, which could silently re-shape the very
-          # document this job exists to produce. npm will not publish a
-          # non-semver version, so this should never fire; it costs one regex
-          # to not depend on that.
-          case "$version" in
-            [0-9]*.[0-9]*.[0-9]*) ;;
-            *)
-              echo "::error::$PACKAGE reported an implausible version: '$version'"
+          # Retried, and only because of the pin. Resolving `latest` always had
+          # SOMETHING to resolve; asking for an exact version seconds after
+          # `npm publish` can 404 while the packument propagates. Without this,
+          # item 1 would trade "the SBOM names the wrong version" for "the
+          # released package has no SBOM at all", which is a worse deal — the
+          # released leg is the one the release actually cares about.
+          for attempt in 1 2 3; do
+            if npm install --ignore-scripts "$SPEC"; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::npm install $SPEC failed three times"
               exit 1
-              ;;
-          esac
-          if printf '%s' "$version" | grep -qv '^[0-9A-Za-z.+-]*$'; then
-            echo "::error::$PACKAGE version contains unexpected characters"
-            exit 1
-          fi
+            fi
+            echo "npm install $SPEC failed (attempt $attempt); retrying"
+            sleep $((attempt * 10))
+          done
 
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "resolved $PACKAGE@$version"
+          cd "$GITHUB_WORKSPACE"
+          if [ -n "$EXPECT" ]; then
+            node scripts/consumer-sbom-meta.mjs stamp \
+              --package "$PACKAGE" --slug "$SLUG" \
+              --dir "$RUNNER_TEMP/consumer" --expect "$EXPECT"
+          else
+            node scripts/consumer-sbom-meta.mjs stamp \
+              --package "$PACKAGE" --slug "$SLUG" \
+              --dir "$RUNNER_TEMP/consumer"
+          fi
 
       # Three problems the first real run surfaced, all fixed by one syft
       # config. None were visible without reading a generated document — which
@@ -399,14 +452,21 @@ jobs:
           default-catalogers:
             - javascript-lock-cataloger
           # The lock cataloger globs **/package-lock.json, **/yarn.lock and
-          # **/pnpm-lock.yaml, so without this it also reads lockfiles that
+          # **/pnpm-lock.yaml, so a directory scan also reads lockfiles that
           # dependencies ship inside their own tarballs. npm always excludes
           # package-lock.json from a tarball but NOT yarn.lock, so one dep
           # publishing without a `files:` field would inject its entire dev
-          # closure into this document. That is the third instance of this
-          # failure class on this branch, after the github-actions cataloger
-          # and the javascript group; restricting the cataloger does not close
-          # it, only excluding the tree does.
+          # closure into this document. That was the third instance of this
+          # failure class on #529's branch, after the github-actions cataloger
+          # and the javascript group.
+          #
+          # As of #530 item 5 the scan targets the lockfile directly rather
+          # than the directory, which makes this exclusion STRUCTURALLY
+          # unnecessary rather than merely correct — there is no tree left to
+          # walk. It stays because it costs nothing and because the failure
+          # class above is worth keeping written down next to the thing that
+          # closes it; if the path ever goes back to being a directory, this is
+          # already right.
           exclude:
             - './node_modules/**'
           source:
@@ -415,26 +475,72 @@ jobs:
           YAML
           cat "$RUNNER_TEMP/syft.yaml"
 
+      # `path` is the LOCKFILE, not the directory (#530 item 5). Pointed at the
+      # tree, syft recursively walked every file under node_modules — thousands
+      # of them for bestax-migrate's 98-package closure, twice per matrix leg —
+      # to satisfy a cataloger that only ever reads the root lockfile.
+      #
+      # `artifact-name` and `output-file` come from one step output rather than
+      # being spelled out four times (#530 item 4). Be precise about what that
+      # fixes: `sign-sbom` and `attach-sbom` glob on these names from their own
+      # jobs and cannot read a step output across a job boundary, so this
+      # collapses four occurrences to one, not eight. What keeps those globs
+      # honest is that the prefix is now a single exported constant
+      # (ARTIFACT_PREFIX in scripts/consumer-sbom-meta.mjs) pinned by a test.
       - name: Generate SPDX consumer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: ${{ runner.temp }}/consumer
+          path: ${{ runner.temp }}/consumer/package-lock.json
           format: spdx-json
           config: ${{ runner.temp }}/syft.yaml
-          artifact-name: bestax-consumer-sbom-${{ matrix.slug }}-${{ steps.install.outputs.version }}.spdx.json
-          output-file: bestax-consumer-sbom-${{ matrix.slug }}-${{ steps.install.outputs.version }}.spdx.json
+          artifact-name: ${{ steps.install.outputs.basename }}.spdx.json
+          output-file: ${{ steps.install.outputs.basename }}.spdx.json
           # Same reason as the repository SBOM: one deterministic uploader.
           upload-release-assets: false
 
       - name: Generate CycloneDX consumer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: ${{ runner.temp }}/consumer
+          path: ${{ runner.temp }}/consumer/package-lock.json
           format: cyclonedx-json
           config: ${{ runner.temp }}/syft.yaml
-          artifact-name: bestax-consumer-sbom-${{ matrix.slug }}-${{ steps.install.outputs.version }}.cdx.json
-          output-file: bestax-consumer-sbom-${{ matrix.slug }}-${{ steps.install.outputs.version }}.cdx.json
+          artifact-name: ${{ steps.install.outputs.basename }}.cdx.json
+          output-file: ${{ steps.install.outputs.basename }}.cdx.json
           upload-release-assets: false
+
+      # The guard #529 deferred (#530 item 2). Nothing asserted anything about
+      # the generated document, so a syft, cataloger or exporter change — or a
+      # dependency that starts shipping a lockfile — shipped silently green.
+      # Every defect #529 fixed was found by dispatching this workflow and
+      # reading the JSON, never by a green job; this is that read, automated.
+      #
+      # Deliberately NOT a count. The first attempt compared `!==` against
+      # counts hardcoded in the matrix (5/12/98/94) and was reverted in
+      # 48c57d5: those are live registry closures that drift whenever any
+      # transitive dependency publishes, so the job would go red on somebody
+      # else's release having found nothing wrong — the cry-wolf failure this
+      # repository has already fixed twice (#391, #525).
+      #
+      # What it asserts instead: every catalogued package resolves to
+      # registry.npmjs.org (catches inflation by its cause — a github-actions
+      # entry or a nested yarn.lock dev closure has no npm download location),
+      # plus a floor that catches the document collapsing to nothing. Neither
+      # knows a count, so growth never reds this. Rule 9: the logic and its
+      # reasoning live in scripts/check-consumer-sbom.mjs with a node --test
+      # sibling that replays both #529 regressions.
+      #
+      # SPDX only. The two documents describe the same closure from the same
+      # syft run, and downloadLocation is the SPDX field the lock cataloger's
+      # `resolved` maps to.
+      - name: Assert the document is still a consumer closure
+        env:
+          PACKAGE: ${{ matrix.package }}
+          SLUG: ${{ matrix.slug }}
+          BASENAME: ${{ steps.install.outputs.basename }}
+        run: |
+          node scripts/check-consumer-sbom.mjs \
+            --file "$BASENAME.spdx.json" \
+            --package "$PACKAGE" --slug "$SLUG"
 
   # Scorecard's Signed-Releases check reads GitHub *release assets* and nothing
   # else. The npm provenance we already publish is invisible to it, so releases

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -475,10 +475,16 @@ jobs:
           YAML
           cat "$RUNNER_TEMP/syft.yaml"
 
-      # `path` is the LOCKFILE, not the directory (#530 item 5). Pointed at the
-      # tree, syft recursively walked every file under node_modules — thousands
-      # of them for bestax-migrate's 98-package closure, twice per matrix leg —
-      # to satisfy a cataloger that only ever reads the root lockfile.
+      # `file:`, not `path:` — the LOCKFILE rather than the directory (#530
+      # item 5). Pointed at the tree, syft recursively walked every file under
+      # node_modules — thousands of them for bestax-migrate's 98-package
+      # closure, twice per matrix leg — to satisfy a cataloger that only ever
+      # reads the root lockfile.
+      #
+      # It has to be the `file` input specifically, and this cost a dispatch to
+      # learn: sbom-action prefixes whatever `path` receives with syft's `dir:`
+      # scheme, so a lockfile passed there fails with `not a directory source`
+      # rather than being scanned. Do not "simplify" this back to `path`.
       #
       # `artifact-name` and `output-file` come from one step output rather than
       # being spelled out four times (#530 item 4). Be precise about what that
@@ -490,7 +496,7 @@ jobs:
       - name: Generate SPDX consumer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: ${{ runner.temp }}/consumer/package-lock.json
+          file: ${{ runner.temp }}/consumer/package-lock.json
           format: spdx-json
           config: ${{ runner.temp }}/syft.yaml
           artifact-name: ${{ steps.install.outputs.basename }}.spdx.json
@@ -501,7 +507,7 @@ jobs:
       - name: Generate CycloneDX consumer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: ${{ runner.temp }}/consumer/package-lock.json
+          file: ${{ runner.temp }}/consumer/package-lock.json
           format: cyclonedx-json
           config: ${{ runner.temp }}/syft.yaml
           artifact-name: ${{ steps.install.outputs.basename }}.cdx.json

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -598,14 +598,23 @@ jobs:
       # else's release having found nothing wrong — the cry-wolf failure this
       # repository has already fixed twice (#391, #525).
       #
-      # What it asserts instead: every catalogued entry came from the npm
-      # registry (SPDX says so with a downloadLocation, CycloneDX with a
-      # `pkg:npm/` purl — a github-actions entry, a nested yarn.lock dev
-      # closure and a bare file component all fail it), that the package the
-      # document names is actually in it at the stamped version, and a floor.
-      # None knows a count, so growth never reds this. Rule 9: the logic and
-      # its reasoning live in scripts/check-consumer-sbom.mjs with a node
-      # --test sibling that replays all three regressions.
+      # What it asserts instead: that every catalogued entry came from the npm
+      # registry, that the package the document names is in it at the stamped
+      # version and its subject agrees, a floor, and that the two documents
+      # list the same closure. None knows a count, so growth never reds this.
+      # Rule 9: the logic and its reasoning live in
+      # scripts/check-consumer-sbom.mjs with a node --test sibling that
+      # replays every regression this job has actually had.
+      #
+      # The registry claim is carried very unequally by the two formats, and
+      # the script says so at length rather than implying parity. SPDX maps the
+      # lockfile's `resolved` to downloadLocation, so it is real provenance.
+      # CycloneDX builds `pkg:npm/name@version` from the name and version and
+      # records `resolved` nowhere at all, so there it is only an ECOSYSTEM
+      # test — enough to catch a github-actions entry or a bare file component,
+      # not a git or tarball dependency. The same-closure assertion is what
+      # closes that gap: anything the weaker test would admit must also appear
+      # in SPDX, where the strong one is waiting.
       #
       # BOTH documents, not just SPDX, and that is not belt-and-braces. They
       # come from two separate sbom-action invocations, and an SPDX-only guard
@@ -624,11 +633,10 @@ jobs:
           VERSION: ${{ steps.install.outputs.version }}
           BASENAME: ${{ steps.install.outputs.basename }}
         run: |
-          for format in spdx cdx; do
-            node scripts/check-consumer-sbom.mjs \
-              --file "$BASENAME.$format.json" \
-              --package "$PACKAGE" --slug "$SLUG" --version "$VERSION"
-          done
+          node scripts/check-consumer-sbom.mjs \
+            --spdx "$BASENAME.spdx.json" \
+            --cdx "$BASENAME.cdx.json" \
+            --package "$PACKAGE" --slug "$SLUG" --version "$VERSION"
 
       # One artifact per matrix leg carrying both formats, replacing the two
       # the action used to upload for itself. The NAME has to keep matching

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -80,24 +80,33 @@ jobs:
   # question procurement actually asks — "what enters my dependency tree if I
   # install this?" — which is a different and much smaller set (#424).
   #
-  # How much smaller, measured rather than asserted:
+  # How much smaller, measured rather than asserted — read out of the documents
+  # produced by run 33260691933 (2026-08-29), not carried forward:
   #
   #   @allxsmith/bestax-bulma   5 packages   (7 entries shipped)
   #   create-bestax            12             (14)
   #   bestax-migrate           98             (100)
-  #   bestax-mcp               94             (95)
+  #   bestax-mcp               93             (95)
   #
   # The first column is the closure; the second is what the document actually
-  # contains, because a directory scan adds two entries that are not
-  # dependencies: the scratch project the lockfile records as its root, and the
-  # configured source syft emits as a package. Both are named so a reader can
-  # tell what they are. Stated in both columns because a procurement reader
-  # counts entries in the SBOM, not in this comment.
+  # contains, because the scan adds two entries that are not dependencies: the
+  # scratch project the lockfile records as its root, and the configured source
+  # syft emits as a package. Both are named so a reader can tell what they are,
+  # and check-consumer-sbom.mjs exempts them by those exact names. Stated in
+  # both columns because a procurement reader counts entries in the SBOM, not
+  # in this comment.
   #
-  # against a repository SBOM covering the whole dev toolchain. Reading the repo
-  # SBOM as a consumer closure overstates our footprint by about two orders of
-  # magnitude, and the genuinely tiny runtime closure is a selling point that
-  # obscures.
+  # These are LIVE REGISTRY closures and they drift whenever any transitive
+  # dependency publishes, so treat them as a scale, not a checksum — bestax-mcp
+  # read 94 here until it was re-measured, against 95 entries it could never
+  # have been consistent with. Nothing enforces them, deliberately: pinning
+  # counts as a gate is what 48c57d5 reverted. Re-measure from a dispatch when
+  # touching this job rather than editing the numbers to taste.
+  #
+  # Compare against a repository SBOM covering the whole dev toolchain: reading
+  # the repo SBOM as a consumer closure overstates our footprint by about two
+  # orders of magnitude, and obscures a genuinely tiny runtime closure that is
+  # a selling point.
   #
   # Per package, not one combined tree. Installing all four together resolves to
   # 204 packages, which would bury bulma-ui's five-package closure under the

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -324,6 +324,43 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
     }
   }
 
+  // Duplicate identities: a WARNING, deliberately, not a failure.
+  //
+  // The doubled-catalogers regression (#529) listed every package twice. It
+  // reds today only because the second copy came from the package.json
+  // cataloger and carried no registry origin — so a future duplication that
+  // kept a valid origin in both documents would pass every assertion here,
+  // since growth is explicitly allowed and the cross-check compares the two
+  // documents to each other rather than to an expectation.
+  //
+  // Not asserted, because npm can legitimately place the same name@version at
+  // two paths when it cannot hoist, and a lockfile with that shape is a real
+  // closure rather than a defect. Failing on it would be the false-red
+  // generator 48c57d5 reverted and #391/#525 are about — reddening somebody
+  // else's release for a dependency-tree shape nobody chose.
+  //
+  // A warning names the count and the offenders, which is enough for a human
+  // reading a dispatch to recognise "every package is listed twice" instantly,
+  // and cannot fail a release on its own. Measured: zero duplicates across all
+  // 208 catalogued entries in the four closures of run 33263381732.
+  const seen = new Map();
+  for (const e of catalogued) {
+    const id = `${e.name}@${e.version ?? '?'}`;
+    seen.set(id, (seen.get(id) ?? 0) + 1);
+  }
+  const dupes = [...seen].filter(([, n]) => n > 1);
+  if (dupes.length > 0) {
+    console.error(
+      `::warning::${norm.format}: ${dupes.length} package(s) listed more than ` +
+        `once (${dupes
+          .slice(0, 5)
+          .map(([id, n]) => `${id} x${n}`)
+          .join(', ')}${dupes.length > 5 ? ', …' : ''}). npm can place the ` +
+        `same version at two paths, so this is not failed — but if MOST of ` +
+        `the closure is duplicated, a second cataloger is running (#529).`
+    );
+  }
+
   // The scratch project root should be present in both formats. Not a failure
   // on its own — the document is still an honest closure without it — but its
   // absence means the scan container changed, and the exemption above is then
@@ -365,12 +402,28 @@ export function identities(doc, { package: pkg, slug }) {
  * for any other reason. They are separate invocations, so nothing makes them
  * agree by construction, and the #529-to-#530 leak is the proof: present in
  * every CycloneDX document, absent from every SPDX one.
+ *
+ * Compared as MULTISETS, not as sets. An earlier version used
+ * `Array.includes`, which asks only "does this identity appear at all" — so a
+ * package listed twice in one document and once in the other looked identical
+ * to both being listed once, and asymmetric duplicate inflation passed
+ * silently. Counting is the same work and answers the question actually being
+ * asked.
  */
 export function crossCheck(spdxDoc, cdxDoc, target) {
   const a = identities(spdxDoc, target);
   const b = identities(cdxDoc, target);
-  const onlySpdx = a.filter(x => !b.includes(x));
-  const onlyCdx = b.filter(x => !a.includes(x));
+  const tally = list =>
+    list.reduce((m, x) => m.set(x, (m.get(x) ?? 0) + 1), new Map());
+  const ta = tally(a);
+  const tb = tally(b);
+  const excess = (x, y) =>
+    [...x].flatMap(([id, n]) => {
+      const d = n - (y.get(id) ?? 0);
+      return d > 0 ? [d > 1 ? `${id} (x${d} extra)` : id] : [];
+    });
+  const onlySpdx = excess(ta, tb);
+  const onlyCdx = excess(tb, ta);
   const problems = [];
 
   if (onlySpdx.length) {

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -555,7 +555,19 @@ export function parseArgs(argv) {
     if (i + 1 >= argv.length) throw new Error(`${key} needs a value`);
     flags[key.slice(2)] = argv[i + 1];
   }
-  for (const required of ['spdx', 'cdx', 'package', 'slug', 'version']) {
+  // Unknown flags rejected rather than ignored, same as the sibling script. No
+  // flag here is optional today, so a typo would be caught by the required
+  // check below — but that is a property of today's flag list, not a guarantee,
+  // and the first optional flag added would silently reopen it.
+  const known = ['spdx', 'cdx', 'package', 'slug', 'version'];
+  for (const name of Object.keys(flags)) {
+    if (!known.includes(name)) {
+      throw new Error(
+        `unknown flag --${name} (expected ${known.map(k => `--${k}`).join(', ')})`
+      );
+    }
+  }
+  for (const required of known) {
     if (!flags[required]) throw new Error(`--${required} is required`);
   }
   return flags;

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -211,9 +211,12 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
       problems.push(
         `"${e.name ?? '(unnamed)'}" has ${norm.originField} ` +
           `${JSON.stringify(origin ?? null)}, which is not under ` +
-          `${norm.originPrefix}. It is not something a consumer installs from ` +
-          `npm — a cataloger is reading files it should not, or the scan ` +
-          `source is leaking into the document (#529, #530).`
+          `${norm.originPrefix}. Usually that means a cataloger is reading ` +
+          `files it should not, or the scan source is leaking into the ` +
+          `document (#529, #530). If instead we have genuinely taken a ` +
+          `runtime dependency that resolves from git, a tarball URL or an ` +
+          `npm: alias, that is worth knowing about on its own — decide ` +
+          `whether to keep the dependency before widening this check.`
       );
     }
   }

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -42,33 +42,60 @@
  * repository has already fixed twice (#391, #525), and re-shipping it would be
  * worse than having no guard.
  *
- * So: three assertions, none of which knows a count.
+ * So: four assertions, none of which knows a count.
  *
- *   1. ORIGIN — every catalogued entry came from the npm registry. SPDX says
- *      that with a `downloadLocation` under registry.npmjs.org; CycloneDX says
- *      it with a `pkg:npm/` purl. This is the one that matters, because it
- *      catches inflation by its cause rather than by its size: a
- *      github-actions entry, a package catalogued out of a dependency's own
- *      yarn.lock, and a bare file component all fail it, and it stays correct
- *      as the closure grows.
+ *   1. ORIGIN — every catalogued entry came from the npm registry. This is the
+ *      one that catches inflation by its cause rather than by its size, and
+ *      the two formats support it VERY unequally, which is worth stating
+ *      precisely rather than glossing:
+ *
+ *      SPDX carries the real thing. syft maps the lockfile's `resolved` to
+ *      `downloadLocation`, so "under registry.npmjs.org" is a genuine
+ *      provenance claim: a git, tarball, private-registry or aliased
+ *      dependency fails it.
+ *
+ *      CycloneDX does NOT. syft's lock cataloger builds `pkg:npm/name@version`
+ *      from the name and version alone and carries `resolved` nowhere in the
+ *      document — no `externalReferences`, not in `properties` (verified
+ *      against a real artifact, run 33262407242). So the `pkg:npm/` test is an
+ *      ECOSYSTEM test, not a provenance one. It still does real work — a
+ *      github-actions entry is `pkg:githubactions/…` and a bare file component
+ *      has no purl at all, which is exactly the leak class — but a git
+ *      dependency would sail through it. Do not describe it as provenance; an
+ *      earlier version of this comment did, and that is the
+ *      comment-overstates-its-mechanism failure .github/CLAUDE.md ends on.
+ *
+ *      Assertion 4 is what stops that asymmetry becoming a hole.
  *
  *   2. TARGET — the package the document claims to describe is actually in it,
- *      at the version the stamp step recorded. Without this the check passes a
- *      document that is a perfectly well-formed closure OF SOMETHING ELSE: a
- *      wrong install spec or a cataloger dropping the direct dependency would
- *      be approved as long as the transitive packages remained.
+ *      at the version the stamp step recorded, and the document's own subject
+ *      says the same. Without this the check passes a document that is a
+ *      perfectly well-formed closure OF SOMETHING ELSE: a wrong install spec
+ *      or a cataloger dropping the direct dependency would be approved as long
+ *      as the transitive packages remained.
  *
  *   3. FLOOR — as MIN_EXPECTED_URLS does in check-pointer-urls.mjs. A floor,
  *      not a count: it catches "the document collapsed to nothing" without
  *      caring which packages are in it. Adding or removing a dependency never
  *      requires touching the number.
  *
+ *   4. AGREEMENT — the two documents list exactly the same name@version set.
+ *      They come from two separate syft runs, so nothing makes them agree by
+ *      construction; the leak that shipped from #529 until #530 was in every
+ *      CycloneDX document and no SPDX one. This is what carries the registry
+ *      claim across to CycloneDX: anything the weaker purl test would let
+ *      through has to appear in SPDX too, where the strong test is waiting.
+ *      It also catches format-specific inflation of any other kind.
+ *
  * Design mirrors check-pointer-urls.mjs: plain node, zero npm deps, pure
  * helpers exported, main only runs when executed directly.
  *
  * Usage:
- *   node scripts/check-consumer-sbom.mjs --file <sbom.json> --package <pkg> \
- *                                        --slug <slug> --version <version>
+ *   node scripts/check-consumer-sbom.mjs --spdx <file> --cdx <file> \
+ *          --package <pkg> --slug <slug> --version <version>
+ *
+ * Both documents in ONE invocation, because assertion 4 compares them against
+ * each other. Two separate runs could each pass while disagreeing.
  *
  * Exit codes: 0 the document checks out,
  *             1 an assertion failed,
@@ -313,6 +340,59 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
   return problems;
 }
 
+/** The catalogued `name@version` identities in a document, sorted. */
+export function identities(doc, { package: pkg, slug }) {
+  const norm = normalize(doc);
+  if (!norm) return [];
+  const structural = structuralNames({ package: pkg, slug });
+  return norm.entries
+    .filter(e => !structural.has(e.name))
+    .map(e => `${e.name}@${e.version ?? '?'}`)
+    .sort();
+}
+
+/**
+ * Assert the two documents describe the same closure.
+ *
+ * This is what carries the registry claim across to CycloneDX. The purl test
+ * there is an ecosystem test — syft builds `pkg:npm/name@version` from the
+ * name and version and puts `resolved` nowhere in the document — so a git or
+ * tarball dependency would pass it. It cannot pass this: the same package has
+ * to appear in the SPDX document, where `downloadLocation` carries the real
+ * origin and the strong test is waiting.
+ *
+ * It is also the only thing that would notice the two syft runs disagreeing
+ * for any other reason. They are separate invocations, so nothing makes them
+ * agree by construction, and the #529-to-#530 leak is the proof: present in
+ * every CycloneDX document, absent from every SPDX one.
+ */
+export function crossCheck(spdxDoc, cdxDoc, target) {
+  const a = identities(spdxDoc, target);
+  const b = identities(cdxDoc, target);
+  const onlySpdx = a.filter(x => !b.includes(x));
+  const onlyCdx = b.filter(x => !a.includes(x));
+  const problems = [];
+
+  if (onlySpdx.length) {
+    problems.push(
+      `${onlySpdx.length} package(s) are in the SPDX document but not the ` +
+        `CycloneDX one: ${onlySpdx.slice(0, 5).join(', ')}` +
+        `${onlySpdx.length > 5 ? ', …' : ''}. The two syft runs disagree ` +
+        `about the closure.`
+    );
+  }
+  if (onlyCdx.length) {
+    problems.push(
+      `${onlyCdx.length} package(s) are in the CycloneDX document but not the ` +
+        `SPDX one: ${onlyCdx.slice(0, 5).join(', ')}` +
+        `${onlyCdx.length > 5 ? ', …' : ''}. CycloneDX carries no registry ` +
+        `URL, so an entry only present there has never been origin-checked ` +
+        `by anything.`
+    );
+  }
+  return problems;
+}
+
 /** Parse `--flag value` argv; throws Error on misuse. */
 export function parseArgs(argv) {
   const flags = {};
@@ -322,7 +402,7 @@ export function parseArgs(argv) {
     if (i + 1 >= argv.length) throw new Error(`${key} needs a value`);
     flags[key.slice(2)] = argv[i + 1];
   }
-  for (const required of ['file', 'package', 'slug', 'version']) {
+  for (const required of ['spdx', 'cdx', 'package', 'slug', 'version']) {
     if (!flags[required]) throw new Error(`--${required} is required`);
   }
   return flags;
@@ -335,40 +415,63 @@ export function main(argv = process.argv.slice(2)) {
   } catch (err) {
     console.error(
       `::error::${err.message}\n` +
-        `usage: check-consumer-sbom.mjs --file <sbom.json> --package <pkg> ` +
-        `--slug <slug> --version <version>`
+        `usage: check-consumer-sbom.mjs --spdx <file> --cdx <file> ` +
+        `--package <pkg> --slug <slug> --version <version>`
     );
     return 2;
   }
 
-  let doc;
-  try {
-    doc = readDocument(args.file);
-  } catch (err) {
-    console.error(`::error::${err.message}`);
-    return 2;
+  // Both documents in one invocation, because assertion 4 compares them. Two
+  // separate invocations could each pass while disagreeing with each other,
+  // which is the case the CycloneDX purl test cannot cover on its own.
+  const docs = {};
+  for (const format of ['spdx', 'cdx']) {
+    try {
+      docs[format] = readDocument(args[format]);
+    } catch (err) {
+      console.error(`::error::${err.message}`);
+      return 2;
+    }
   }
 
-  const problems = inspect(doc, {
+  const target = {
     package: args.package,
     slug: args.slug,
     version: args.version,
     minPackages: MIN_EXPECTED_PACKAGES,
-  });
+  };
 
-  if (problems.length > 0) {
+  let failed = 0;
+  for (const format of ['spdx', 'cdx']) {
+    const problems = inspect(docs[format], target);
+    if (problems.length === 0) continue;
+    failed += 1;
     console.error(
-      `::error::${args.file} is not a clean consumer closure (${problems.length} problem(s))`
+      `::error::${args[format]} is not a clean consumer closure ` +
+        `(${problems.length} problem(s))`
     );
     for (const p of problems) console.error(`  - ${p}`);
-    return 1;
   }
 
-  const norm = normalize(doc);
+  const disagreements = crossCheck(docs.spdx, docs.cdx, target);
+  if (disagreements.length > 0) {
+    failed += 1;
+    console.error(
+      `::error::the two documents do not describe the same closure`
+    );
+    for (const p of disagreements) console.error(`  - ${p}`);
+  }
+
+  if (failed > 0) return 1;
+
+  const counts = ['spdx', 'cdx']
+    .map(f => `${normalize(docs[f]).entries.length} ${f}`)
+    .join(' / ');
   console.log(
-    `check-consumer-sbom: ${args.file} — ${norm.entries.length} ${norm.format} ` +
-      `entries, ${args.package}@${args.version} present, every catalogued ` +
-      `package under ${norm.originPrefix}`
+    `check-consumer-sbom: ${args.package}@${args.version} — ${counts} entries, ` +
+      `subject and target correct in both, every catalogued package under ` +
+      `${REGISTRY_PREFIX} in SPDX, and the two agree on ` +
+      `${identities(docs.spdx, target).length} packages`
   );
   return 0;
 }

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -190,7 +190,10 @@ export function readDocument(file) {
   try {
     return JSON.parse(raw);
   } catch (err) {
-    throw new Error(`${file} is not valid JSON: ${err.message}`, {
+    // SyntaxError.message embeds a snippet of the offending source, newlines
+    // and all, and this is printed under `::error::`. Same defect as the
+    // version validator's: the complaint re-introduces what it rejected.
+    throw new Error(`${file} is not valid JSON: ${forLog(err.message)}`, {
       cause: err,
     });
   }
@@ -476,10 +479,13 @@ export function crossCheck(spdxDoc, cdxDoc, target) {
     list.reduce((m, x) => m.set(x, (m.get(x) ?? 0) + 1), new Map());
   const ta = tally(a);
   const tb = tally(b);
+  // forLog on the identity, not just at the print site: these are `name@version`
+  // strings built straight out of a document, so an entry present in only one
+  // format reaches the log through this list.
   const excess = (x, y) =>
     [...x].flatMap(([id, n]) => {
       const d = n - (y.get(id) ?? 0);
-      return d > 0 ? [d > 1 ? `${id} (x${d} extra)` : id] : [];
+      return d > 0 ? [d > 1 ? `${forLog(id)} (x${d} extra)` : forLog(id)] : [];
     });
   const onlySpdx = excess(ta, tb);
   const onlyCdx = excess(tb, ta);

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -127,6 +127,24 @@ import { pathToFileURL } from 'node:url';
 /** Where every package in a consumer closure must have come from (SPDX). */
 export const REGISTRY_PREFIX = 'https://registry.npmjs.org/';
 
+/**
+ * Render an untrusted value for a log line.
+ *
+ * Everything in these documents is derived from published tarball metadata, so
+ * an entry name or version is attacker-influenced in exactly the way this
+ * job's own version string is. Problems are printed under `::error::`, and a
+ * GitHub Actions workflow command ends at a newline — so naming a bad entry
+ * with a bare `"${name}"` lets that entry emit a second, forged workflow
+ * command through the very message reporting it.
+ *
+ * JSON.stringify escapes newlines, carriage returns, quotes and control
+ * characters, so the value can only be one line of inert text. Use it for
+ * every value read out of a document.
+ */
+export function forLog(value) {
+  return JSON.stringify(String(value ?? ''));
+}
+
 /** The same claim in CycloneDX's vocabulary. */
 export const NPM_PURL_PREFIX = 'pkg:npm/';
 
@@ -271,8 +289,8 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
     const origin = e.origin;
     if (typeof origin !== 'string' || !origin.startsWith(norm.originPrefix)) {
       problems.push(
-        `"${e.name ?? '(unnamed)'}" has ${norm.originField} ` +
-          `${JSON.stringify(origin ?? null)}, which is not under ` +
+        `${forLog(e.name ?? '(unnamed)')} has ${norm.originField} ` +
+          `${forLog(origin)}, which is not under ` +
           `${norm.originPrefix}. Usually that means a cataloger is reading ` +
           `files it should not, or the scan source is leaking into the ` +
           `document (#529, #530). If instead we have genuinely taken a ` +
@@ -303,7 +321,7 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
   } else if (version && !matches.some(e => e.version === version)) {
     problems.push(
       `"${pkg}" is present at ` +
-        `${matches.map(e => JSON.stringify(e.version ?? null)).join(', ')} ` +
+        `${matches.map(e => forLog(e.version)).join(', ')} ` +
         `but the install stamped ${version}. The document and its filename ` +
         `disagree about which release this describes.`
     );
@@ -329,14 +347,14 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
 
   if (subject?.name !== expected) {
     problems.push(
-      `${where} names ${JSON.stringify(subject?.name ?? null)}, expected ` +
+      `${where} names ${forLog(subject?.name)}, expected ` +
         `"${expected}". The document does not say which package it describes, ` +
         `or it is naming a filesystem path (#529).`
     );
   }
   if (version && subject?.version !== version) {
     problems.push(
-      `${where} carries version ${JSON.stringify(subject?.version ?? null)}, ` +
+      `${where} carries version ${forLog(subject?.version)}, ` +
         `expected "${version}". The document would identify a different ` +
         `release than the one its filename and closure describe.`
     );
@@ -357,7 +375,7 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
     const cleaned = name.replace(/^\.\//, '');
     if (cleaned.includes('/') || cleaned.includes('\\')) {
       problems.push(
-        `the files array names ${JSON.stringify(name)}, which carries a path. ` +
+        `the files array names ${forLog(name)}, which carries a path. ` +
           `That is the runner's filesystem layout, which a published document ` +
           `must not disclose (#529, #530). The only expected entry is a bare ` +
           `"package-lock.json".`
@@ -395,7 +413,7 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
       `::warning::${norm.format}: ${dupes.length} package(s) listed more than ` +
         `once (${dupes
           .slice(0, 5)
-          .map(([id, n]) => `${id} x${n}`)
+          .map(([id, n]) => `${forLog(id)} x${n}`)
           .join(', ')}${dupes.length > 5 ? ', …' : ''}). npm can place the ` +
         `same version at two paths, so this is not failed — but if MOST of ` +
         `the closure is duplicated, a second cataloger is running (#529).`

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -135,13 +135,22 @@ export function readDocument(file) {
 /**
  * Flatten either format into one shape: { format, entries, subject }.
  *
- * Both are generated from the same syft run and describe the same closure, so
- * they are checked by the same assertions rather than by two parallel
- * implementations that could drift into disagreeing about what is acceptable.
+ * The two documents describe the same closure from the same scan directory and
+ * the same syft config, but they are produced by TWO SEPARATE `sbom-action`
+ * invocations — two syft runs, not one. That is not pedantry, it is the whole
+ * reason each is inspected independently rather than one being taken as proof
+ * of the other: the leak that shipped from #529 until #530 was present in
+ * every CycloneDX document and absent from every SPDX one, which cannot happen
+ * if they are two renderings of a single result.
  *
- * `subject` is what the document says it describes — CycloneDX's
- * `metadata.component`. SPDX carries the equivalent as an ordinary package
- * entry, so it has none here and is checked through the structural names.
+ * Normalizing them means the shared assertions are written once rather than as
+ * two implementations that could drift into disagreeing about what is
+ * acceptable. Where the formats genuinely differ, they differ here rather than
+ * at the call site.
+ *
+ * `subject` is CycloneDX's `metadata.component`. SPDX states the same thing as
+ * an ordinary package entry, so it is resolved by name in `inspect`, where the
+ * package name is known.
  */
 export function normalize(doc) {
   if (Array.isArray(doc?.packages)) {
@@ -239,25 +248,37 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
     );
   }
 
-  // CycloneDX states its subject in metadata.component rather than as an
-  // entry, so it is checked here rather than exempted by name and forgotten.
-  if (norm.format === 'cyclonedx') {
-    const expected = `consumer-closure:${pkg}`;
-    if (norm.subject?.name !== expected) {
-      problems.push(
-        `metadata.component.name is ` +
-          `${JSON.stringify(norm.subject?.name ?? null)}, expected ` +
-          `"${expected}". The document does not say which package it ` +
-          `describes, or it is naming a filesystem path (#529).`
-      );
-    }
-    if (version && norm.subject?.version !== version) {
-      problems.push(
-        `metadata.component.version is ` +
-          `${JSON.stringify(norm.subject?.version ?? null)}, expected ` +
-          `"${version}".`
-      );
-    }
+  // The document's own claim about what it describes, checked in BOTH formats.
+  //
+  // The two state it in different places — CycloneDX in metadata.component,
+  // SPDX as an ordinary package entry — and for a while only CycloneDX was
+  // checked. That left the SPDX subject exempted by name and never validated,
+  // so an SPDX document could name the wrong version, or omit the claim
+  // entirely, while its dependency entries were perfectly correct. The subject
+  // is the document's identity, not a structural detail to skip past.
+  const expected = `consumer-closure:${pkg}`;
+  const where =
+    norm.format === 'cyclonedx'
+      ? 'metadata.component'
+      : `the "${expected}" entry`;
+  const subject =
+    norm.format === 'cyclonedx'
+      ? norm.subject
+      : (norm.entries.find(e => e.name === expected) ?? null);
+
+  if (subject?.name !== expected) {
+    problems.push(
+      `${where} names ${JSON.stringify(subject?.name ?? null)}, expected ` +
+        `"${expected}". The document does not say which package it describes, ` +
+        `or it is naming a filesystem path (#529).`
+    );
+  }
+  if (version && subject?.version !== version) {
+    problems.push(
+      `${where} carries version ${JSON.stringify(subject?.version ?? null)}, ` +
+        `expected "${version}". The document would identify a different ` +
+        `release than the one its filename and closure describe.`
+    );
   }
 
   // SPDX keeps file entries in their own `files` array rather than among the

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -87,6 +87,25 @@
  *      through has to appear in SPDX too, where the strong test is waiting.
  *      It also catches format-specific inflation of any other kind.
  *
+ * ## What this does NOT defend, and what does
+ *
+ * This guard is the SECOND line against inflation, not the first, and reading
+ * it as the first is the way to quietly reopen everything above.
+ *
+ * The registry-origin assertion catches entries that are not npm packages —
+ * github-actions entries, file components, a dependency's own yarn.lock dev
+ * tree. It cannot catch a genuine npm package that resolves from
+ * registry.npmjs.org and appears identically in both documents: that passes
+ * origin, passes the floor (growth is deliberately allowed), and passes the
+ * cross-check (which compares the two documents to each other, not to an
+ * expectation).
+ *
+ * What actually prevents that class is the SCAN SHAPE — supply-chain.yml
+ * scans a directory holding only the root lockfile, so there is no
+ * dependency-shipped lockfile anywhere for a cataloger to find. Weakening the
+ * scan back to the installed tree on the grounds that "the guard will catch
+ * it" would be a mistake: it would not.
+ *
  * Design mirrors check-pointer-urls.mjs: plain node, zero npm deps, pure
  * helpers exported, main only runs when executed directly.
  *
@@ -180,7 +199,13 @@ export function readDocument(file) {
  * package name is known.
  */
 export function normalize(doc) {
-  if (Array.isArray(doc?.packages)) {
+  // Keyed on each format's REQUIRED top-level identifier, not on the shape of
+  // an array. Shape alone is a guess: any object carrying a `packages` array
+  // read as SPDX, so an exporter result that had lost `spdxVersion` — no
+  // longer a valid SPDX document, and not what the asset's name promises —
+  // satisfied the --spdx/--cdx role check and shipped. The array is still
+  // required, but it is now a second condition rather than the whole test.
+  if (typeof doc?.spdxVersion === 'string' && Array.isArray(doc?.packages)) {
     return {
       format: 'spdx',
       originField: 'downloadLocation',
@@ -193,7 +218,7 @@ export function normalize(doc) {
       subject: null,
     };
   }
-  if (Array.isArray(doc?.components)) {
+  if (doc?.bomFormat === 'CycloneDX' && Array.isArray(doc?.components)) {
     return {
       format: 'cyclonedx',
       originField: 'purl',
@@ -220,9 +245,10 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
   const norm = normalize(doc);
   if (!norm) {
     return [
-      `the document has neither a \`packages\` array (SPDX) nor a ` +
-        `\`components\` array (CycloneDX). Either an exporter changed shape ` +
-        `or this is not an SBOM.`,
+      `the document is neither SPDX (a \`spdxVersion\` plus a \`packages\` ` +
+        `array) nor CycloneDX (\`bomFormat: "CycloneDX"\` plus a ` +
+        `\`components\` array). Either an exporter changed shape, dropped its ` +
+        `format marker, or this is not an SBOM.`,
     ];
   }
 
@@ -261,16 +287,24 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
   // is well-formed but is a closure of something else — a wrong install spec,
   // a cataloger that dropped the direct dependency — passes every other
   // assertion here.
-  const target = catalogued.find(e => e.name === pkg);
-  if (!target) {
+  //
+  // ANY matching entry, not the first. npm can carry more than one version of
+  // a package in a closure, and nothing orders the document by depth, so a
+  // nested older copy emitted before the direct one made `find` report a
+  // mismatch while the stamped version was sitting right there — a false red
+  // on a perfectly good release, which is the failure mode this whole guard is
+  // written to avoid (48c57d5, #391, #525).
+  const matches = catalogued.filter(e => e.name === pkg);
+  if (matches.length === 0) {
     problems.push(
       `"${pkg}" is not in its own closure. The document is well-formed but ` +
         `describes something else.`
     );
-  } else if (version && target.version !== version) {
+  } else if (version && !matches.some(e => e.version === version)) {
     problems.push(
-      `"${pkg}" is present at ${JSON.stringify(target.version ?? null)} but ` +
-        `the install stamped ${version}. The document and its filename ` +
+      `"${pkg}" is present at ` +
+        `${matches.map(e => JSON.stringify(e.version ?? null)).join(', ')} ` +
+        `but the install stamped ${version}. The document and its filename ` +
         `disagree about which release this describes.`
     );
   }
@@ -309,17 +343,24 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
   }
 
   // SPDX keeps file entries in their own `files` array rather than among the
-  // packages, so the origin loop above cannot see them. syft writes those
-  // names RELATIVE to the source today — a bare `package-lock.json`, which
-  // leaks nothing and is left alone. An ABSOLUTE one is the SPDX shape of the
-  // leak that shipped in every .cdx.json from #529 until #530, so it is
-  // rejected rather than trusted to stay relative.
+  // packages, so the origin loop above cannot see them.
+  //
+  // Rejects any name carrying a PATH, not just an absolute one. The scan
+  // directory holds exactly one file, so syft's only legitimate entry is the
+  // bare `package-lock.json` it writes today; anything with a separator is
+  // describing a directory structure. Testing only `startsWith('/')` let a
+  // relative-but-still-leaking name through — `work/_temp/scan/…` discloses
+  // the same layout as the absolute form it was written to catch.
   for (const f of Array.isArray(doc?.files) ? doc.files : []) {
-    if (typeof f?.fileName === 'string' && f.fileName.startsWith('/')) {
+    const name = f?.fileName;
+    if (typeof name !== 'string') continue;
+    const cleaned = name.replace(/^\.\//, '');
+    if (cleaned.includes('/') || cleaned.includes('\\')) {
       problems.push(
-        `the files array names ${JSON.stringify(f.fileName)}, an absolute ` +
-          `path. That is the runner's filesystem layout, which a published ` +
-          `document must not carry (#529, #530).`
+        `the files array names ${JSON.stringify(name)}, which carries a path. ` +
+          `That is the runner's filesystem layout, which a published document ` +
+          `must not disclose (#529, #530). The only expected entry is a bare ` +
+          `"package-lock.json".`
       );
     }
   }

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -260,6 +260,22 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
     }
   }
 
+  // SPDX keeps file entries in their own `files` array rather than among the
+  // packages, so the origin loop above cannot see them. syft writes those
+  // names RELATIVE to the source today — a bare `package-lock.json`, which
+  // leaks nothing and is left alone. An ABSOLUTE one is the SPDX shape of the
+  // leak that shipped in every .cdx.json from #529 until #530, so it is
+  // rejected rather than trusted to stay relative.
+  for (const f of Array.isArray(doc?.files) ? doc.files : []) {
+    if (typeof f?.fileName === 'string' && f.fileName.startsWith('/')) {
+      problems.push(
+        `the files array names ${JSON.stringify(f.fileName)}, an absolute ` +
+          `path. That is the runner's filesystem layout, which a published ` +
+          `document must not carry (#529, #530).`
+      );
+    }
+  }
+
   // The scratch project root should be present in both formats. Not a failure
   // on its own — the document is still an honest closure without it — but its
   // absence means the scan container changed, and the exemption above is then

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -22,8 +22,15 @@
  *   - Selecting the whole `javascript` cataloger group enabled both javascript
  *     catalogers, listing every package twice — bestax-migrate at 200.
  *
- * Both were found by dispatching the workflow and reading the JSON. Neither
- * was visible from a green job. That is what this script is for.
+ * And a third time on THIS branch, which is why the check reads both formats
+ * rather than SPDX alone: pointing syft at the lockfile as a `file:` source put
+ * a `type: file` component named `/home/runner/work/_temp/consumer/
+ * package-lock.json` into every CycloneDX document — the same runner-path leak
+ * #529 fixed for SPDX, in the format nothing was reading. An SPDX-only guard
+ * passed it, and the leaked document was signed and attached.
+ *
+ * All three were found by generating a document and reading it. None was
+ * visible from a green job. That is what this script is for.
  *
  * ## Why there is no expected count here
  *
@@ -35,26 +42,33 @@
  * repository has already fixed twice (#391, #525), and re-shipping it would be
  * worse than having no guard.
  *
- * So: two assertions, neither of which knows a count.
+ * So: three assertions, none of which knows a count.
  *
- *   1. REGISTRY-URL — every catalogued package resolves to registry.npmjs.org.
- *      This is the one that matters, because it catches inflation by its cause
- *      rather than by its size. A github-actions entry has no npm download
- *      location; neither does a package catalogued out of a dependency's own
- *      yarn.lock. It would have caught both #529 regressions, and it stays
- *      correct as the closure grows.
+ *   1. ORIGIN — every catalogued entry came from the npm registry. SPDX says
+ *      that with a `downloadLocation` under registry.npmjs.org; CycloneDX says
+ *      it with a `pkg:npm/` purl. This is the one that matters, because it
+ *      catches inflation by its cause rather than by its size: a
+ *      github-actions entry, a package catalogued out of a dependency's own
+ *      yarn.lock, and a bare file component all fail it, and it stays correct
+ *      as the closure grows.
  *
- *   2. FLOOR — as MIN_EXPECTED_URLS does in check-pointer-urls.mjs. A floor,
- *      not a count: it catches "the document collapsed to nothing" (an
- *      exporter change, a cataloger that stopped matching) without caring
- *      which packages are in it. Adding or removing a dependency never
+ *   2. TARGET — the package the document claims to describe is actually in it,
+ *      at the version the stamp step recorded. Without this the check passes a
+ *      document that is a perfectly well-formed closure OF SOMETHING ELSE: a
+ *      wrong install spec or a cataloger dropping the direct dependency would
+ *      be approved as long as the transitive packages remained.
+ *
+ *   3. FLOOR — as MIN_EXPECTED_URLS does in check-pointer-urls.mjs. A floor,
+ *      not a count: it catches "the document collapsed to nothing" without
+ *      caring which packages are in it. Adding or removing a dependency never
  *      requires touching the number.
  *
  * Design mirrors check-pointer-urls.mjs: plain node, zero npm deps, pure
  * helpers exported, main only runs when executed directly.
  *
  * Usage:
- *   node scripts/check-consumer-sbom.mjs --file <spdx.json> --package <pkg> --slug <slug>
+ *   node scripts/check-consumer-sbom.mjs --file <sbom.json> --package <pkg> \
+ *                                        --slug <slug> --version <version>
  *
  * Exit codes: 0 the document checks out,
  *             1 an assertion failed,
@@ -64,29 +78,32 @@ import fs from 'node:fs';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
-/** Where every package in a consumer closure must have come from. */
+/** Where every package in a consumer closure must have come from (SPDX). */
 export const REGISTRY_PREFIX = 'https://registry.npmjs.org/';
+
+/** The same claim in CycloneDX's vocabulary. */
+export const NPM_PURL_PREFIX = 'pkg:npm/';
 
 /**
  * Fail below this many packages. A FLOOR, not the current count — bulma-ui has
  * the smallest real closure at five, so three leaves room for a dependency to
  * be dropped without touching this file, while still catching a document that
- * collapsed to the two structural entries or to nothing at all.
+ * collapsed to the structural entries or to nothing at all.
  */
 export const MIN_EXPECTED_PACKAGES = 3;
 
 /**
- * The two entries that are legitimately NOT dependencies, named exactly.
+ * The entries that are legitimately NOT dependencies, named exactly.
  *
- * A directory scan adds the scratch project the lockfile records as its root;
- * syft additionally emits the configured source as a package of its own. Both
- * are ours, both are named deliberately in supply-chain.yml, and neither has a
- * registry URL.
+ * The scratch project the lockfile records as its root appears in both
+ * formats. The configured source appears as an SPDX package, but CycloneDX
+ * puts it in `metadata.component` instead — where it is checked separately,
+ * rather than being exempted and forgotten.
  *
- * Exempted BY NAME rather than by allowing NOASSERTION generally. A blanket
- * "packages without a download location are fine" exemption would readmit
- * precisely the github-actions entries this check exists to catch — they carry
- * NOASSERTION too. If syft stops emitting one of these, the name simply stops
+ * Exempted BY NAME rather than by allowing a missing origin generally. A
+ * blanket "entries without an origin are fine" exemption would readmit
+ * precisely the github-actions entries and file components this check exists
+ * to catch. If syft stops emitting one of these, the name simply stops
  * matching and nothing is weakened.
  */
 export function structuralNames({ package: pkg, slug }) {
@@ -96,7 +113,7 @@ export function structuralNames({ package: pkg, slug }) {
   ]);
 }
 
-/** Read and parse an SPDX document, throwing a message that names the file. */
+/** Read and parse an SBOM, throwing a message that names the file. */
 export function readDocument(file) {
   let raw;
   try {
@@ -116,29 +133,70 @@ export function readDocument(file) {
 }
 
 /**
+ * Flatten either format into one shape: { format, entries, subject }.
+ *
+ * Both are generated from the same syft run and describe the same closure, so
+ * they are checked by the same assertions rather than by two parallel
+ * implementations that could drift into disagreeing about what is acceptable.
+ *
+ * `subject` is what the document says it describes — CycloneDX's
+ * `metadata.component`. SPDX carries the equivalent as an ordinary package
+ * entry, so it has none here and is checked through the structural names.
+ */
+export function normalize(doc) {
+  if (Array.isArray(doc?.packages)) {
+    return {
+      format: 'spdx',
+      originField: 'downloadLocation',
+      originPrefix: REGISTRY_PREFIX,
+      entries: doc.packages.map(p => ({
+        name: p?.name,
+        version: p?.versionInfo,
+        origin: p?.downloadLocation,
+      })),
+      subject: null,
+    };
+  }
+  if (Array.isArray(doc?.components)) {
+    return {
+      format: 'cyclonedx',
+      originField: 'purl',
+      originPrefix: NPM_PURL_PREFIX,
+      entries: doc.components.map(c => ({
+        name: c?.name,
+        version: c?.version,
+        origin: c?.purl,
+      })),
+      subject: doc?.metadata?.component ?? null,
+    };
+  }
+  return null;
+}
+
+/**
  * The problems with a document, as a list of strings. Empty means it checks
  * out.
  *
  * Returns every problem rather than the first: a reader who has to dispatch
  * the workflow to see this at all should get the whole picture from one run.
  */
-export function inspect(doc, { package: pkg, slug, minPackages }) {
-  const problems = [];
-  const packages = Array.isArray(doc?.packages) ? doc.packages : null;
-
-  if (!packages) {
+export function inspect(doc, { package: pkg, slug, version, minPackages }) {
+  const norm = normalize(doc);
+  if (!norm) {
     return [
-      `the document has no \`packages\` array. Either the exporter changed ` +
-        `shape or this is not an SPDX document.`,
+      `the document has neither a \`packages\` array (SPDX) nor a ` +
+        `\`components\` array (CycloneDX). Either an exporter changed shape ` +
+        `or this is not an SBOM.`,
     ];
   }
 
+  const problems = [];
   const structural = structuralNames({ package: pkg, slug });
-  const catalogued = packages.filter(p => !structural.has(p?.name));
+  const catalogued = norm.entries.filter(e => !structural.has(e.name));
 
-  // The floor counts catalogued packages, not entries. Counting entries would
-  // let a document consisting only of the two structural names pass a floor of
-  // two, which is exactly the collapse being guarded against.
+  // The floor counts catalogued entries, not all of them. Counting everything
+  // would let a document consisting only of the structural names pass a floor
+  // of two, which is exactly the collapse being guarded against.
   if (catalogued.length < minPackages) {
     problems.push(
       `only ${catalogued.length} catalogued package(s), expected at least ` +
@@ -147,30 +205,69 @@ export function inspect(doc, { package: pkg, slug, minPackages }) {
     );
   }
 
-  for (const p of catalogued) {
-    const location = p?.downloadLocation;
-    if (typeof location !== 'string' || !location.startsWith(REGISTRY_PREFIX)) {
+  for (const e of catalogued) {
+    const origin = e.origin;
+    if (typeof origin !== 'string' || !origin.startsWith(norm.originPrefix)) {
       problems.push(
-        `"${p?.name ?? '(unnamed)'}" has downloadLocation ` +
-          `${JSON.stringify(location ?? null)}, which is not under ` +
-          `${REGISTRY_PREFIX}. It is not something a consumer installs from ` +
-          `npm — a cataloger is reading files it should not (#529).`
+        `"${e.name ?? '(unnamed)'}" has ${norm.originField} ` +
+          `${JSON.stringify(origin ?? null)}, which is not under ` +
+          `${norm.originPrefix}. It is not something a consumer installs from ` +
+          `npm — a cataloger is reading files it should not, or the scan ` +
+          `source is leaking into the document (#529, #530).`
       );
     }
   }
 
-  // Both structural entries should be present. Not a failure on its own — the
-  // document is still an honest closure without them — but their absence means
-  // the source configuration changed, and the exemptions above are then
-  // exempting nothing while looking like they still work.
-  for (const name of structural) {
-    if (!packages.some(p => p?.name === name)) {
-      console.error(
-        `::warning::expected structural entry "${name}" is absent; the syft ` +
-          `source config in supply-chain.yml and the exemptions in ` +
-          `check-consumer-sbom.mjs have drifted apart.`
+  // The document must contain the thing it claims to describe. A closure that
+  // is well-formed but is a closure of something else — a wrong install spec,
+  // a cataloger that dropped the direct dependency — passes every other
+  // assertion here.
+  const target = catalogued.find(e => e.name === pkg);
+  if (!target) {
+    problems.push(
+      `"${pkg}" is not in its own closure. The document is well-formed but ` +
+        `describes something else.`
+    );
+  } else if (version && target.version !== version) {
+    problems.push(
+      `"${pkg}" is present at ${JSON.stringify(target.version ?? null)} but ` +
+        `the install stamped ${version}. The document and its filename ` +
+        `disagree about which release this describes.`
+    );
+  }
+
+  // CycloneDX states its subject in metadata.component rather than as an
+  // entry, so it is checked here rather than exempted by name and forgotten.
+  if (norm.format === 'cyclonedx') {
+    const expected = `consumer-closure:${pkg}`;
+    if (norm.subject?.name !== expected) {
+      problems.push(
+        `metadata.component.name is ` +
+          `${JSON.stringify(norm.subject?.name ?? null)}, expected ` +
+          `"${expected}". The document does not say which package it ` +
+          `describes, or it is naming a filesystem path (#529).`
       );
     }
+    if (version && norm.subject?.version !== version) {
+      problems.push(
+        `metadata.component.version is ` +
+          `${JSON.stringify(norm.subject?.version ?? null)}, expected ` +
+          `"${version}".`
+      );
+    }
+  }
+
+  // The scratch project root should be present in both formats. Not a failure
+  // on its own — the document is still an honest closure without it — but its
+  // absence means the scan container changed, and the exemption above is then
+  // exempting nothing while looking like it still works.
+  const root = `bestax-consumer-closure-${slug}`;
+  if (!norm.entries.some(e => e.name === root)) {
+    console.error(
+      `::warning::expected structural entry "${root}" is absent from this ` +
+        `${norm.format} document; the scan container in supply-chain.yml and ` +
+        `the exemptions in check-consumer-sbom.mjs have drifted apart.`
+    );
   }
 
   return problems;
@@ -185,7 +282,7 @@ export function parseArgs(argv) {
     if (i + 1 >= argv.length) throw new Error(`${key} needs a value`);
     flags[key.slice(2)] = argv[i + 1];
   }
-  for (const required of ['file', 'package', 'slug']) {
+  for (const required of ['file', 'package', 'slug', 'version']) {
     if (!flags[required]) throw new Error(`--${required} is required`);
   }
   return flags;
@@ -198,7 +295,8 @@ export function main(argv = process.argv.slice(2)) {
   } catch (err) {
     console.error(
       `::error::${err.message}\n` +
-        `usage: check-consumer-sbom.mjs --file <spdx.json> --package <pkg> --slug <slug>`
+        `usage: check-consumer-sbom.mjs --file <sbom.json> --package <pkg> ` +
+        `--slug <slug> --version <version>`
     );
     return 2;
   }
@@ -214,6 +312,7 @@ export function main(argv = process.argv.slice(2)) {
   const problems = inspect(doc, {
     package: args.package,
     slug: args.slug,
+    version: args.version,
     minPackages: MIN_EXPECTED_PACKAGES,
   });
 
@@ -225,10 +324,11 @@ export function main(argv = process.argv.slice(2)) {
     return 1;
   }
 
-  const total = Array.isArray(doc.packages) ? doc.packages.length : 0;
+  const norm = normalize(doc);
   console.log(
-    `check-consumer-sbom: ${args.file} — ${total} entries, every catalogued ` +
-      `package resolves to ${REGISTRY_PREFIX}`
+    `check-consumer-sbom: ${args.file} — ${norm.entries.length} ${norm.format} ` +
+      `entries, ${args.package}@${args.version} present, every catalogued ` +
+      `package under ${norm.originPrefix}`
   );
   return 0;
 }

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Assert that a generated consumer-closure SBOM still describes a consumer
+ * closure (#530 item 2, deferred from #529).
+ *
+ * ## What this is guarding against
+ *
+ * Nothing asserted anything about the generated document, so a syft,
+ * cataloger, or exporter change — or a dependency that starts shipping a
+ * lockfile inside its tarball — ships silently green. The knowledge that
+ * prevents that ("do not select the `javascript` group", "exclude
+ * node_modules") lived only in comments in supply-chain.yml, and comments do
+ * not fail a build.
+ *
+ * The failure mode is specifically INFLATION, and it happened twice on #529's
+ * own branch:
+ *
+ *   - syft's github-actions cataloger read `.github/workflows` YAML that some
+ *     upstream packages ship inside their npm tarballs, listing
+ *     `actions/checkout@v4` as a dependency — bestax-migrate at 111 entries
+ *     against a real closure of 98.
+ *   - Selecting the whole `javascript` cataloger group enabled both javascript
+ *     catalogers, listing every package twice — bestax-migrate at 200.
+ *
+ * Both were found by dispatching the workflow and reading the JSON. Neither
+ * was visible from a green job. That is what this script is for.
+ *
+ * ## Why there is no expected count here
+ *
+ * Because there cannot be one. The first implementation of this guard compared
+ * `!==` against counts hardcoded in the workflow matrix (5/12/98/94) and was
+ * reverted in 48c57d5. Those are LIVE REGISTRY closures: they drift whenever
+ * any transitive dependency publishes, so the job would go red on somebody
+ * else's release having found nothing wrong. That is the cry-wolf failure this
+ * repository has already fixed twice (#391, #525), and re-shipping it would be
+ * worse than having no guard.
+ *
+ * So: two assertions, neither of which knows a count.
+ *
+ *   1. REGISTRY-URL — every catalogued package resolves to registry.npmjs.org.
+ *      This is the one that matters, because it catches inflation by its cause
+ *      rather than by its size. A github-actions entry has no npm download
+ *      location; neither does a package catalogued out of a dependency's own
+ *      yarn.lock. It would have caught both #529 regressions, and it stays
+ *      correct as the closure grows.
+ *
+ *   2. FLOOR — as MIN_EXPECTED_URLS does in check-pointer-urls.mjs. A floor,
+ *      not a count: it catches "the document collapsed to nothing" (an
+ *      exporter change, a cataloger that stopped matching) without caring
+ *      which packages are in it. Adding or removing a dependency never
+ *      requires touching the number.
+ *
+ * Design mirrors check-pointer-urls.mjs: plain node, zero npm deps, pure
+ * helpers exported, main only runs when executed directly.
+ *
+ * Usage:
+ *   node scripts/check-consumer-sbom.mjs --file <spdx.json> --package <pkg> --slug <slug>
+ *
+ * Exit codes: 0 the document checks out,
+ *             1 an assertion failed,
+ *             2 bad usage or an unreadable document.
+ */
+import fs from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+/** Where every package in a consumer closure must have come from. */
+export const REGISTRY_PREFIX = 'https://registry.npmjs.org/';
+
+/**
+ * Fail below this many packages. A FLOOR, not the current count — bulma-ui has
+ * the smallest real closure at five, so three leaves room for a dependency to
+ * be dropped without touching this file, while still catching a document that
+ * collapsed to the two structural entries or to nothing at all.
+ */
+export const MIN_EXPECTED_PACKAGES = 3;
+
+/**
+ * The two entries that are legitimately NOT dependencies, named exactly.
+ *
+ * A directory scan adds the scratch project the lockfile records as its root;
+ * syft additionally emits the configured source as a package of its own. Both
+ * are ours, both are named deliberately in supply-chain.yml, and neither has a
+ * registry URL.
+ *
+ * Exempted BY NAME rather than by allowing NOASSERTION generally. A blanket
+ * "packages without a download location are fine" exemption would readmit
+ * precisely the github-actions entries this check exists to catch — they carry
+ * NOASSERTION too. If syft stops emitting one of these, the name simply stops
+ * matching and nothing is weakened.
+ */
+export function structuralNames({ package: pkg, slug }) {
+  return new Set([
+    `bestax-consumer-closure-${slug}`,
+    `consumer-closure:${pkg}`,
+  ]);
+}
+
+/** Read and parse an SPDX document, throwing a message that names the file. */
+export function readDocument(file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    throw new Error(`cannot read ${file}: ${err.code ?? err.message}`, {
+      cause: err,
+    });
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`${file} is not valid JSON: ${err.message}`, {
+      cause: err,
+    });
+  }
+}
+
+/**
+ * The problems with a document, as a list of strings. Empty means it checks
+ * out.
+ *
+ * Returns every problem rather than the first: a reader who has to dispatch
+ * the workflow to see this at all should get the whole picture from one run.
+ */
+export function inspect(doc, { package: pkg, slug, minPackages }) {
+  const problems = [];
+  const packages = Array.isArray(doc?.packages) ? doc.packages : null;
+
+  if (!packages) {
+    return [
+      `the document has no \`packages\` array. Either the exporter changed ` +
+        `shape or this is not an SPDX document.`,
+    ];
+  }
+
+  const structural = structuralNames({ package: pkg, slug });
+  const catalogued = packages.filter(p => !structural.has(p?.name));
+
+  // The floor counts catalogued packages, not entries. Counting entries would
+  // let a document consisting only of the two structural names pass a floor of
+  // two, which is exactly the collapse being guarded against.
+  if (catalogued.length < minPackages) {
+    problems.push(
+      `only ${catalogued.length} catalogued package(s), expected at least ` +
+        `${minPackages}. This is a floor, not a count — the document has ` +
+        `collapsed, not merely shrunk.`
+    );
+  }
+
+  for (const p of catalogued) {
+    const location = p?.downloadLocation;
+    if (typeof location !== 'string' || !location.startsWith(REGISTRY_PREFIX)) {
+      problems.push(
+        `"${p?.name ?? '(unnamed)'}" has downloadLocation ` +
+          `${JSON.stringify(location ?? null)}, which is not under ` +
+          `${REGISTRY_PREFIX}. It is not something a consumer installs from ` +
+          `npm — a cataloger is reading files it should not (#529).`
+      );
+    }
+  }
+
+  // Both structural entries should be present. Not a failure on its own — the
+  // document is still an honest closure without them — but their absence means
+  // the source configuration changed, and the exemptions above are then
+  // exempting nothing while looking like they still work.
+  for (const name of structural) {
+    if (!packages.some(p => p?.name === name)) {
+      console.error(
+        `::warning::expected structural entry "${name}" is absent; the syft ` +
+          `source config in supply-chain.yml and the exemptions in ` +
+          `check-consumer-sbom.mjs have drifted apart.`
+      );
+    }
+  }
+
+  return problems;
+}
+
+/** Parse `--flag value` argv; throws Error on misuse. */
+export function parseArgs(argv) {
+  const flags = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    if (!key.startsWith('--')) throw new Error(`unexpected argument "${key}"`);
+    if (i + 1 >= argv.length) throw new Error(`${key} needs a value`);
+    flags[key.slice(2)] = argv[i + 1];
+  }
+  for (const required of ['file', 'package', 'slug']) {
+    if (!flags[required]) throw new Error(`--${required} is required`);
+  }
+  return flags;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    console.error(
+      `::error::${err.message}\n` +
+        `usage: check-consumer-sbom.mjs --file <spdx.json> --package <pkg> --slug <slug>`
+    );
+    return 2;
+  }
+
+  let doc;
+  try {
+    doc = readDocument(args.file);
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    return 2;
+  }
+
+  const problems = inspect(doc, {
+    package: args.package,
+    slug: args.slug,
+    minPackages: MIN_EXPECTED_PACKAGES,
+  });
+
+  if (problems.length > 0) {
+    console.error(
+      `::error::${args.file} is not a clean consumer closure (${problems.length} problem(s))`
+    );
+    for (const p of problems) console.error(`  - ${p}`);
+    return 1;
+  }
+
+  const total = Array.isArray(doc.packages) ? doc.packages.length : 0;
+  console.log(
+    `check-consumer-sbom: ${args.file} — ${total} entries, every catalogued ` +
+      `package resolves to ${REGISTRY_PREFIX}`
+  );
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  process.exitCode = main();
+}

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -277,18 +277,53 @@ export function inspect(doc, { package: pkg, slug, version, minPackages }) {
   const structural = structuralNames({ package: pkg, slug });
   const catalogued = norm.entries.filter(e => !structural.has(e.name));
 
-  // The floor counts catalogued entries, not all of them. Counting everything
-  // would let a document consisting only of the structural names pass a floor
-  // of two, which is exactly the collapse being guarded against.
-  if (catalogued.length < minPackages) {
+  // The floor counts DISTINCT NAMES, not entries, and not merely
+  // non-structural entries. Both narrowings were needed, one at a time:
+  //
+  //   - counting everything let a document of just the structural names pass a
+  //     floor of two;
+  //   - counting entries let DUPLICATES satisfy it. Duplicates are only warned
+  //     about below (npm can legitimately place a version at two paths), so
+  //     three copies of the target package cleared a floor of three while the
+  //     closure had in fact collapsed to a single package — and if both
+  //     documents carried those copies, origin, target, subject and the
+  //     multiset cross-check all passed too.
+  //
+  // Distinct names is what "the document collapsed" actually means. Measured
+  // before tightening: the smallest real closure has 5 distinct names
+  // (run 33263381732), so the floor of 3 keeps its headroom.
+  const distinctNames = new Set(catalogued.map(e => e.name)).size;
+  if (distinctNames < minPackages) {
     problems.push(
-      `only ${catalogued.length} catalogued package(s), expected at least ` +
-        `${minPackages}. This is a floor, not a count — the document has ` +
-        `collapsed, not merely shrunk.`
+      `only ${distinctNames} distinct catalogued package(s) across ` +
+        `${catalogued.length} entr${catalogued.length === 1 ? 'y' : 'ies'}, ` +
+        `expected at least ${minPackages}. This is a floor, not a count — the ` +
+        `document has collapsed, not merely shrunk.`
     );
   }
 
   for (const e of catalogued) {
+    // A name and a version are what makes an entry an inventory record at all.
+    // Without this an entry carrying a plausible origin but no identity
+    // produced no problem, and identities() rendered its missing version as
+    // `?` — so when both syft runs omitted the same metadata the floor and the
+    // cross-check agreed with each other and a malformed document shipped.
+    // Measured before requiring it: 428 entries across the four closures, none
+    // missing either field.
+    if (typeof e.name !== 'string' || e.name === '') {
+      problems.push(
+        `an entry has no usable name (${forLog(e.name)}). An inventory record ` +
+          `without an identity is not evidence of anything.`
+      );
+    }
+    if (typeof e.version !== 'string' || e.version === '') {
+      problems.push(
+        `${forLog(e.name ?? '(unnamed)')} has no usable version ` +
+          `(${forLog(e.version)}). A closure entry that does not say which ` +
+          `version it is cannot be checked against anything.`
+      );
+    }
+
     const origin = e.origin;
     if (typeof origin !== 'string' || !origin.startsWith(norm.originPrefix)) {
       problems.push(

--- a/scripts/check-consumer-sbom.mjs
+++ b/scripts/check-consumer-sbom.mjs
@@ -434,6 +434,27 @@ export function main(argv = process.argv.slice(2)) {
     }
   }
 
+  // The flags are a CLAIM about each file; normalize() detects the format from
+  // the document's own shape. Those are two different things, and until they
+  // are compared the flags are decoration: hand this the CycloneDX file twice
+  // and every per-document assertion passes, assertion 4 trivially agrees with
+  // itself, and the release ships a file called `.spdx.json` that is not SPDX.
+  // A `format:` typo on either sbom-action step produces exactly that.
+  for (const [flag, expected] of [
+    ['spdx', 'spdx'],
+    ['cdx', 'cyclonedx'],
+  ]) {
+    const detected = normalize(docs[flag])?.format ?? null;
+    if (detected !== expected) {
+      console.error(
+        `::error::${args[flag]} was passed as --${flag} but its contents are ` +
+          `${JSON.stringify(detected)}, not ${expected}. The asset's name and ` +
+          `its format disagree.`
+      );
+      return 1;
+    }
+  }
+
   const target = {
     package: args.package,
     slug: args.slug,

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -758,3 +758,28 @@ test('a missing version is not laundered into an agreeing `?` identity', () => {
   assert.ok(inspect(s, TARGET).length > 0); // ...but each is now rejected
   assert.ok(inspect(c, TARGET).length > 0);
 });
+
+test('an unknown flag is rejected here too', () => {
+  // No flag is optional in this script today, so a typo would be caught by the
+  // required check anyway — but that is a property of today's flag list rather
+  // than a guarantee, and the sibling script shows what happens when an
+  // optional flag meets a permissive parser.
+  assert.throws(
+    () =>
+      parseArgs([
+        '--spdx',
+        'a',
+        '--cdx',
+        'b',
+        '--package',
+        'p',
+        '--slug',
+        's',
+        '--version',
+        '1.0.0',
+        '--bogus',
+        'z',
+      ]),
+    /unknown flag --bogus/
+  );
+});

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -1,0 +1,223 @@
+/**
+ * Guards on check-consumer-sbom.mjs.
+ *
+ * The two cases that matter most are regressions that really happened, on
+ * #529's own branch, and were found only by dispatching the workflow and
+ * reading the JSON:
+ *
+ *   - a github-actions cataloger entry, from `.github/workflows` YAML shipped
+ *     inside an upstream npm tarball;
+ *   - every package listed twice, from selecting the whole `javascript`
+ *     cataloger group.
+ *
+ * Both are reproduced below as documents this check must reject. If either
+ * test is ever relaxed, the corresponding syft config in supply-chain.yml is
+ * the thing to look at first.
+ *
+ * The negative case is just as important: a document that has merely GROWN
+ * must pass. The first version of this guard compared against hardcoded counts
+ * and was reverted in 48c57d5 for exactly that reason — a live registry
+ * closure drifts on somebody else's release, and a gate that reds every open
+ * PR when nothing is wrong gets deleted (#391, #525).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  REGISTRY_PREFIX,
+  MIN_EXPECTED_PACKAGES,
+  structuralNames,
+  readDocument,
+  inspect,
+  parseArgs,
+  main,
+} from './check-consumer-sbom.mjs';
+
+const PKG = '@allxsmith/bestax-bulma';
+const SLUG = 'allxsmith-bestax-bulma';
+const TARGET = { package: PKG, slug: SLUG, minPackages: MIN_EXPECTED_PACKAGES };
+
+const dep = (name, version = '1.0.0') => ({
+  name,
+  versionInfo: version,
+  downloadLocation: `${REGISTRY_PREFIX}${name}/-/${name}-${version}.tgz`,
+});
+
+/** The two entries syft legitimately adds that are not dependencies. */
+const structural = [
+  { name: `bestax-consumer-closure-${SLUG}`, downloadLocation: 'NOASSERTION' },
+  { name: `consumer-closure:${PKG}`, downloadLocation: 'NOASSERTION' },
+];
+
+/** A healthy bulma-ui closure: five packages plus the two structural entries. */
+const healthy = () => ({
+  packages: [
+    ...structural,
+    dep('bulma', '1.0.4'),
+    dep('react'),
+    dep('react-dom'),
+    dep('scheduler'),
+    dep('loose-envify'),
+  ],
+});
+
+function writeDoc(doc) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-consumer-sbom-'));
+  const file = path.join(dir, 'sbom.spdx.json');
+  fs.writeFileSync(file, JSON.stringify(doc));
+  return file;
+}
+
+// --- the happy path ----------------------------------------------------------
+
+test('a clean closure has no problems', () => {
+  assert.deepEqual(inspect(healthy(), TARGET), []);
+});
+
+test('a closure that merely GREW still passes', () => {
+  // The whole reason there is no expected count. A transitive dependency
+  // publishing must never red this job.
+  const doc = healthy();
+  for (let i = 0; i < 200; i += 1) doc.packages.push(dep(`transitive-${i}`));
+  assert.deepEqual(inspect(doc, TARGET), []);
+});
+
+test('a closure that merely SHRANK, but is still a closure, passes', () => {
+  const doc = { packages: [...structural, dep('a'), dep('b'), dep('c')] };
+  assert.deepEqual(inspect(doc, TARGET), []);
+});
+
+// --- the two real regressions ------------------------------------------------
+
+test('rejects a github-actions cataloger entry (#529)', () => {
+  const doc = healthy();
+  doc.packages.push({
+    name: 'actions/checkout',
+    versionInfo: 'v4',
+    downloadLocation: 'NOASSERTION',
+  });
+  const problems = inspect(doc, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /actions\/checkout/);
+  assert.match(problems[0], /not under https:\/\/registry\.npmjs\.org\//);
+});
+
+test("rejects a dependency's own yarn.lock dev closure leaking in", () => {
+  // npm always excludes package-lock.json from a tarball but NOT yarn.lock, so
+  // one dependency publishing without a `files:` field would inject its whole
+  // dev tree. Those entries resolve to the yarn registry, a git URL, or
+  // nothing — never to registry.npmjs.org via our lockfile's `resolved`.
+  const doc = healthy();
+  doc.packages.push({
+    name: 'some-dev-tool',
+    versionInfo: '2.0.0',
+    downloadLocation: 'https://registry.yarnpkg.com/some-dev-tool.tgz',
+  });
+  doc.packages.push({
+    name: 'a-git-dep',
+    versionInfo: '0.0.0',
+    downloadLocation: 'git+https://github.com/someone/thing.git',
+  });
+  const problems = inspect(doc, TARGET);
+  assert.equal(problems.length, 2);
+});
+
+test('the doubled-catalogers regression is not silently tolerated', () => {
+  // Selecting the `javascript` GROUP enabled both javascript catalogers and
+  // listed every package twice — bestax-migrate at 200. The package.json
+  // cataloger carries no `resolved`, so the duplicates arrive with no registry
+  // URL and are caught by the same assertion that catches everything else.
+  const doc = healthy();
+  doc.packages.push({ name: 'bulma', versionInfo: '1.0.4' });
+  const problems = inspect(doc, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /"bulma"/);
+});
+
+// --- the floor ---------------------------------------------------------------
+
+test('rejects a document that collapsed to the structural entries', () => {
+  const problems = inspect({ packages: structural }, TARGET);
+  assert.match(problems[0], /only 0 catalogued package/);
+});
+
+test('rejects an empty document', () => {
+  assert.match(inspect({ packages: [] }, TARGET)[0], /only 0 catalogued/);
+});
+
+test('rejects a document with no packages array at all', () => {
+  assert.match(inspect({}, TARGET)[0], /no `packages` array/);
+  assert.match(inspect(null, TARGET)[0], /no `packages` array/);
+});
+
+test('the floor counts catalogued packages, not entries', () => {
+  // A floor of 3 against ENTRIES would pass a document holding only the two
+  // structural names plus one real package, which is the collapse this is for.
+  const doc = { packages: [...structural, dep('only-one')] };
+  assert.match(inspect(doc, TARGET)[0], /only 1 catalogued package/);
+});
+
+// --- exemptions --------------------------------------------------------------
+
+test('the structural entries are exempt by NAME, not by NOASSERTION', () => {
+  // A blanket "no download location is fine" exemption would readmit every
+  // github-actions entry. Prove the exemption is name-scoped by renaming one.
+  const doc = healthy();
+  doc.packages[0] = {
+    name: 'bestax-consumer-closure-WRONG',
+    downloadLocation: 'NOASSERTION',
+  };
+  const problems = inspect(doc, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /bestax-consumer-closure-WRONG/);
+});
+
+test('structuralNames matches what supply-chain.yml configures', () => {
+  // These two strings are built in the workflow: the scratch package.json
+  // `name`, and syft's `source.name`. If either changes there, this fails.
+  assert.deepEqual(
+    [...structuralNames({ package: PKG, slug: SLUG })],
+    [`bestax-consumer-closure-${SLUG}`, `consumer-closure:${PKG}`]
+  );
+});
+
+// --- CLI ---------------------------------------------------------------------
+
+test('readDocument names the file it could not read', () => {
+  assert.throws(() => readDocument('/nope/missing.json'), /cannot read/);
+  const bad = writeDoc({});
+  fs.writeFileSync(bad, 'not json');
+  assert.throws(() => readDocument(bad), /not valid JSON/);
+});
+
+test('parseArgs requires all three flags', () => {
+  assert.throws(() => parseArgs([]), /--file is required/);
+  assert.throws(
+    () => parseArgs(['--file', 'x', '--package', 'y']),
+    /--slug is required/
+  );
+});
+
+test('main returns 0 on a clean document and 1 on a dirty one', () => {
+  const clean = writeDoc(healthy());
+  assert.equal(main(['--file', clean, '--package', PKG, '--slug', SLUG]), 0);
+
+  const doc = healthy();
+  doc.packages.push({
+    name: 'actions/checkout',
+    downloadLocation: 'NOASSERTION',
+  });
+  const dirty = writeDoc(doc);
+  assert.equal(main(['--file', dirty, '--package', PKG, '--slug', SLUG]), 1);
+});
+
+test('main separates usage and read errors from assertion failures', () => {
+  // Exit 2 must not be readable as "the SBOM is wrong".
+  assert.equal(main([]), 2);
+  assert.equal(
+    main(['--file', '/nope/missing.json', '--package', PKG, '--slug', SLUG]),
+    2
+  );
+});

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -273,6 +273,37 @@ test('crossCheck is silent when the two agree', () => {
   assert.deepEqual(crossCheck(healthySpdx(), healthyCdx(), TARGET), []);
 });
 
+test('crossCheck compares multisets, not sets', () => {
+  // With `Array.includes`, a package listed twice on one side and once on the
+  // other looked identical to both listing it once, so asymmetric duplicate
+  // inflation passed silently.
+  const c = healthyCdx();
+  c.components.push(cdxDep('bulma', '1.0.4'));
+  const problems = crossCheck(healthySpdx(), c, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /bulma@1\.0\.4/);
+
+  // And the count is reported when more than one copy is extra.
+  const c2 = healthyCdx();
+  c2.components.push(cdxDep('bulma', '1.0.4'), cdxDep('bulma', '1.0.4'));
+  assert.match(crossCheck(healthySpdx(), c2, TARGET)[0], /x2 extra/);
+});
+
+test('symmetric duplicates warn but do not fail', () => {
+  // npm can place the same name@version at two paths when it cannot hoist, so
+  // a duplicate is a real closure shape rather than a defect. Failing on it
+  // would be the false-red generator 48c57d5 reverted (#391, #525).
+  const s = healthySpdx();
+  const c = healthyCdx();
+  s.packages.push(spdxDep('bulma', '1.0.4'));
+  c.components.push(cdxDep('bulma', '1.0.4'));
+
+  assert.deepEqual(inspect(s, TARGET), []);
+  assert.deepEqual(inspect(c, TARGET), []);
+  // Symmetric, so the two documents still agree with each other.
+  assert.deepEqual(crossCheck(s, c, TARGET), []);
+});
+
 test('identities excludes the structural entries from the comparison', () => {
   // SPDX carries the subject as an entry and CycloneDX does not, so comparing
   // raw entry lists would report a permanent, meaningless disagreement.

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -470,6 +470,22 @@ test('main fails when the two documents disagree, though each is clean alone', (
   assert.equal(main(cli(writeDoc(healthySpdx()), writeDoc(c))), 1);
 });
 
+test('main rejects a document whose contents contradict its flag', () => {
+  // The flags are a claim about each file; normalize() reads the format off
+  // the document. Until those are compared the flags are decoration — the same
+  // CycloneDX file passed twice satisfies every per-document assertion and
+  // agrees with itself, while the release ships a `.spdx.json` that is not
+  // SPDX. A `format:` typo on either sbom-action step produces exactly that.
+  const cdx = writeDoc(healthyCdx());
+  assert.equal(main(cli(cdx, cdx)), 1);
+
+  const spdx = writeDoc(healthySpdx());
+  assert.equal(main(cli(spdx, spdx)), 1);
+
+  // Swapped, each individually well-formed.
+  assert.equal(main(cli(cdx, spdx)), 1);
+});
+
 test('main separates usage and read errors from assertion failures', () => {
   // Exit 2 must not be readable as "the SBOM is wrong".
   assert.equal(main([]), 2);

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -197,6 +197,22 @@ test('rejects the runner-path file component a file: source emits (#530)', () =>
   assert.match(problems[0], /not under pkg:npm\//);
 });
 
+test("SPDX's files array tolerates a relative name and rejects an absolute one", () => {
+  // syft writes these relative today, which leaks nothing — a real document
+  // from run 33262407242 carries a bare `package-lock.json` and must pass.
+  const ok = healthySpdx();
+  ok.files = [{ fileName: 'package-lock.json', SPDXID: 'SPDXRef-File-1' }];
+  assert.deepEqual(inspect(ok, TARGET), []);
+
+  // The same array is where an absolute path would land if the file config
+  // changed, so it is checked rather than assumed to stay relative.
+  const bad = healthySpdx();
+  bad.files = [{ fileName: '/home/runner/work/_temp/scan/package-lock.json' }];
+  const problems = inspect(bad, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /an absolute path/);
+});
+
 test('rejects a CycloneDX subject naming a filesystem path (#529)', () => {
   // The metadata.component half of the same failure class.
   const doc = healthyCdx();

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -202,9 +202,12 @@ test('rejects the runner-path file component a file: source emits (#530)', () =>
     hashes: [{ alg: 'SHA-256', content: 'c3f5' }],
   });
   const problems = inspect(doc, TARGET);
-  assert.equal(problems.length, 1);
-  assert.match(problems[0], /home\/runner/);
-  assert.match(problems[0], /not under pkg:npm\//);
+  // Two problems, not one: a file component has neither a purl nor a version.
+  assert.equal(problems.length, 2);
+  assert.ok(
+    problems.some(p => /home\/runner/.test(p) && /not under pkg:npm\//.test(p))
+  );
+  assert.ok(problems.some(p => /no usable version/.test(p)));
 });
 
 test("SPDX's files array tolerates a bare name and rejects anything with a path", () => {
@@ -446,7 +449,7 @@ test('rejects a document that collapsed to the structural entries', () => {
     structuralNames({ package: PKG, slug: SLUG }).has(p.name)
   );
   const problems = inspect(doc, TARGET);
-  assert.match(problems[0], /only 0 catalogued package/);
+  assert.match(problems[0], /only 0 distinct catalogued package/);
 });
 
 test('rejects an empty document in both formats', () => {
@@ -454,11 +457,11 @@ test('rejects an empty document in both formats', () => {
   // which the floor must catch rather than the format detection.
   assert.match(
     inspect({ spdxVersion: 'SPDX-2.3', packages: [] }, TARGET)[0],
-    /only 0 catalogued/
+    /only 0 distinct catalogued/
   );
   assert.match(
     inspect({ bomFormat: 'CycloneDX', components: [] }, TARGET)[0],
-    /only 0 catalogued/
+    /only 0 distinct catalogued/
   );
 });
 
@@ -481,7 +484,7 @@ test('the floor counts catalogued packages, not entries', () => {
       spdxDep('only-one'),
     ],
   };
-  assert.match(inspect(doc, TARGET)[0], /only 1 catalogued package/);
+  assert.match(inspect(doc, TARGET)[0], /only 1 distinct catalogued package/);
 });
 
 // --- exemptions and normalization --------------------------------------------
@@ -492,6 +495,7 @@ test('the structural entries are exempt by NAME, not by a missing origin', () =>
   const doc = healthySpdx();
   doc.packages[0] = {
     name: 'bestax-consumer-closure-WRONG',
+    versionInfo: '0.0.0',
     downloadLocation: 'NOASSERTION',
   };
   const problems = inspect(doc, TARGET);
@@ -669,4 +673,88 @@ test('readDocument does not echo a malformed source snippet verbatim', () => {
       return true;
     }
   );
+});
+
+// --- the floor counts identities, not entries --------------------------------
+
+test('symmetric duplicates cannot satisfy the floor', () => {
+  // Duplicates only warn, so counting ENTRIES let three copies of one package
+  // clear a floor of three while the closure had collapsed to a single
+  // package — and symmetric copies pass origin, target, subject and the
+  // multiset cross-check too, so nothing else would have caught it.
+  const s = healthySpdx();
+  s.packages = s.packages.filter(
+    p => !p.downloadLocation.startsWith(REGISTRY_PREFIX)
+  );
+  s.packages.push(
+    spdxDep(PKG, VERSION),
+    spdxDep(PKG, VERSION),
+    spdxDep(PKG, VERSION)
+  );
+
+  const c = healthyCdx();
+  c.components = [
+    cdxDep(`bestax-consumer-closure-${SLUG}`, '0.0.0'),
+    cdxDep(PKG, VERSION),
+    cdxDep(PKG, VERSION),
+    cdxDep(PKG, VERSION),
+  ];
+
+  // Each document is internally consistent and the two agree with each other.
+  assert.deepEqual(crossCheck(s, c, TARGET), []);
+  // The floor is the only thing standing between this and a green run.
+  assert.match(inspect(s, TARGET)[0], /only 1 distinct catalogued package/);
+  assert.match(inspect(c, TARGET)[0], /only 1 distinct catalogued package/);
+});
+
+test('the floor still passes a real closure with a legitimate duplicate', () => {
+  // Tightening to distinct names must not red a closure that merely carries
+  // the same version at two paths.
+  const s = healthySpdx();
+  s.packages.push(spdxDep('bulma', '1.0.4'));
+  assert.deepEqual(inspect(s, TARGET), []);
+});
+
+// --- an entry must actually identify something -------------------------------
+
+test('rejects catalogued entries with no name or no version, in both formats', () => {
+  // An entry with a plausible origin but no identity produced no problem, and
+  // identities() rendered a missing version as `?` — so when both syft runs
+  // omitted the same metadata, the floor and the cross-check agreed with each
+  // other and a malformed document shipped.
+  const s = healthySpdx();
+  s.packages.push({
+    versionInfo: '1.0.0',
+    downloadLocation: `${REGISTRY_PREFIX}x/-/x-1.0.0.tgz`,
+  });
+  assert.ok(inspect(s, TARGET).some(p => /no usable name/.test(p)));
+
+  const s2 = healthySpdx();
+  s2.packages.push({
+    name: 'no-version',
+    downloadLocation: `${REGISTRY_PREFIX}x/-/x-1.0.0.tgz`,
+  });
+  assert.ok(inspect(s2, TARGET).some(p => /no usable version/.test(p)));
+
+  const c = healthyCdx();
+  c.components.push({ version: '1.0.0', purl: `${NPM_PURL_PREFIX}x@1.0.0` });
+  assert.ok(inspect(c, TARGET).some(p => /no usable name/.test(p)));
+
+  const c2 = healthyCdx();
+  c2.components.push({ name: 'no-version', purl: `${NPM_PURL_PREFIX}x@1.0.0` });
+  assert.ok(inspect(c2, TARGET).some(p => /no usable version/.test(p)));
+});
+
+test('a missing version is not laundered into an agreeing `?` identity', () => {
+  // Both documents omitting the same field used to agree with each other.
+  const s = healthySpdx();
+  s.packages.push({
+    name: 'ghost',
+    downloadLocation: `${REGISTRY_PREFIX}g/-/g-1.tgz`,
+  });
+  const c = healthyCdx();
+  c.components.push({ name: 'ghost', purl: `${NPM_PURL_PREFIX}g@1` });
+  assert.deepEqual(crossCheck(s, c, TARGET), []); // they do still agree...
+  assert.ok(inspect(s, TARGET).length > 0); // ...but each is now rejected
+  assert.ok(inspect(c, TARGET).length > 0);
 });

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -37,6 +37,7 @@ import {
   inspect,
   identities,
   crossCheck,
+  forLog,
   parseArgs,
   main,
 } from './check-consumer-sbom.mjs';
@@ -588,4 +589,30 @@ test('main separates usage and read errors from assertion failures', () => {
   // Exit 2 must not be readable as "the SBOM is wrong".
   assert.equal(main([]), 2);
   assert.equal(main(cli('/nope/missing.json', writeDoc(healthyCdx()))), 2);
+});
+
+// --- log injection through the rejection message -----------------------------
+
+test('a rejected value cannot forge an Actions workflow command', () => {
+  // The sharp version of this defect: the guard rejects the entry, and then
+  // hands the attacker's newline straight back to the runner inside its own
+  // `::error::` complaint, emitting a second forged command. Rejecting is not
+  // enough if the rejection message re-introduces the value verbatim.
+  const doc = healthySpdx();
+  doc.packages.push({
+    name: 'evil\n::error::FORGED',
+    versionInfo: '1.0.0\n::notice::ALSO FORGED',
+    downloadLocation: 'NOASSERTION',
+  });
+  for (const p of inspect(doc, TARGET)) {
+    assert.ok(!p.includes('\n'), `problem carries a raw newline: ${p}`);
+    assert.ok(!/^::/m.test(p), `problem could start a workflow command: ${p}`);
+  }
+});
+
+test('forLog neutralises every value read out of a document', () => {
+  assert.equal(forLog('1.0.0\n::error::x'), '"1.0.0\\n::error::x"');
+  assert.equal(forLog('a\r\nb'), '"a\\r\\nb"');
+  assert.equal(forLog(undefined), '""');
+  assert.ok(!forLog('x\ny').includes('\n'));
 });

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -59,8 +59,15 @@ const spdxDep = (name, version = '1.0.0') => ({
   downloadLocation: `${REGISTRY_PREFIX}${name}/-/${name}-${version}.tgz`,
 });
 
-/** SPDX: five closure packages plus the two structural entries. */
+/**
+ * SPDX: five closure packages plus the two structural entries.
+ *
+ * `spdxVersion` is present because a real document has it and normalize() now
+ * requires it — shape alone was a guess, and a document that had lost its
+ * format marker is not the thing its filename promises.
+ */
 const healthySpdx = () => ({
+  spdxVersion: 'SPDX-2.3',
   packages: [
     {
       name: `bestax-consumer-closure-${SLUG}`,
@@ -199,12 +206,23 @@ test('rejects the runner-path file component a file: source emits (#530)', () =>
   assert.match(problems[0], /not under pkg:npm\//);
 });
 
-test("SPDX's files array tolerates a relative name and rejects an absolute one", () => {
-  // syft writes these relative today, which leaks nothing — a real document
-  // from run 33262407242 carries a bare `package-lock.json` and must pass.
+test("SPDX's files array tolerates a bare name and rejects anything with a path", () => {
+  // syft writes a bare relative name today, which leaks nothing — a real
+  // document from run 33262407242 carries `package-lock.json` and must pass.
   const ok = healthySpdx();
   ok.files = [{ fileName: 'package-lock.json', SPDXID: 'SPDXRef-File-1' }];
   assert.deepEqual(inspect(ok, TARGET), []);
+
+  // `./name` is the same bare name and must also pass.
+  const dotted = healthySpdx();
+  dotted.files = [{ fileName: './package-lock.json' }];
+  assert.deepEqual(inspect(dotted, TARGET), []);
+
+  // A RELATIVE name that still discloses layout. Only absolute names were
+  // rejected before, and `work/_temp/scan/…` leaks the same structure.
+  const rel = healthySpdx();
+  rel.files = [{ fileName: 'work/_temp/scan/package-lock.json' }];
+  assert.match(inspect(rel, TARGET)[0], /carries a path/);
 
   // The same array is where an absolute path would land if the file config
   // changed, so it is checked rather than assumed to stay relative.
@@ -212,7 +230,47 @@ test("SPDX's files array tolerates a relative name and rejects an absolute one",
   bad.files = [{ fileName: '/home/runner/work/_temp/scan/package-lock.json' }];
   const problems = inspect(bad, TARGET);
   assert.equal(problems.length, 1);
-  assert.match(problems[0], /an absolute path/);
+  assert.match(problems[0], /carries a path/);
+});
+
+test('a closure carrying two versions of the target is not a mismatch', () => {
+  // npm can carry more than one version of a package, and nothing orders the
+  // document by depth. Checking only the FIRST entry with the target name
+  // reported a mismatch while the stamped version sat further down the list —
+  // a false red on a good release, which is the failure this guard exists to
+  // avoid (48c57d5, #391, #525).
+  const doc = healthySpdx();
+  doc.packages.splice(2, 0, spdxDep(PKG, '5.10.0'));
+  assert.deepEqual(inspect(doc, TARGET), []);
+
+  // Still a mismatch when NO copy carries the stamped version, and the message
+  // lists what was actually found.
+  const wrong = healthySpdx();
+  wrong.packages = wrong.packages.filter(p => p.name !== PKG);
+  wrong.packages.push(spdxDep(PKG, '5.10.0'), spdxDep(PKG, '5.9.0'));
+  const problems = inspect(wrong, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /"5\.10\.0", "5\.9\.0"/);
+});
+
+test("normalize requires each format's own identifier, not just an array", () => {
+  // A malformed exporter result that dropped its format marker is no longer
+  // the thing its filename promises, and used to satisfy the --spdx/--cdx
+  // role check on array shape alone.
+  const noMarker = healthySpdx();
+  delete noMarker.spdxVersion;
+  assert.equal(normalize(noMarker), null);
+
+  const noBomFormat = healthyCdx();
+  delete noBomFormat.bomFormat;
+  assert.equal(normalize(noBomFormat), null);
+
+  // And the marker alone is not enough either — the array is still required.
+  assert.equal(normalize({ spdxVersion: 'SPDX-2.3' }), null);
+  assert.equal(normalize({ bomFormat: 'CycloneDX' }), null);
+
+  assert.equal(normalize(healthySpdx()).format, 'spdx');
+  assert.equal(normalize(healthyCdx()).format, 'cyclonedx');
 });
 
 test('rejects a CycloneDX subject naming a filesystem path (#529)', () => {
@@ -391,19 +449,28 @@ test('rejects a document that collapsed to the structural entries', () => {
 });
 
 test('rejects an empty document in both formats', () => {
-  assert.match(inspect({ packages: [] }, TARGET)[0], /only 0 catalogued/);
-  assert.match(inspect({ components: [] }, TARGET)[0], /only 0 catalogued/);
+  // Markers present, arrays empty: a real document that catalogued nothing,
+  // which the floor must catch rather than the format detection.
+  assert.match(
+    inspect({ spdxVersion: 'SPDX-2.3', packages: [] }, TARGET)[0],
+    /only 0 catalogued/
+  );
+  assert.match(
+    inspect({ bomFormat: 'CycloneDX', components: [] }, TARGET)[0],
+    /only 0 catalogued/
+  );
 });
 
 test('rejects a document that is neither format', () => {
-  assert.match(inspect({}, TARGET)[0], /neither a `packages` array/);
-  assert.match(inspect(null, TARGET)[0], /neither a `packages` array/);
+  assert.match(inspect({}, TARGET)[0], /neither SPDX .* nor CycloneDX/);
+  assert.match(inspect(null, TARGET)[0], /neither SPDX .* nor CycloneDX/);
 });
 
 test('the floor counts catalogued packages, not entries', () => {
   // A floor of 3 against ALL entries would pass a document holding only the
   // structural names plus one real package, which is the collapse this is for.
   const doc = {
+    spdxVersion: 'SPDX-2.3',
     packages: [
       {
         name: `bestax-consumer-closure-${SLUG}`,

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -1,18 +1,20 @@
 /**
  * Guards on check-consumer-sbom.mjs.
  *
- * The two cases that matter most are regressions that really happened, on
- * #529's own branch, and were found only by dispatching the workflow and
- * reading the JSON:
+ * The cases that matter most are regressions that really happened and were
+ * found only by generating a document and reading it:
  *
  *   - a github-actions cataloger entry, from `.github/workflows` YAML shipped
- *     inside an upstream npm tarball;
+ *     inside an upstream npm tarball (#529);
  *   - every package listed twice, from selecting the whole `javascript`
- *     cataloger group.
+ *     cataloger group (#529);
+ *   - a `type: file` component named with the runner's absolute path, from
+ *     scanning the lockfile as a `file:` source — present in every CycloneDX
+ *     document while every SPDX document was clean (#530).
  *
- * Both are reproduced below as documents this check must reject. If either
- * test is ever relaxed, the corresponding syft config in supply-chain.yml is
- * the thing to look at first.
+ * All three are reproduced below as documents this check must reject. The
+ * third is why `inspect` reads both formats: the guard that existed when it
+ * happened read SPDX only and passed the leak.
  *
  * The negative case is just as important: a document that has merely GROWN
  * must pass. The first version of this guard compared against hardcoded counts
@@ -27,8 +29,10 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   REGISTRY_PREFIX,
+  NPM_PURL_PREFIX,
   MIN_EXPECTED_PACKAGES,
   structuralNames,
+  normalize,
   readDocument,
   inspect,
   parseArgs,
@@ -37,62 +41,103 @@ import {
 
 const PKG = '@allxsmith/bestax-bulma';
 const SLUG = 'allxsmith-bestax-bulma';
-const TARGET = { package: PKG, slug: SLUG, minPackages: MIN_EXPECTED_PACKAGES };
+const VERSION = '5.11.4';
+const TARGET = {
+  package: PKG,
+  slug: SLUG,
+  version: VERSION,
+  minPackages: MIN_EXPECTED_PACKAGES,
+};
 
-const dep = (name, version = '1.0.0') => ({
+// --- fixtures, shaped after the real run-33260691933 documents ---------------
+
+const spdxDep = (name, version = '1.0.0') => ({
   name,
   versionInfo: version,
   downloadLocation: `${REGISTRY_PREFIX}${name}/-/${name}-${version}.tgz`,
 });
 
-/** The two entries syft legitimately adds that are not dependencies. */
-const structural = [
-  { name: `bestax-consumer-closure-${SLUG}`, downloadLocation: 'NOASSERTION' },
-  { name: `consumer-closure:${PKG}`, downloadLocation: 'NOASSERTION' },
-];
-
-/** A healthy bulma-ui closure: five packages plus the two structural entries. */
-const healthy = () => ({
+/** SPDX: five closure packages plus the two structural entries. */
+const healthySpdx = () => ({
   packages: [
-    ...structural,
-    dep('bulma', '1.0.4'),
-    dep('react'),
-    dep('react-dom'),
-    dep('scheduler'),
-    dep('loose-envify'),
+    {
+      name: `bestax-consumer-closure-${SLUG}`,
+      versionInfo: '0.0.0',
+      downloadLocation: 'NOASSERTION',
+    },
+    {
+      name: `consumer-closure:${PKG}`,
+      versionInfo: VERSION,
+      downloadLocation: 'NOASSERTION',
+    },
+    spdxDep(PKG, VERSION),
+    spdxDep('bulma', '1.0.4'),
+    spdxDep('react', '19.2.8'),
+    spdxDep('react-dom', '19.2.8'),
+    spdxDep('scheduler', '0.27.0'),
+  ],
+});
+
+const cdxDep = (name, version = '1.0.0') => ({
+  name,
+  version,
+  purl: `${NPM_PURL_PREFIX}${name}@${version}`,
+});
+
+/** CycloneDX: the same closure, with the subject in metadata.component. */
+const healthyCdx = () => ({
+  bomFormat: 'CycloneDX',
+  metadata: {
+    component: {
+      type: 'directory',
+      name: `consumer-closure:${PKG}`,
+      version: VERSION,
+    },
+  },
+  components: [
+    cdxDep(`bestax-consumer-closure-${SLUG}`, '0.0.0'),
+    cdxDep(PKG, VERSION),
+    cdxDep('bulma', '1.0.4'),
+    cdxDep('react', '19.2.8'),
+    cdxDep('react-dom', '19.2.8'),
+    cdxDep('scheduler', '0.27.0'),
   ],
 });
 
 function writeDoc(doc) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-consumer-sbom-'));
-  const file = path.join(dir, 'sbom.spdx.json');
+  const file = path.join(dir, 'sbom.json');
   fs.writeFileSync(file, JSON.stringify(doc));
   return file;
 }
 
 // --- the happy path ----------------------------------------------------------
 
-test('a clean closure has no problems', () => {
-  assert.deepEqual(inspect(healthy(), TARGET), []);
+test('a clean SPDX closure has no problems', () => {
+  assert.deepEqual(inspect(healthySpdx(), TARGET), []);
 });
 
-test('a closure that merely GREW still passes', () => {
+test('a clean CycloneDX closure has no problems', () => {
+  assert.deepEqual(inspect(healthyCdx(), TARGET), []);
+});
+
+test('a closure that merely GREW still passes, in both formats', () => {
   // The whole reason there is no expected count. A transitive dependency
   // publishing must never red this job.
-  const doc = healthy();
-  for (let i = 0; i < 200; i += 1) doc.packages.push(dep(`transitive-${i}`));
-  assert.deepEqual(inspect(doc, TARGET), []);
+  const s = healthySpdx();
+  const c = healthyCdx();
+  for (let i = 0; i < 200; i += 1) {
+    s.packages.push(spdxDep(`transitive-${i}`));
+    c.components.push(cdxDep(`transitive-${i}`));
+  }
+  assert.deepEqual(inspect(s, TARGET), []);
+  assert.deepEqual(inspect(c, TARGET), []);
 });
 
-test('a closure that merely SHRANK, but is still a closure, passes', () => {
-  const doc = { packages: [...structural, dep('a'), dep('b'), dep('c')] };
-  assert.deepEqual(inspect(doc, TARGET), []);
-});
-
-// --- the two real regressions ------------------------------------------------
+// --- the three real regressions ----------------------------------------------
 
 test('rejects a github-actions cataloger entry (#529)', () => {
-  const doc = healthy();
+  const doc = healthySpdx();
   doc.packages.push({
     name: 'actions/checkout',
     versionInfo: 'v4',
@@ -104,12 +149,12 @@ test('rejects a github-actions cataloger entry (#529)', () => {
   assert.match(problems[0], /not under https:\/\/registry\.npmjs\.org\//);
 });
 
-test("rejects a dependency's own yarn.lock dev closure leaking in", () => {
+test("rejects a dependency's own yarn.lock dev closure leaking in (#529)", () => {
   // npm always excludes package-lock.json from a tarball but NOT yarn.lock, so
   // one dependency publishing without a `files:` field would inject its whole
   // dev tree. Those entries resolve to the yarn registry, a git URL, or
   // nothing — never to registry.npmjs.org via our lockfile's `resolved`.
-  const doc = healthy();
+  const doc = healthySpdx();
   doc.packages.push({
     name: 'some-dev-tool',
     versionInfo: '2.0.0',
@@ -120,51 +165,121 @@ test("rejects a dependency's own yarn.lock dev closure leaking in", () => {
     versionInfo: '0.0.0',
     downloadLocation: 'git+https://github.com/someone/thing.git',
   });
-  const problems = inspect(doc, TARGET);
-  assert.equal(problems.length, 2);
+  assert.equal(inspect(doc, TARGET).length, 2);
 });
 
-test('the doubled-catalogers regression is not silently tolerated', () => {
+test('rejects the doubled-catalogers regression (#529)', () => {
   // Selecting the `javascript` GROUP enabled both javascript catalogers and
   // listed every package twice — bestax-migrate at 200. The package.json
   // cataloger carries no `resolved`, so the duplicates arrive with no registry
   // URL and are caught by the same assertion that catches everything else.
-  const doc = healthy();
+  const doc = healthySpdx();
   doc.packages.push({ name: 'bulma', versionInfo: '1.0.4' });
   const problems = inspect(doc, TARGET);
   assert.equal(problems.length, 1);
   assert.match(problems[0], /"bulma"/);
 });
 
+test('rejects the runner-path file component a file: source emits (#530)', () => {
+  // The exact document run 33260691933 produced. Every SPDX document was
+  // clean, so the SPDX-only guard this replaces passed it, and the leaked
+  // CycloneDX file was signed and attached.
+  const doc = healthyCdx();
+  doc.components.push({
+    'bom-ref': 'fd71c2238fc07657',
+    type: 'file',
+    name: '/home/runner/work/_temp/consumer/package-lock.json',
+    hashes: [{ alg: 'SHA-256', content: 'c3f5' }],
+  });
+  const problems = inspect(doc, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /home\/runner/);
+  assert.match(problems[0], /not under pkg:npm\//);
+});
+
+test('rejects a CycloneDX subject naming a filesystem path (#529)', () => {
+  // The metadata.component half of the same failure class.
+  const doc = healthyCdx();
+  doc.metadata.component = {
+    type: 'directory',
+    name: '/home/runner/work/_temp/consumer',
+  };
+  const problems = inspect(doc, TARGET);
+  assert.ok(problems.some(p => /metadata\.component\.name/.test(p)));
+});
+
+// --- the target must be in its own closure -----------------------------------
+
+test('rejects a well-formed closure of something else', () => {
+  // Copilot's finding on #594: every other assertion passes on a document that
+  // simply does not contain the package it claims to describe.
+  const doc = healthySpdx();
+  doc.packages = doc.packages.filter(p => p.name !== PKG);
+  const problems = inspect(doc, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /is not in its own closure/);
+});
+
+test('rejects a target present at the wrong version', () => {
+  // Catches the document and its filename disagreeing about the release.
+  const doc = healthySpdx();
+  doc.packages.find(p => p.name === PKG).versionInfo = '5.11.1';
+  const problems = inspect(doc, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /present at "5\.11\.1".*stamped 5\.11\.4/);
+});
+
+test('rejects a CycloneDX subject at the wrong version', () => {
+  const doc = healthyCdx();
+  doc.metadata.component.version = '5.11.1';
+  assert.ok(
+    inspect(doc, TARGET).some(p => /metadata\.component\.version/.test(p))
+  );
+});
+
 // --- the floor ---------------------------------------------------------------
 
 test('rejects a document that collapsed to the structural entries', () => {
-  const problems = inspect({ packages: structural }, TARGET);
+  const doc = healthySpdx();
+  doc.packages = doc.packages.filter(p =>
+    structuralNames({ package: PKG, slug: SLUG }).has(p.name)
+  );
+  const problems = inspect(doc, TARGET);
   assert.match(problems[0], /only 0 catalogued package/);
 });
 
-test('rejects an empty document', () => {
+test('rejects an empty document in both formats', () => {
   assert.match(inspect({ packages: [] }, TARGET)[0], /only 0 catalogued/);
+  assert.match(inspect({ components: [] }, TARGET)[0], /only 0 catalogued/);
 });
 
-test('rejects a document with no packages array at all', () => {
-  assert.match(inspect({}, TARGET)[0], /no `packages` array/);
-  assert.match(inspect(null, TARGET)[0], /no `packages` array/);
+test('rejects a document that is neither format', () => {
+  assert.match(inspect({}, TARGET)[0], /neither a `packages` array/);
+  assert.match(inspect(null, TARGET)[0], /neither a `packages` array/);
 });
 
 test('the floor counts catalogued packages, not entries', () => {
-  // A floor of 3 against ENTRIES would pass a document holding only the two
+  // A floor of 3 against ALL entries would pass a document holding only the
   // structural names plus one real package, which is the collapse this is for.
-  const doc = { packages: [...structural, dep('only-one')] };
+  const doc = {
+    packages: [
+      {
+        name: `bestax-consumer-closure-${SLUG}`,
+        downloadLocation: 'NOASSERTION',
+      },
+      { name: `consumer-closure:${PKG}`, downloadLocation: 'NOASSERTION' },
+      spdxDep('only-one'),
+    ],
+  };
   assert.match(inspect(doc, TARGET)[0], /only 1 catalogued package/);
 });
 
-// --- exemptions --------------------------------------------------------------
+// --- exemptions and normalization --------------------------------------------
 
-test('the structural entries are exempt by NAME, not by NOASSERTION', () => {
-  // A blanket "no download location is fine" exemption would readmit every
-  // github-actions entry. Prove the exemption is name-scoped by renaming one.
-  const doc = healthy();
+test('the structural entries are exempt by NAME, not by a missing origin', () => {
+  // A blanket "no origin is fine" exemption would readmit every github-actions
+  // entry and every file component. Prove it is name-scoped by renaming one.
+  const doc = healthySpdx();
   doc.packages[0] = {
     name: 'bestax-consumer-closure-WRONG',
     downloadLocation: 'NOASSERTION',
@@ -183,6 +298,12 @@ test('structuralNames matches what supply-chain.yml configures', () => {
   );
 });
 
+test('normalize picks the format off the document, not a flag', () => {
+  assert.equal(normalize(healthySpdx()).format, 'spdx');
+  assert.equal(normalize(healthyCdx()).format, 'cyclonedx');
+  assert.equal(normalize({}), null);
+});
+
 // --- CLI ---------------------------------------------------------------------
 
 test('readDocument names the file it could not read', () => {
@@ -192,32 +313,50 @@ test('readDocument names the file it could not read', () => {
   assert.throws(() => readDocument(bad), /not valid JSON/);
 });
 
-test('parseArgs requires all three flags', () => {
+test('parseArgs requires all four flags', () => {
   assert.throws(() => parseArgs([]), /--file is required/);
   assert.throws(
-    () => parseArgs(['--file', 'x', '--package', 'y']),
-    /--slug is required/
+    () => parseArgs(['--file', 'x', '--package', 'y', '--slug', 'z']),
+    /--version is required/
   );
 });
 
-test('main returns 0 on a clean document and 1 on a dirty one', () => {
-  const clean = writeDoc(healthy());
-  assert.equal(main(['--file', clean, '--package', PKG, '--slug', SLUG]), 0);
+test('main returns 0 on clean documents and 1 on a dirty one', () => {
+  const args = f => [
+    '--file',
+    f,
+    '--package',
+    PKG,
+    '--slug',
+    SLUG,
+    '--version',
+    VERSION,
+  ];
+  assert.equal(main(args(writeDoc(healthySpdx()))), 0);
+  assert.equal(main(args(writeDoc(healthyCdx()))), 0);
 
-  const doc = healthy();
+  const doc = healthySpdx();
   doc.packages.push({
     name: 'actions/checkout',
     downloadLocation: 'NOASSERTION',
   });
-  const dirty = writeDoc(doc);
-  assert.equal(main(['--file', dirty, '--package', PKG, '--slug', SLUG]), 1);
+  assert.equal(main(args(writeDoc(doc))), 1);
 });
 
 test('main separates usage and read errors from assertion failures', () => {
   // Exit 2 must not be readable as "the SBOM is wrong".
   assert.equal(main([]), 2);
   assert.equal(
-    main(['--file', '/nope/missing.json', '--package', PKG, '--slug', SLUG]),
+    main([
+      '--file',
+      '/nope/missing.json',
+      '--package',
+      PKG,
+      '--slug',
+      SLUG,
+      '--version',
+      VERSION,
+    ]),
     2
   );
 });

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -220,8 +220,44 @@ test('rejects a CycloneDX subject naming a filesystem path (#529)', () => {
     type: 'directory',
     name: '/home/runner/work/_temp/consumer',
   };
+  assert.ok(
+    inspect(doc, TARGET).some(p => /metadata\.component names/.test(p))
+  );
+});
+
+// --- the subject is checked in BOTH formats ----------------------------------
+
+test('rejects an SPDX subject at the wrong version', () => {
+  // SPDX states its subject as an ordinary package entry, which was exempted
+  // by name and never validated — so the document could identify a different
+  // release than its filename and closure while every dependency entry was
+  // correct.
+  const doc = healthySpdx();
+  doc.packages.find(p => p.name === `consumer-closure:${PKG}`).versionInfo =
+    '5.11.1';
   const problems = inspect(doc, TARGET);
-  assert.ok(problems.some(p => /metadata\.component\.name/.test(p)));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /carries version "5\.11\.1", expected "5\.11\.4"/);
+});
+
+test('rejects an SPDX document with no subject entry at all', () => {
+  const doc = healthySpdx();
+  doc.packages = doc.packages.filter(p => p.name !== `consumer-closure:${PKG}`);
+  assert.ok(
+    inspect(doc, TARGET).some(p => /does not say which package/.test(p))
+  );
+});
+
+test('the subject check is symmetric across the two formats', () => {
+  // Same defect, same detection, whichever document it lands in — the
+  // asymmetry is what let the SPDX side go unchecked.
+  const s = healthySpdx();
+  s.packages.find(p => p.name === `consumer-closure:${PKG}`).versionInfo =
+    '9.9.9';
+  const c = healthyCdx();
+  c.metadata.component.version = '9.9.9';
+  assert.equal(inspect(s, TARGET).length, 1);
+  assert.equal(inspect(c, TARGET).length, 1);
 });
 
 // --- the target must be in its own closure -----------------------------------
@@ -249,7 +285,9 @@ test('rejects a CycloneDX subject at the wrong version', () => {
   const doc = healthyCdx();
   doc.metadata.component.version = '5.11.1';
   assert.ok(
-    inspect(doc, TARGET).some(p => /metadata\.component\.version/.test(p))
+    inspect(doc, TARGET).some(p =>
+      /metadata\.component carries version/.test(p)
+    )
   );
 });
 

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -35,6 +35,8 @@ import {
   normalize,
   readDocument,
   inspect,
+  identities,
+  crossCheck,
   parseArgs,
   main,
 } from './check-consumer-sbom.mjs';
@@ -225,6 +227,61 @@ test('rejects a CycloneDX subject naming a filesystem path (#529)', () => {
   );
 });
 
+// --- the purl test is weaker than the downloadLocation test ------------------
+
+test('a git dependency passes the CycloneDX purl test — by design, documented', () => {
+  // syft builds `pkg:npm/name@version` from the name and version alone and
+  // records `resolved` nowhere in a CycloneDX document, so the purl is an
+  // ECOSYSTEM claim, not a provenance one. Asserted rather than assumed,
+  // because the comments used to describe it as provenance and that is the
+  // kind of overstatement that stops the next reader checking.
+  const c = healthyCdx();
+  c.components.push(cdxDep('a-git-dep', '0.0.0'));
+  assert.deepEqual(inspect(c, TARGET), []);
+
+  // The same dependency in SPDX carries its real origin and is rejected.
+  const s = healthySpdx();
+  s.packages.push({
+    name: 'a-git-dep',
+    versionInfo: '0.0.0',
+    downloadLocation: 'git+https://github.com/someone/thing.git',
+  });
+  assert.equal(inspect(s, TARGET).length, 1);
+});
+
+test('the same-closure check is what stops the weak purl test being a hole', () => {
+  // A git dep that syft put in BOTH documents is caught by SPDX. One that
+  // somehow appeared only in CycloneDX — where nothing can origin-check it —
+  // is caught by the disagreement instead. Neither path lets it through.
+  const c = healthyCdx();
+  c.components.push(cdxDep('a-git-dep', '0.0.0'));
+  const problems = crossCheck(healthySpdx(), c, TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /CycloneDX document but not the SPDX one/);
+  assert.match(problems[0], /a-git-dep@0\.0\.0/);
+});
+
+test('crossCheck reports a package missing from CycloneDX too', () => {
+  const s = healthySpdx();
+  s.packages.push(spdxDep('only-in-spdx', '1.0.0'));
+  const problems = crossCheck(s, healthyCdx(), TARGET);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /SPDX document but not the CycloneDX one/);
+});
+
+test('crossCheck is silent when the two agree', () => {
+  assert.deepEqual(crossCheck(healthySpdx(), healthyCdx(), TARGET), []);
+});
+
+test('identities excludes the structural entries from the comparison', () => {
+  // SPDX carries the subject as an entry and CycloneDX does not, so comparing
+  // raw entry lists would report a permanent, meaningless disagreement.
+  const ids = identities(healthySpdx(), TARGET);
+  assert.ok(!ids.some(i => i.startsWith('consumer-closure:')));
+  assert.ok(!ids.some(i => i.startsWith('bestax-consumer-closure-')));
+  assert.deepEqual(ids, identities(healthyCdx(), TARGET));
+});
+
 // --- the subject is checked in BOTH formats ----------------------------------
 
 test('rejects an SPDX subject at the wrong version', () => {
@@ -367,50 +424,54 @@ test('readDocument names the file it could not read', () => {
   assert.throws(() => readDocument(bad), /not valid JSON/);
 });
 
-test('parseArgs requires all four flags', () => {
-  assert.throws(() => parseArgs([]), /--file is required/);
+test('parseArgs requires both documents and the target', () => {
+  assert.throws(() => parseArgs([]), /--spdx is required/);
+  assert.throws(() => parseArgs(['--spdx', 'a']), /--cdx is required/);
   assert.throws(
-    () => parseArgs(['--file', 'x', '--package', 'y', '--slug', 'z']),
+    () =>
+      parseArgs(['--spdx', 'a', '--cdx', 'b', '--package', 'y', '--slug', 'z']),
     /--version is required/
   );
 });
 
-test('main returns 0 on clean documents and 1 on a dirty one', () => {
-  const args = f => [
-    '--file',
-    f,
-    '--package',
-    PKG,
-    '--slug',
-    SLUG,
-    '--version',
-    VERSION,
-  ];
-  assert.equal(main(args(writeDoc(healthySpdx()))), 0);
-  assert.equal(main(args(writeDoc(healthyCdx()))), 0);
+const cli = (spdx, cdx) => [
+  '--spdx',
+  spdx,
+  '--cdx',
+  cdx,
+  '--package',
+  PKG,
+  '--slug',
+  SLUG,
+  '--version',
+  VERSION,
+];
+
+test('main returns 0 on a clean pair and 1 on a dirty one', () => {
+  assert.equal(main(cli(writeDoc(healthySpdx()), writeDoc(healthyCdx()))), 0);
 
   const doc = healthySpdx();
   doc.packages.push({
     name: 'actions/checkout',
     downloadLocation: 'NOASSERTION',
   });
-  assert.equal(main(args(writeDoc(doc))), 1);
+  assert.equal(main(cli(writeDoc(doc), writeDoc(healthyCdx()))), 1);
+});
+
+test('main fails when the two documents disagree, though each is clean alone', () => {
+  // The case two separate invocations could not catch: both documents satisfy
+  // every per-document assertion and still describe different closures. This
+  // is the shape a git dependency takes in CycloneDX, where nothing can
+  // origin-check it.
+  const c = healthyCdx();
+  c.components.push(cdxDep('ghost-package', '9.9.9'));
+  assert.deepEqual(inspect(healthySpdx(), TARGET), []);
+  assert.deepEqual(inspect(c, TARGET), []);
+  assert.equal(main(cli(writeDoc(healthySpdx()), writeDoc(c))), 1);
 });
 
 test('main separates usage and read errors from assertion failures', () => {
   // Exit 2 must not be readable as "the SBOM is wrong".
   assert.equal(main([]), 2);
-  assert.equal(
-    main([
-      '--file',
-      '/nope/missing.json',
-      '--package',
-      PKG,
-      '--slug',
-      SLUG,
-      '--version',
-      VERSION,
-    ]),
-    2
-  );
+  assert.equal(main(cli('/nope/missing.json', writeDoc(healthyCdx()))), 2);
 });

--- a/scripts/check-consumer-sbom.test.mjs
+++ b/scripts/check-consumer-sbom.test.mjs
@@ -616,3 +616,57 @@ test('forLog neutralises every value read out of a document', () => {
   assert.equal(forLog(undefined), '""');
   assert.ok(!forLog('x\ny').includes('\n'));
 });
+
+test('NO message path can emit a raw newline, swept exhaustively', () => {
+  // Written as a sweep rather than a list because eyeballing the call sites is
+  // exactly what missed `readDocument`'s parser message and `crossCheck`'s
+  // identity list after a previous pass claimed the file was clean. Every
+  // string-valued field a document can carry gets the payload, and every
+  // problem string from both entry points is checked.
+  const EVIL = 'x\n::error::FORGED';
+  const collect = [];
+
+  const poison = doc => {
+    const d = JSON.parse(JSON.stringify(doc));
+    for (const e of d.packages ?? d.components ?? []) {
+      if (e.name) e.name = EVIL;
+      if (e.versionInfo) e.versionInfo = EVIL;
+      if (e.version) e.version = EVIL;
+      if (e.downloadLocation) e.downloadLocation = EVIL;
+      if (e.purl) e.purl = EVIL;
+    }
+    if (d.metadata?.component) {
+      d.metadata.component.name = EVIL;
+      d.metadata.component.version = EVIL;
+    }
+    d.files = [{ fileName: EVIL }];
+    return d;
+  };
+
+  const ps = poison(healthySpdx());
+  const pc = poison(healthyCdx());
+  collect.push(...inspect(ps, TARGET), ...inspect(pc, TARGET));
+  collect.push(...crossCheck(ps, pc, TARGET));
+  collect.push(...crossCheck(healthySpdx(), pc, TARGET));
+  collect.push(...crossCheck(ps, healthyCdx(), TARGET));
+
+  assert.ok(collect.length > 0, 'the sweep must actually produce problems');
+  for (const p of collect) {
+    assert.ok(!p.includes('\n'), `raw newline in: ${JSON.stringify(p)}`);
+    assert.ok(!p.includes('\r'), `raw CR in: ${JSON.stringify(p)}`);
+  }
+});
+
+test('readDocument does not echo a malformed source snippet verbatim', () => {
+  // SyntaxError.message quotes the offending input, newlines included.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-consumer-sbom-'));
+  const f = path.join(dir, 'bad.json');
+  fs.writeFileSync(f, '{"a":\n::error::FORGED\n}');
+  assert.throws(
+    () => readDocument(f),
+    err => {
+      assert.ok(!err.message.includes('\n'), `raw newline: ${err.message}`);
+      return true;
+    }
+  );
+});

--- a/scripts/consumer-sbom-meta.mjs
+++ b/scripts/consumer-sbom-meta.mjs
@@ -218,6 +218,15 @@ export function parseArgs(argv) {
     if (i + 1 >= rest.length) throw new Error(`${key} needs a value`);
     flags[key.slice(2)] = rest[i + 1];
   }
+  // Required flags are validated HERE, not in main, so a mistyped invocation
+  // exits 2 like every other usage error. Checking them in main put them on
+  // the assertion path, which returns 1 — and 1 is what a caller reads as "the
+  // published package is wrong". Keeping the codes distinct is the whole
+  // reason there are two of them.
+  const required = mode === 'spec' ? ['package'] : ['package', 'slug', 'dir'];
+  for (const name of required) {
+    if (!flags[name]) throw new Error(`${mode} requires --${name}`);
+  }
   return { mode, ...flags };
 }
 
@@ -240,7 +249,6 @@ export function main(argv = process.argv.slice(2), env = process.env) {
 
   try {
     if (args.mode === 'spec') {
-      if (!args.package) throw new Error('spec requires --package');
       const spec = installSpec({
         package: args.package,
         eventName: args.event,
@@ -264,10 +272,6 @@ export function main(argv = process.argv.slice(2), env = process.env) {
       );
       return 0;
     }
-
-    if (!args.package) throw new Error('stamp requires --package');
-    if (!args.slug) throw new Error('stamp requires --slug');
-    if (!args.dir) throw new Error('stamp requires --dir');
 
     const version = readInstalledVersion(args.dir, args.package);
 

--- a/scripts/consumer-sbom-meta.mjs
+++ b/scripts/consumer-sbom-meta.mjs
@@ -270,7 +270,13 @@ export function parseArgs(argv) {
   // the assertion path, which returns 1 — and 1 is what a caller reads as "the
   // published package is wrong". Keeping the codes distinct is the whole
   // reason there are two of them.
-  const required = mode === 'spec' ? ['package'] : ['package', 'slug', 'dir'];
+  // `event` is required for spec, and its absence is the dangerous case rather
+  // than a cosmetic one: installSpec treats an absent event as "not a release",
+  // so a malformed invocation would exit 0, resolve `latest`, and silently turn
+  // OFF the release pin this script exists to apply. A workflow edit dropping
+  // the flag would disable item 1 with nothing anywhere reporting it.
+  const required =
+    mode === 'spec' ? ['package', 'event'] : ['package', 'slug', 'dir'];
   for (const name of required) {
     if (!flags[name]) throw new Error(`${mode} requires --${name}`);
   }

--- a/scripts/consumer-sbom-meta.mjs
+++ b/scripts/consumer-sbom-meta.mjs
@@ -270,6 +270,26 @@ export function parseArgs(argv) {
   // the assertion path, which returns 1 — and 1 is what a caller reads as "the
   // published package is wrong". Keeping the codes distinct is the whole
   // reason there are two of them.
+  // Unknown flags are REJECTED, not ignored, and this is the same hazard as
+  // the required-flag check below rather than tidiness. Every optional flag
+  // here disables a safeguard by being absent: `--tagg` makes a release leg
+  // resolve `latest` (no pin), `--exepct` skips the installed-version
+  // assertion. Ignoring the typo means both exit 0 having quietly turned off
+  // the thing this script exists to do.
+  const known =
+    mode === 'spec'
+      ? ['package', 'event', 'tag']
+      : ['package', 'slug', 'dir', 'expect'];
+  for (const name of Object.keys(flags)) {
+    if (!known.includes(name)) {
+      throw new Error(
+        `${mode} does not take --${name} (expected ${known
+          .map(k => `--${k}`)
+          .join(', ')})`
+      );
+    }
+  }
+
   // `event` is required for spec, and its absence is the dangerous case rather
   // than a cosmetic one: installSpec treats an absent event as "not a release",
   // so a malformed invocation would exit 0, resolve `latest`, and silently turn

--- a/scripts/consumer-sbom-meta.mjs
+++ b/scripts/consumer-sbom-meta.mjs
@@ -92,6 +92,26 @@ import { pathToFileURL } from 'node:url';
 export const ARTIFACT_PREFIX = 'bestax-consumer-sbom-';
 
 /**
+ * Render an untrusted value for a log line.
+ *
+ * Rejecting a value is not enough if the rejection MESSAGE hands it straight
+ * back to the runner. Every error here is printed as `::error::<message>`, and
+ * a GitHub Actions workflow command is terminated by a newline — so a version
+ * of `1.0.0\n::error::…` was blocked from $GITHUB_OUTPUT by assertVersion and
+ * then re-entered through assertVersion's own complaint about it, emitting a
+ * second, forged workflow command. The guard was reporting the attack by
+ * performing it.
+ *
+ * JSON.stringify is the whole fix: it escapes newlines, carriage returns,
+ * quotes, backslashes and every other control character, so the value can only
+ * ever be one line of inert text. Use it for ANYTHING that came out of a
+ * published tarball, a generated document, or argv — never a bare `"${value}"`.
+ */
+export function forLog(value) {
+  return JSON.stringify(String(value ?? ''));
+}
+
+/**
  * Split a release tag into the package it names and the version it carries.
  *
  * Split on the LAST `@`, not the first: `@allxsmith/bestax-bulma@5.12.0` has
@@ -136,7 +156,7 @@ export function installSpec({ package: pkg, eventName, tagName } = {}) {
   const parsed = parseReleaseTag(tagName);
   if (!parsed || parsed.package !== pkg) return pkg;
 
-  assertVersion(parsed.version, `release tag ${tagName}`);
+  assertVersion(parsed.version, `release tag ${forLog(tagName)}`);
   return `${pkg}@${parsed.version}`;
 }
 
@@ -177,10 +197,12 @@ export const SEMVER =
 export function assertVersion(version, source = 'version') {
   const value = String(version ?? '');
   if (!/^[0-9A-Za-z.+-]+$/.test(value)) {
-    throw new Error(`${source} contains unexpected characters: "${value}"`);
+    throw new Error(
+      `${source} contains unexpected characters: ${forLog(value)}`
+    );
   }
   if (!SEMVER.test(value)) {
-    throw new Error(`${source} is not a semver version: "${value}"`);
+    throw new Error(`${source} is not a semver version: ${forLog(value)}`);
   }
   return value;
 }
@@ -213,11 +235,15 @@ export function readInstalledVersion(dir, pkg) {
   }
   let parsed;
   try {
+    // The parser echoes the offending input in its message, so a tarball whose
+    // package.json is deliberately malformed gets a newline into the log the
+    // same way a malformed version would.
     parsed = JSON.parse(raw);
   } catch (err) {
-    throw new Error(`${pkg} has an unparsable package.json: ${err.message}`, {
-      cause: err,
-    });
+    throw new Error(
+      `${pkg} has an unparsable package.json: ${forLog(err.message)}`,
+      { cause: err }
+    );
   }
   return assertVersion(parsed.version, `${pkg} package.json version`);
 }
@@ -302,9 +328,9 @@ export function main(argv = process.argv.slice(2), env = process.env) {
     // which is the failure mode the read-back existed for in the first place.
     if (args.expect && args.expect !== version) {
       throw new Error(
-        `asked npm for ${args.package}@${args.expect} but the tree carries ` +
-          `${version}. The document would describe a different release than ` +
-          `the one it is attached to.`
+        `asked npm for ${args.package}@${forLog(args.expect)} but the tree ` +
+          `carries ${forLog(version)}. The document would describe a ` +
+          `different release than the one it is attached to.`
       );
     }
 

--- a/scripts/consumer-sbom-meta.mjs
+++ b/scripts/consumer-sbom-meta.mjs
@@ -141,25 +141,46 @@ export function installSpec({ package: pkg, eventName, tagName } = {}) {
 }
 
 /**
+ * semver.org's official grammar, anchored at both ends.
+ *
+ * Anchored at BOTH ends is the point. This started as `/^\d+\.\d+\.\d+/`,
+ * which only checks a semver-looking prefix — so `1.2.3garbage`, `1.2.3.4`
+ * and `01.2.3` all satisfied it while the function's own error message said
+ * "is not a semver version". A validator that accepts what it says it rejects
+ * is the comment-overstates-its-mechanism failure .github/CLAUDE.md ends its
+ * checklist on.
+ *
+ * Prerelease and build metadata are in the grammar rather than waved through:
+ * `1.2.3-rc.1` and `1.2.3+build.4` are legitimately publishable, and a regex
+ * that failed a real release would be worse than the loose one it replaced.
+ */
+export const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/**
  * Validate a version string, throwing with a message naming where it came from.
  *
- * Two checks rather than one, and both earn their place. The shape test is the
- * plausibility check — npm will not publish a non-semver version, so it should
- * never fire. The character test is the injection guard, and it is the one
- * that matters: it is what stops a newline, a `$`, or a quote reaching
- * $GITHUB_OUTPUT and syft's YAML heredoc.
+ * Two checks, and the ORDER is deliberate. SEMVER alone would reject
+ * everything the character test rejects, so running it first would make the
+ * character test unreachable — dead code wearing the label of the control that
+ * matters most here. Running the character test first keeps both live and,
+ * more usefully, makes each error name the actual problem: a value carrying a
+ * newline is reported as an injection attempt, not as a formatting quibble.
  *
- * Kept permissive on purpose beyond those two: prerelease and build-metadata
- * versions (`1.2.3-rc.1`, `1.2.3+build.4`) are legitimately publishable and a
- * stricter regex would fail a real release rather than catch an attack.
+ * The character test is the security-relevant one. This value reaches
+ * $GITHUB_OUTPUT and syft's YAML heredoc, where a newline defines arbitrary
+ * extra step outputs and a `$` or a quote reshapes the config. SEMVER is the
+ * correctness one: it catches `1.2.3.4` and `01.2.3`, which are harmless but
+ * are not versions, and which the loose prefix test this replaced accepted
+ * while claiming otherwise.
  */
 export function assertVersion(version, source = 'version') {
   const value = String(version ?? '');
-  if (!/^\d+\.\d+\.\d+/.test(value)) {
-    throw new Error(`${source} is not a semver version: "${value}"`);
-  }
   if (!/^[0-9A-Za-z.+-]+$/.test(value)) {
     throw new Error(`${source} contains unexpected characters: "${value}"`);
+  }
+  if (!SEMVER.test(value)) {
+    throw new Error(`${source} is not a semver version: "${value}"`);
   }
   return value;
 }

--- a/scripts/consumer-sbom-meta.mjs
+++ b/scripts/consumer-sbom-meta.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Decide what `consumer-sbom` installs, and stamp what it actually got (#530,
+ * items 1, 3 and 4; deferred from #529).
+ *
+ * Two questions, one script, because they are the same fact seen from either
+ * side of an `npm install`:
+ *
+ *   spec  — which version should this matrix leg install?
+ *   stamp — which version did it get, and what is the artifact called?
+ *
+ * ## Why `spec` exists at all (item 1)
+ *
+ * The job used to install the mutable `latest` dist-tag for all four packages.
+ * For the ONE package a release names that is wrong twice over, and both are
+ * real rather than theoretical:
+ *
+ *   - `release: published` fires immediately after `npm publish`, so a
+ *     CDN-cached packument can resolve the PREVIOUS version. Release 5.12.0
+ *     then carries an SBOM stamped 5.11.1.
+ *   - A re-run days later resolves a newer `latest` and produces a different
+ *     filename, which `gh release upload --clobber` cannot replace. The
+ *     release ends up permanently carrying two contradictory consumer SBOMs
+ *     for the same package.
+ *
+ * `release.tag_name` is `<pkg>@X.Y.Z` (VERSIONING.md, and the `tagFormat` in
+ * each package's release.config.js), so the exact version IS available for
+ * that one leg. The other three necessarily stay on `latest` — a release says
+ * nothing about them, and pretending otherwise would pin them to whatever
+ * happened to be current when an unrelated package shipped.
+ *
+ * That asymmetry is the whole reason this is not a one-line workflow change:
+ * the tag has to be matched to its matrix leg, and only that leg pinned.
+ *
+ * ## Why `stamp` is here rather than in the YAML (rule 9, item 3)
+ *
+ * `assertVersion` guards a value that comes out of a published tarball — the
+ * one input to this job an attacker would control if a package were
+ * compromised — and it flows into `$GITHUB_OUTPUT` and from there into a YAML
+ * heredoc that writes syft's config. A value containing a newline would define
+ * arbitrary extra step outputs and inject syft config keys, silently
+ * re-shaping the very document the job exists to produce. That is logic worth
+ * testing, and `.github/CLAUDE.md` rule 9 says shell in a workflow step cannot
+ * be tested where it lives.
+ *
+ * ## Why the basename is here (item 4)
+ *
+ * `bestax-consumer-sbom-<slug>-<version>` was written out four times across
+ * two sbom-action steps. `artifactBasename` is now the only place it is
+ * constructed, and `ARTIFACT_PREFIX` is the constant that `sign-sbom` and
+ * `attach-sbom` glob on from their own jobs — they cannot read a step output
+ * across a job boundary, so the prefix being pinned by a test is what keeps
+ * those globs honest. Change it here and the test fails; that is the point.
+ *
+ * Design mirrors check-security-txt-expiry.mjs: plain node, zero npm deps,
+ * pure helpers exported, main only runs when executed directly. No subprocess
+ * and no network — every input is an argument or a file the install already
+ * wrote, which makes every assertion testable against a temp directory.
+ *
+ * Usage:
+ *   node scripts/consumer-sbom-meta.mjs spec  --package <pkg> --event <name> [--tag <tag>]
+ *   node scripts/consumer-sbom-meta.mjs stamp --package <pkg> --slug <slug> \
+ *                                             --dir <tree> [--expect <version>]
+ *
+ * Both modes append their results to $GITHUB_OUTPUT and echo them, so a
+ * dispatch log says what happened without opening the artifact: `spec` writes
+ * `spec=` and `expect=` (the latter empty unless this leg was pinned), `stamp`
+ * writes `version=` and `basename=`.
+ *
+ * Deliberately no shell-side parsing of what this returns. An earlier draft had
+ * the workflow derive `expect` from `spec` with `${spec##*@}`, which is the
+ * same last-`@` split parseReleaseTag already does — reimplemented in YAML,
+ * untested, one character away from being wrong for the scoped package.
+ *
+ * Exit codes: 0 fine,
+ *             1 an assertion failed,
+ *             2 bad usage — kept distinct, as in verify-attestation.mjs, so a
+ *               typo'd flag is not reported as a supply-chain failure.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * The one string `sign-sbom`'s and `attach-sbom`'s globs key on. They run in
+ * other jobs and download by artifact pattern, so they cannot consume the step
+ * output built from this — pinning it in the test sibling is the only thing
+ * standing between a rename here and an SBOM that silently stops being signed
+ * or attached.
+ */
+export const ARTIFACT_PREFIX = 'bestax-consumer-sbom-';
+
+/**
+ * Split a release tag into the package it names and the version it carries.
+ *
+ * Split on the LAST `@`, not the first: `@allxsmith/bestax-bulma@5.12.0` has
+ * two, and splitting on the first yields the empty package name and
+ * `allxsmith/bestax-bulma@5.12.0` as a version. Three of the four packages are
+ * unscoped and would hide this bug completely.
+ *
+ * Returns null for anything that is not `<name>@<version>` rather than
+ * throwing: a tag this cannot parse is not an error, it is a release this job
+ * has nothing to pin to, and the caller falls back to `latest`.
+ */
+export function parseReleaseTag(tag) {
+  const value = String(tag ?? '').trim();
+  const at = value.lastIndexOf('@');
+  // `at < 1` covers both "no @ at all" and a leading @ with nothing before it,
+  // which would name the empty package.
+  if (at < 1) return null;
+
+  const pkg = value.slice(0, at);
+  const version = value.slice(at + 1);
+  if (!pkg || !version) return null;
+  return { package: pkg, version };
+}
+
+/**
+ * The npm spec this matrix leg should install.
+ *
+ * Pinned only when a release event names THIS package. Everything else —
+ * schedule, workflow_dispatch, a release for one of the sibling packages, an
+ * unparsable tag — resolves `latest`, which is the correct answer for a leg no
+ * release makes a claim about.
+ *
+ * Note what is deliberately NOT done: no attempt to guess a version for the
+ * other three legs from the repository, the changelog, or the previous run. A
+ * consumer SBOM describes what a consumer installs today, and today for those
+ * three is whatever `latest` resolves to.
+ */
+export function installSpec({ package: pkg, eventName, tagName } = {}) {
+  if (!pkg) throw new Error('installSpec requires a package name');
+  if (eventName !== 'release') return pkg;
+
+  const parsed = parseReleaseTag(tagName);
+  if (!parsed || parsed.package !== pkg) return pkg;
+
+  assertVersion(parsed.version, `release tag ${tagName}`);
+  return `${pkg}@${parsed.version}`;
+}
+
+/**
+ * Validate a version string, throwing with a message naming where it came from.
+ *
+ * Two checks rather than one, and both earn their place. The shape test is the
+ * plausibility check — npm will not publish a non-semver version, so it should
+ * never fire. The character test is the injection guard, and it is the one
+ * that matters: it is what stops a newline, a `$`, or a quote reaching
+ * $GITHUB_OUTPUT and syft's YAML heredoc.
+ *
+ * Kept permissive on purpose beyond those two: prerelease and build-metadata
+ * versions (`1.2.3-rc.1`, `1.2.3+build.4`) are legitimately publishable and a
+ * stricter regex would fail a real release rather than catch an attack.
+ */
+export function assertVersion(version, source = 'version') {
+  const value = String(version ?? '');
+  if (!/^\d+\.\d+\.\d+/.test(value)) {
+    throw new Error(`${source} is not a semver version: "${value}"`);
+  }
+  if (!/^[0-9A-Za-z.+-]+$/.test(value)) {
+    throw new Error(`${source} contains unexpected characters: "${value}"`);
+  }
+  return value;
+}
+
+/** The artifact basename both sbom-action steps use, minus the format suffix. */
+export function artifactBasename(slug, version) {
+  if (!slug) throw new Error('artifactBasename requires a slug');
+  assertVersion(version, 'artifact version');
+  return `${ARTIFACT_PREFIX}${slug}-${version}`;
+}
+
+/**
+ * Read back the version npm actually installed.
+ *
+ * Read from the tree rather than re-resolved from the registry, so the stamp
+ * cannot disagree with what was scanned. A second `npm view` seconds later can
+ * legitimately return a different answer; the document describes the tree.
+ */
+export function readInstalledVersion(dir, pkg) {
+  const manifest = path.join(dir, 'node_modules', pkg, 'package.json');
+  let raw;
+  try {
+    raw = fs.readFileSync(manifest, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `${pkg} is not installed under ${dir} (${manifest}: ${err.code ?? err.message}). ` +
+        `The install step did not do what this stamp assumes.`,
+      { cause: err }
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`${pkg} has an unparsable package.json: ${err.message}`, {
+      cause: err,
+    });
+  }
+  return assertVersion(parsed.version, `${pkg} package.json version`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/** Parse `--flag value` argv into { mode, ...flags }; throws Error on misuse. */
+export function parseArgs(argv) {
+  const [mode, ...rest] = argv;
+  if (mode !== 'spec' && mode !== 'stamp') {
+    throw new Error(`usage: consumer-sbom-meta.mjs <spec|stamp> [flags]`);
+  }
+  const flags = {};
+  for (let i = 0; i < rest.length; i += 2) {
+    const key = rest[i];
+    if (!key.startsWith('--')) throw new Error(`unexpected argument "${key}"`);
+    if (i + 1 >= rest.length) throw new Error(`${key} needs a value`);
+    flags[key.slice(2)] = rest[i + 1];
+  }
+  return { mode, ...flags };
+}
+
+/** Append `key=value` lines to $GITHUB_OUTPUT (when set) and echo them. */
+function emit(lines, env) {
+  if (env.GITHUB_OUTPUT) {
+    fs.appendFileSync(env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+  }
+  for (const line of lines) console.log(line);
+}
+
+export function main(argv = process.argv.slice(2), env = process.env) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    return 2;
+  }
+
+  try {
+    if (args.mode === 'spec') {
+      if (!args.package) throw new Error('spec requires --package');
+      const spec = installSpec({
+        package: args.package,
+        eventName: args.event,
+        tagName: args.tag,
+      });
+      const pinned = spec !== args.package;
+      console.error(
+        pinned
+          ? `pinned ${args.package} to the release tag`
+          : `resolving ${args.package} from the latest dist-tag`
+      );
+      // `expect` is what the stamp step asserts the tree against, and it is
+      // written here rather than derived in the workflow so the last-`@` split
+      // exists in exactly one tested place.
+      emit(
+        [
+          `spec=${spec}`,
+          `expect=${pinned ? spec.slice(args.package.length + 1) : ''}`,
+        ],
+        env
+      );
+      return 0;
+    }
+
+    if (!args.package) throw new Error('stamp requires --package');
+    if (!args.slug) throw new Error('stamp requires --slug');
+    if (!args.dir) throw new Error('stamp requires --dir');
+
+    const version = readInstalledVersion(args.dir, args.package);
+
+    // The pin's free assertion: when a version was asked for, the tree must
+    // carry it. Without this the pin would be a request rather than a
+    // guarantee, and a registry serving something else would go unnoticed —
+    // which is the failure mode the read-back existed for in the first place.
+    if (args.expect && args.expect !== version) {
+      throw new Error(
+        `asked npm for ${args.package}@${args.expect} but the tree carries ` +
+          `${version}. The document would describe a different release than ` +
+          `the one it is attached to.`
+      );
+    }
+
+    emit(
+      [
+        `version=${version}`,
+        `basename=${artifactBasename(args.slug, version)}`,
+      ],
+      env
+    );
+    return 0;
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    return 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  process.exitCode = main();
+}

--- a/scripts/consumer-sbom-meta.test.mjs
+++ b/scripts/consumer-sbom-meta.test.mjs
@@ -273,7 +273,28 @@ test('readInstalledVersion validates what the tarball claims', () => {
 test('parseArgs requires a known mode', () => {
   assert.throws(() => parseArgs([]), /spec\|stamp/);
   assert.throws(() => parseArgs(['stampede']), /spec\|stamp/);
-  assert.equal(parseArgs(['spec', '--package', 'x']).package, 'x');
+  assert.equal(
+    parseArgs(['spec', '--package', 'x', '--event', 'release']).package,
+    'x'
+  );
+});
+
+test('spec requires --event, because its absence disables the pin silently', () => {
+  // installSpec treats an absent event as "not a release", so without this a
+  // malformed invocation exits 0 and resolves `latest` — turning item 1 OFF
+  // with nothing anywhere reporting it. A workflow edit dropping the flag is
+  // the realistic way that happens.
+  assert.throws(
+    () => parseArgs(['spec', '--package', 'x']),
+    /spec requires --event/
+  );
+  assert.equal(main(['spec', '--package', 'x'], {}), 2);
+
+  // --tag stays optional: schedule and dispatch legitimately have none.
+  assert.equal(
+    parseArgs(['spec', '--package', 'x', '--event', 'schedule']).tag,
+    undefined
+  );
 });
 
 test('parseArgs rejects a flag with no value', () => {

--- a/scripts/consumer-sbom-meta.test.mjs
+++ b/scripts/consumer-sbom-meta.test.mjs
@@ -1,0 +1,325 @@
+/**
+ * Guards on the decision logic in consumer-sbom-meta.mjs.
+ *
+ * These tests carry an unusual amount of weight, because the code they cover
+ * is almost entirely unverifiable any other way. `consumer-sbom` runs on
+ * `release`, `schedule` and `workflow_dispatch` only, so no PR exercises it —
+ * and the pinning path specifically fires ONLY on a real release event, which
+ * means a dispatch cannot reach it either. There is no run to read. This file
+ * is the coverage.
+ *
+ * Two assertions are load-bearing beyond their apparent size:
+ *
+ *   - the two-`@` scoped-package case. Three of the four packages are
+ *     unscoped, so a lastIndexOf/indexOf slip passes every test that does not
+ *     name @allxsmith/bestax-bulma and then mis-pins the one package whose
+ *     release triggered the run.
+ *   - ARTIFACT_PREFIX. `sign-sbom` and `attach-sbom` glob on that string from
+ *     other jobs and cannot read a step output across a job boundary, so
+ *     nothing else connects the constant to the globs that depend on it. If
+ *     this assertion is ever "fixed" by updating the expected string, update
+ *     the globs in supply-chain.yml in the same commit.
+ *
+ * `.mjs` and `node --test` rather than jest: root-level scripts with no
+ * package of their own, matching check-security-txt-expiry.test.mjs.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  ARTIFACT_PREFIX,
+  parseReleaseTag,
+  installSpec,
+  assertVersion,
+  artifactBasename,
+  readInstalledVersion,
+  parseArgs,
+  main,
+} from './consumer-sbom-meta.mjs';
+
+const SCOPED = '@allxsmith/bestax-bulma';
+
+/** A scratch consumer tree with one installed package, as npm would leave it. */
+function tree(pkg, version) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'consumer-sbom-'));
+  const manifest = path.join(dir, 'node_modules', pkg);
+  fs.mkdirSync(manifest, { recursive: true });
+  fs.writeFileSync(
+    path.join(manifest, 'package.json'),
+    JSON.stringify({ name: pkg, version })
+  );
+  return dir;
+}
+
+// --- release tags ------------------------------------------------------------
+
+test('parseReleaseTag splits a scoped tag on the LAST @', () => {
+  assert.deepEqual(parseReleaseTag(`${SCOPED}@5.12.0`), {
+    package: SCOPED,
+    version: '5.12.0',
+  });
+});
+
+test('parseReleaseTag handles the three unscoped packages', () => {
+  for (const pkg of ['create-bestax', 'bestax-migrate', 'bestax-mcp']) {
+    assert.deepEqual(parseReleaseTag(`${pkg}@1.2.3`), {
+      package: pkg,
+      version: '1.2.3',
+    });
+  }
+});
+
+test('parseReleaseTag returns null rather than throwing on a tag it cannot use', () => {
+  // Not an error — just a release with nothing to pin to. The caller falls
+  // back to `latest`, which is the correct answer.
+  for (const tag of ['', undefined, null, 'v1.2.3', '@scope/only', 'name@']) {
+    assert.equal(parseReleaseTag(tag), null, `expected null for ${tag}`);
+  }
+});
+
+// --- install spec ------------------------------------------------------------
+
+test('installSpec pins the package the release names', () => {
+  assert.equal(
+    installSpec({
+      package: SCOPED,
+      eventName: 'release',
+      tagName: `${SCOPED}@5.12.0`,
+    }),
+    `${SCOPED}@5.12.0`
+  );
+});
+
+test('installSpec leaves the other three legs on latest during a release', () => {
+  // The whole asymmetry of item 1: a bulma-ui release says nothing about what
+  // version of bestax-migrate a consumer installs today.
+  for (const pkg of ['create-bestax', 'bestax-migrate', 'bestax-mcp']) {
+    assert.equal(
+      installSpec({
+        package: pkg,
+        eventName: 'release',
+        tagName: `${SCOPED}@5.12.0`,
+      }),
+      pkg
+    );
+  }
+});
+
+test('installSpec resolves latest on schedule and dispatch', () => {
+  for (const eventName of ['schedule', 'workflow_dispatch']) {
+    assert.equal(
+      // A tag is present in neither event, but pass one anyway: the event
+      // check must be what decides, not the tag's absence.
+      installSpec({
+        package: SCOPED,
+        eventName,
+        tagName: `${SCOPED}@5.12.0`,
+      }),
+      SCOPED
+    );
+  }
+});
+
+test('installSpec falls back to latest on an unparsable or foreign tag', () => {
+  for (const tagName of [undefined, '', 'v5.12.0', 'some-other-pkg@1.0.0']) {
+    assert.equal(
+      installSpec({ package: SCOPED, eventName: 'release', tagName }),
+      SCOPED
+    );
+  }
+});
+
+test('installSpec refuses a release tag carrying a junk version', () => {
+  // A tag is repo-authored rather than registry-authored, but it reaches an
+  // `npm install` argument either way.
+  assert.throws(
+    () =>
+      installSpec({
+        package: SCOPED,
+        eventName: 'release',
+        tagName: `${SCOPED}@latest`,
+      }),
+    /not a semver version/
+  );
+});
+
+// --- version validation ------------------------------------------------------
+
+test('assertVersion accepts prerelease and build metadata', () => {
+  for (const v of ['5.12.0', '1.0.0-rc.1', '1.0.0+build.4', '1.0.0-rc.1+b.2']) {
+    assert.equal(assertVersion(v), v);
+  }
+});
+
+test('assertVersion rejects the injection shapes it exists for', () => {
+  // This is the reason the read-back moved out of YAML: each of these flows
+  // into $GITHUB_OUTPUT and then into syft's config heredoc.
+  assert.throws(() => assertVersion('1.0.0\nbasename=evil'), /unexpected/);
+  assert.throws(() => assertVersion('1.0.0"; rm -rf /'), /unexpected/);
+  assert.throws(() => assertVersion('1.0.0 $(id)'), /unexpected/);
+  assert.throws(() => assertVersion(''), /not a semver/);
+  assert.throws(() => assertVersion(undefined), /not a semver/);
+  assert.throws(() => assertVersion('latest'), /not a semver/);
+});
+
+test('assertVersion names where the value came from', () => {
+  assert.throws(
+    () => assertVersion('nope', 'release tag x@nope'),
+    /release tag/
+  );
+});
+
+// --- artifact naming ---------------------------------------------------------
+
+test('ARTIFACT_PREFIX matches the globs in supply-chain.yml', () => {
+  // sign-sbom globs `bestax-consumer-sbom-*.spdx.json` and
+  // `bestax-consumer-sbom-*.cdx.json`; attach-sbom does the same. They are in
+  // other jobs and cannot read a step output. Changing this constant without
+  // changing those globs stops the consumer SBOMs being signed and attached,
+  // silently and greenly.
+  assert.equal(ARTIFACT_PREFIX, 'bestax-consumer-sbom-');
+});
+
+test('artifactBasename builds the one name both sbom-action steps use', () => {
+  assert.equal(
+    artifactBasename('allxsmith-bestax-bulma', '5.12.0'),
+    'bestax-consumer-sbom-allxsmith-bestax-bulma-5.12.0'
+  );
+});
+
+test('artifactBasename validates the version it is about to embed', () => {
+  assert.throws(() => artifactBasename('slug', 'x'), /not a semver/);
+  assert.throws(() => artifactBasename('', '1.2.3'), /requires a slug/);
+});
+
+// --- read-back ---------------------------------------------------------------
+
+test('readInstalledVersion reads the tree, scoped names included', () => {
+  assert.equal(readInstalledVersion(tree(SCOPED, '5.12.0'), SCOPED), '5.12.0');
+});
+
+test('readInstalledVersion fails loudly when the package is absent', () => {
+  assert.throws(
+    () => readInstalledVersion(tree(SCOPED, '5.12.0'), 'create-bestax'),
+    /is not installed under/
+  );
+});
+
+test('readInstalledVersion validates what the tarball claims', () => {
+  // The one input to this job an attacker would control if a package were
+  // compromised.
+  const dir = tree('evil', '0.0.0');
+  fs.writeFileSync(
+    path.join(dir, 'node_modules', 'evil', 'package.json'),
+    JSON.stringify({ name: 'evil', version: '1.0.0\nbasename=owned' })
+  );
+  assert.throws(() => readInstalledVersion(dir, 'evil'), /unexpected/);
+});
+
+// --- CLI ---------------------------------------------------------------------
+
+test('parseArgs requires a known mode', () => {
+  assert.throws(() => parseArgs([]), /spec\|stamp/);
+  assert.throws(() => parseArgs(['stampede']), /spec\|stamp/);
+  assert.equal(parseArgs(['spec', '--package', 'x']).package, 'x');
+});
+
+test('parseArgs rejects a flag with no value', () => {
+  assert.throws(() => parseArgs(['spec', '--package']), /needs a value/);
+  assert.throws(
+    () => parseArgs(['spec', 'package', 'x']),
+    /unexpected argument/
+  );
+});
+
+test('main stamps version and basename into GITHUB_OUTPUT', () => {
+  const dir = tree(SCOPED, '5.12.0');
+  const out = path.join(dir, 'gh-output');
+  const code = main(
+    [
+      'stamp',
+      '--package',
+      SCOPED,
+      '--slug',
+      'allxsmith-bestax-bulma',
+      '--dir',
+      dir,
+    ],
+    { GITHUB_OUTPUT: out }
+  );
+  assert.equal(code, 0);
+  assert.equal(
+    fs.readFileSync(out, 'utf8'),
+    'version=5.12.0\nbasename=bestax-consumer-sbom-allxsmith-bestax-bulma-5.12.0\n'
+  );
+});
+
+test('main fails when the tree disagrees with the pinned version', () => {
+  // The assertion the pin buys: without it, pinning is a request rather than a
+  // guarantee, and a registry serving something else goes unnoticed.
+  const dir = tree(SCOPED, '5.11.1');
+  const code = main(
+    [
+      'stamp',
+      '--package',
+      SCOPED,
+      '--slug',
+      'allxsmith-bestax-bulma',
+      '--dir',
+      dir,
+      '--expect',
+      '5.12.0',
+    ],
+    {}
+  );
+  assert.equal(code, 1);
+});
+
+test('main separates usage errors from assertion failures', () => {
+  // Exit 2 must not be readable as a supply-chain failure.
+  assert.equal(main(['stamp', '--package', SCOPED], {}), 1);
+  assert.equal(main(['nonsense'], {}), 2);
+});
+
+test('main emits spec and expect when the release names this leg', () => {
+  const out = path.join(tree(SCOPED, '5.12.0'), 'gh-output');
+  const code = main(
+    [
+      'spec',
+      '--package',
+      SCOPED,
+      '--event',
+      'release',
+      '--tag',
+      `${SCOPED}@5.12.0`,
+    ],
+    { GITHUB_OUTPUT: out }
+  );
+  assert.equal(code, 0);
+  // `expect` must be the version alone, not the spec. Deriving it in the
+  // workflow instead would reimplement the last-`@` split in untested YAML.
+  assert.equal(
+    fs.readFileSync(out, 'utf8'),
+    `spec=${SCOPED}@5.12.0\nexpect=5.12.0\n`
+  );
+});
+
+test('main emits an empty expect for an unpinned leg', () => {
+  const out = path.join(tree(SCOPED, '5.12.0'), 'gh-output');
+  const code = main(
+    [
+      'spec',
+      '--package',
+      'bestax-migrate',
+      '--event',
+      'release',
+      '--tag',
+      `${SCOPED}@5.12.0`,
+    ],
+    { GITHUB_OUTPUT: out }
+  );
+  assert.equal(code, 0);
+  assert.equal(fs.readFileSync(out, 'utf8'), 'spec=bestax-migrate\nexpect=\n');
+});

--- a/scripts/consumer-sbom-meta.test.mjs
+++ b/scripts/consumer-sbom-meta.test.mjs
@@ -278,9 +278,49 @@ test('main fails when the tree disagrees with the pinned version', () => {
 });
 
 test('main separates usage errors from assertion failures', () => {
-  // Exit 2 must not be readable as a supply-chain failure.
-  assert.equal(main(['stamp', '--package', SCOPED], {}), 1);
+  // Exit 2 must not be readable as a supply-chain failure, and the converse:
+  // a mistyped invocation must not be reported as one. A missing --slug is a
+  // usage error, so parseArgs owns it and the code is 2, not 1.
   assert.equal(main(['nonsense'], {}), 2);
+  assert.equal(main(['stamp', '--package', SCOPED], {}), 2);
+  assert.equal(main(['stamp', '--package', SCOPED, '--slug', 'x'], {}), 2);
+  assert.equal(main(['spec'], {}), 2);
+
+  // 1 is reserved for a real assertion failure — here, a tree that does not
+  // contain the package it was asked about.
+  assert.equal(
+    main(
+      [
+        'stamp',
+        '--package',
+        'absent-pkg',
+        '--slug',
+        'x',
+        '--dir',
+        tree(SCOPED, '5.12.0'),
+      ],
+      {}
+    ),
+    1
+  );
+});
+
+test('parseArgs owns the required flags for each mode', () => {
+  assert.throws(() => parseArgs(['spec']), /spec requires --package/);
+  assert.throws(
+    () => parseArgs(['stamp', '--package', SCOPED]),
+    /stamp requires --slug/
+  );
+  assert.throws(
+    () => parseArgs(['stamp', '--package', SCOPED, '--slug', 'x']),
+    /stamp requires --dir/
+  );
+  // --expect stays optional: only a pinned leg passes one.
+  assert.equal(
+    parseArgs(['stamp', '--package', SCOPED, '--slug', 'x', '--dir', '/t'])
+      .expect,
+    undefined
+  );
 });
 
 test('main emits spec and expect when the release names this leg', () => {

--- a/scripts/consumer-sbom-meta.test.mjs
+++ b/scripts/consumer-sbom-meta.test.mjs
@@ -36,6 +36,7 @@ import {
   artifactBasename,
   readInstalledVersion,
   parseArgs,
+  forLog,
   main,
 } from './consumer-sbom-meta.mjs';
 
@@ -411,4 +412,53 @@ test('main emits an empty expect for an unpinned leg', () => {
   );
   assert.equal(code, 0);
   assert.equal(fs.readFileSync(out, 'utf8'), 'spec=bestax-migrate\nexpect=\n');
+});
+
+// --- log injection through the rejection message -----------------------------
+
+test('a rejected version cannot forge an Actions workflow command', () => {
+  // The value is blocked from $GITHUB_OUTPUT, and then the complaint about it
+  // used to hand the same newline straight back to the runner inside
+  // `::error::…`, emitting a second forged command. Rejecting is not enough if
+  // the rejection message re-introduces the value verbatim.
+  const attacks = [
+    '1.0.0\n::error::FORGED',
+    '1.0.0\r\n::add-mask::secret',
+    '1.0.0\n::notice::x',
+  ];
+  for (const v of attacks) {
+    assert.throws(
+      () => assertVersion(v),
+      err => {
+        assert.ok(
+          !err.message.includes('\n'),
+          `raw newline in: ${err.message}`
+        );
+        assert.ok(!/^::/m.test(err.message), `command in: ${err.message}`);
+        return true;
+      }
+    );
+  }
+});
+
+test('forLog neutralises anything bound for a log line', () => {
+  assert.equal(forLog('1.0.0\n::error::x'), '"1.0.0\\n::error::x"');
+  assert.equal(forLog('a\r\nb'), '"a\\r\\nb"');
+  assert.equal(forLog(undefined), '""');
+  assert.ok(!forLog('x\ny').includes('\n'));
+});
+
+test('the tarball read-back cannot forge one either', () => {
+  const dir = tree('evil', '0.0.0');
+  fs.writeFileSync(
+    path.join(dir, 'node_modules', 'evil', 'package.json'),
+    JSON.stringify({ name: 'evil', version: '1.0.0\n::error::FORGED' })
+  );
+  assert.throws(
+    () => readInstalledVersion(dir, 'evil'),
+    err => {
+      assert.ok(!err.message.includes('\n'));
+      return true;
+    }
+  );
 });

--- a/scripts/consumer-sbom-meta.test.mjs
+++ b/scripts/consumer-sbom-meta.test.mjs
@@ -483,3 +483,56 @@ test('the tarball read-back cannot forge one either', () => {
     }
   );
 });
+
+test('an unknown flag is rejected, not ignored', () => {
+  // Every optional flag here disables a safeguard by being absent, so a typo
+  // that is silently ignored turns the safeguard off and exits 0. `--tagg`
+  // makes a release leg resolve `latest` — no pin at all — and `--exepct`
+  // skips the installed-version assertion.
+  assert.throws(
+    () =>
+      parseArgs([
+        'spec',
+        '--package',
+        'p',
+        '--event',
+        'release',
+        '--tagg',
+        'p@1.0.0',
+      ]),
+    /spec does not take --tagg/
+  );
+  assert.throws(
+    () =>
+      parseArgs([
+        'stamp',
+        '--package',
+        'p',
+        '--slug',
+        's',
+        '--dir',
+        '/t',
+        '--exepct',
+        '1.0.0',
+      ]),
+    /stamp does not take --exepct/
+  );
+  // And a flag valid for the OTHER mode is still wrong for this one.
+  assert.throws(
+    () =>
+      parseArgs([
+        'spec',
+        '--package',
+        'p',
+        '--event',
+        'release',
+        '--dir',
+        '/t',
+      ]),
+    /spec does not take --dir/
+  );
+  assert.equal(
+    main(['spec', '--package', 'p', '--event', 'release', '--tagg', 'x'], {}),
+    2
+  );
+});

--- a/scripts/consumer-sbom-meta.test.mjs
+++ b/scripts/consumer-sbom-meta.test.mjs
@@ -148,19 +148,68 @@ test('installSpec refuses a release tag carrying a junk version', () => {
 // --- version validation ------------------------------------------------------
 
 test('assertVersion accepts prerelease and build metadata', () => {
-  for (const v of ['5.12.0', '1.0.0-rc.1', '1.0.0+build.4', '1.0.0-rc.1+b.2']) {
+  // These are legitimately publishable, so the grammar must not reject them —
+  // a validator that reds a real release is worse than a loose one.
+  for (const v of [
+    '5.12.0',
+    '0.0.0',
+    '1.0.0-rc.1',
+    '1.0.0+build.4',
+    '1.0.0-rc.1+b.2',
+    '1.0.0-0.3.7',
+    '1.0.0-x.7.z.92',
+    '10.20.30',
+  ]) {
     assert.equal(assertVersion(v), v);
   }
 });
 
+test('assertVersion is anchored at BOTH ends', () => {
+  // The grammar used to be a prefix test, so every one of these passed while
+  // the error message claimed the opposite. None is a valid semver version,
+  // and all are made of legal characters — so the SEMVER test is what has to
+  // catch them, which is exactly what a prefix test could not do.
+  for (const v of [
+    '1.2.3garbage',
+    '1.2.3.4',
+    '01.2.3',
+    '1.02.3',
+    '1.2.3-',
+    '1.2.3+',
+    '1.2',
+    'v1.2.3',
+  ]) {
+    assert.throws(
+      () => assertVersion(v),
+      /not a semver version/,
+      `expected "${v}" to be rejected as non-semver`
+    );
+  }
+
+  // Trailing whitespace is not a legal character, so it is turned away one
+  // check earlier. Asserted rather than lumped in above, because "rejected"
+  // for the wrong reason is how the prefix-test bug survived review.
+  assert.throws(() => assertVersion('1.2.3 '), /unexpected/);
+});
+
 test('assertVersion rejects the injection shapes it exists for', () => {
   // This is the reason the read-back moved out of YAML: each of these flows
-  // into $GITHUB_OUTPUT and then into syft's config heredoc.
+  // into $GITHUB_OUTPUT and then into syft's config heredoc. They are expected
+  // to trip the CHARACTER test specifically — it runs first precisely so the
+  // error names the injection rather than the formatting.
   assert.throws(() => assertVersion('1.0.0\nbasename=evil'), /unexpected/);
   assert.throws(() => assertVersion('1.0.0"; rm -rf /'), /unexpected/);
   assert.throws(() => assertVersion('1.0.0 $(id)'), /unexpected/);
-  assert.throws(() => assertVersion(''), /not a semver/);
-  assert.throws(() => assertVersion(undefined), /not a semver/);
+  assert.throws(() => assertVersion('1.0.0`id`'), /unexpected/);
+  assert.throws(() => assertVersion('1.0.0;id'), /unexpected/);
+});
+
+test('assertVersion rejects empty and non-numeric values', () => {
+  // Empty and nullish carry no characters at all, so the character test is
+  // what turns them away; `latest` is well-formed text that is not a version.
+  assert.throws(() => assertVersion(''), /unexpected/);
+  assert.throws(() => assertVersion(undefined), /unexpected/);
+  assert.throws(() => assertVersion(null), /unexpected/);
   assert.throws(() => assertVersion('latest'), /not a semver/);
 });
 


### PR DESCRIPTION
# Pull Request

## Description

Four of the five follow-ups #529 deferred, plus part of the fifth. Affects `.github/workflows/supply-chain.yml`'s `consumer-sbom` job and adds two `scripts/*.mjs` with `node --test` siblings.

- [ ] bulma-ui (`@allxsmith/bestax-bulma`)
- [ ] create-bestax (`create-bestax`)
- [ ] docs (`@allxsmith/bestax-docs`)
- [x] Other: `.github/workflows/supply-chain.yml`, `scripts/consumer-sbom-meta.mjs`, `scripts/check-consumer-sbom.mjs`

**1. Pin the released package to its release tag.** `release.tag_name` is `<pkg>@X.Y.Z`, so the one package a release names is installed at that exact version instead of resolving `latest`. That closes two real failures: the event fires immediately after `npm publish`, so a CDN-cached packument could stamp release 5.12.0 with an SBOM describing 5.11.1; and a re-run days later resolved a newer `latest` and produced a filename `--clobber` cannot replace, leaving the release permanently carrying two contradictory documents for the same package. The other three legs stay on `latest` — a release says nothing about them — which is why the decision is a script matching the tag to its matrix leg rather than an expression in YAML.

The pin buys a free assertion: `--expect` fails the job if the tree does not carry the version that was asked for. It also needs a retry, because pinning trades "resolves the wrong version" for "may not resolve at all" while the packument propagates — without it, the released leg, the one the release actually cares about, would be the one most likely to ship no SBOM.

**2. Assert the documents are still a consumer closure.** Nothing checked, so a syft, cataloger or exporter change shipped silently green. Deliberately **not** a count: 48c57d5 reverted exactly that, because live registry closures drift on somebody else's release and a false-red generator is the cry-wolf failure #391 and #525 already fixed. Instead: every catalogued entry must have come from the npm registry (a `registry.npmjs.org` download location in SPDX, a `pkg:npm/` purl in CycloneDX), the package the document names must be in it at the stamped version, and a floor. That catches inflation by its cause rather than its size. The test sibling replays all three real regressions and pins the negative case that a closure which merely **grew** must still pass.

It runs on **both** documents and **before** the artifact is uploaded, so it is a gate rather than a detector — see the review round below for why both of those matter.

**3. Move the install/stamp shell into `scripts/` (rule 9) — partial, see below.**

**4. Build the artifact name once.** Four occurrences collapse to one step output, and the two artifacts per leg become one carrying both formats.

**5. Scan a lockfile-only directory rather than the consumer tree.** syft walked every file under `node_modules` — thousands per leg, twice — to satisfy a cataloger that reads the root lockfile and nothing else. A copied directory rather than the lockfile as a file source; the review round explains why that distinction stopped being cosmetic.

## Related Issue(s)

Refs #530
Refs #529, #424

**Not `Closes`, on purpose.** Item 3 is deliberately partial, so #530 should stay open for the remainder.

## Type of Change

- [x] Build tooling
- [x] Refactor

## What is deliberately NOT done

`attach-sbom`'s upload branching is left inline. That job has no checkout and runs no repository code — which is precisely what makes it safe to give it `contents: write`, and why `.github/CLAUDE.md`'s rule-10 inventory lists it under "genuinely API-only". Extracting its shell means adding a checkout and executing repository code beside a write-scoped token, which is a worse trade than the unit test it buys. Item 4 removes most of the reason that shell was fragile anyway. If the preference is to do it, it wants its own PR with a `block` harden-runner on that job.

## Security review (`.github/CLAUDE.md`)

- **No allowlist grows.** `consumer-sbom` gains a `checkout`, which reaches `github.com`, `api.github.com` and `objects.githubusercontent.com` — all already in that job's `allowed-endpoints`. `harden-runner` at `block` and its assertion are unchanged.
- **No `permissions:` change.** `consumer-sbom` stays `contents: read`.
- **No model session is involved**, so I1/I2 are not in play; no comment body, no posting identity.
- **Action SHAs**: the new `checkout` is on the repo-wide pin. Both rule-1 greps are clean — the per-action grep returns one line (29 usages, one SHA) and the repo-wide dedupe grep returns no output.
- **The new checkout takes the EVENT ref, not `ref: main`,** and this is the one judgement call worth arguing. `verify-provenance` pins `main` because it reads a verifier that must not come from the tag it is verifying. This job asserts a property of a document *it just generated*; there is no third party whose claim the checked-out code could be made to rubber-stamp, so that reasoning does not transfer. Pinning `main` would also make the only available verification — a dispatch on a branch — impossible, since the guard would be read from a `main` that does not have it yet. If you would rather have the `main` pin on `release` events specifically, `ref: ${{ github.event_name == 'release' && 'main' || github.ref }}` gets both at the cost of legibility.
- Rule 9's bootstrap gap does not bite here: the jobs that check out the default branch are the ones in the AI pipeline, not this one.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated documentation as needed (workflow comments; no docs-site surface)
- [ ] I have updated Storybook stories as needed (bulma-ui) — n/a
- [ ] My changes require a change to the documentation — n/a
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated — n/a
- [x] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated — no change needed; rule 10's inventory is unaffected (`consumer-sbom` was already listed as enforcing and asserted), and the job's addition of a checkout does not move it between that rule's groups since it already held a read-scoped credential.

## Review round (CodeRabbit, Copilot, Claude deep review)

All findings addressed; the CycloneDX one turned out to be a **live defect predating this PR**.

| Finding | From | Outcome |
| --- | --- | --- |
| Missing required flags exit 1, but the header promises 2 for usage errors | CodeRabbit | Fixed (`c241137`). `parseArgs` owns required flags per mode. The test asserting the old behaviour sat directly under a comment saying the opposite. |
| The guard never requires the target package to be in its own closure | Copilot | Fixed (`c241137`). Asserted in both formats at the stamped version. The fixture that hid it omitted the target; both fixtures are now shaped after real artifacts. |
| Only SPDX is inspected; a CycloneDX regression ships unchecked | Copilot | Fixed, and see below — it was not hypothetical. |
| The guard detects but does not **prevent** publication | Claude deep review #1 | Fixed (`d44f0a4`). See below. |
| Item 1 fixes the `--clobber` failure only for the released leg | Claude deep review #2 | Accurate, pre-existing, unchanged. A release makes no claim about the other three. |
| The registry invariant could false-red on a legitimate git/tarball/alias runtime dep | Claude deep review #3 | Latent, kept. Such a dependency is worth flagging on its own; the message now says so instead of inviting a reflexive widening. |
| The semver check was a PREFIX match, so `1.2.3garbage`, `1.2.3.4`, `01.2.3` passed a function whose error says otherwise | Copilot (2nd pass) | Fixed (`6f1b545`). semver.org's anchored grammar, prerelease and build metadata still admitted. See below — the fix had a trap in it. |
| The SPDX subject entry is exempted by name and never validated, unlike the CycloneDX one | Copilot (3rd pass) | Fixed (`1006b10`). Both formats resolve a subject and run the same assertions; a test pins the symmetry. |
| "Both are generated from the same syft run" — they are two separate `sbom-action` invocations | Copilot (3rd pass) | Fixed (`1006b10`). That distinction is the whole justification for reading both documents. |
| `pkg:npm/` is an ecosystem identifier, not a download origin — the CycloneDX check is not provenance | Copilot (4th pass) | Fixed (`9bb7aa7`). Correct, and the claim was mine. See below. |
| `--spdx`/`--cdx` are never enforced against the files' actual contents | Copilot (5th pass) | Fixed (`2217f70`). The flags were decoration: the same file passed twice satisfied everything. Detected format is now compared to the flag first. |
| `crossCheck` compared with `includes`, so duplicate inflation passed | Deep review r2 | Fixed (`6bbe4b2`). Multiset comparison; duplicates within a document warn rather than fail, to avoid a false red. |
| Target check took the FIRST matching entry — a false red on multi-version closures | Copilot (6th pass) | Fixed (`6c75ca9`). Any matching entry satisfies it. |
| `normalize` keyed on array shape, so a document missing its format marker passed | Copilot (6th pass) | Fixed (`6c75ca9`). Requires `spdxVersion` / `bomFormat` too. |
| The files-array check rejected only *absolute* paths | Deep review r3 | Fixed (`6c75ca9`). Rejects any path separator. |
| The guard is the second line against inflation, not the first | Deep review r3 | Documented (`6c75ca9`). The scan shape is what prevents that class. |
| **The rejection message re-introduced the value it rejected, forging Actions workflow commands** | Copilot (7th pass) | Fixed (`db5d0c0`). See below. |

### The CycloneDX leak was already shipping

Chasing Copilot's finding turned up a `type: file` component named
`/home/runner/work/_temp/consumer/package-lock.json` in **every** CycloneDX consumer SBOM. This is the runner-path leak #529 fixed for SPDX, still live in the format nothing was reading — signed and attached to every release since.

**Not introduced here.** Run [32706731377](https://github.com/allxsmith/bestax/actions/runs/32706731377), a scheduled run on `main` from before this branch existed, carries it in all four `.cdx.json` files. An intermediate commit on this branch claimed the branch had caused it; `7860c7e` corrects that.

Cause: file metadata is cataloged independently of `default-catalogers`, so narrowing that to the lock cataloger never touched it, and the exporters named the artifact differently — SPDX a *relative* `package-lock.json` in its `files` array, CycloneDX the *absolute* path. Fixed with `file.metadata.selection: none`.

### The guard is now a gate

`sbom-action` generates and uploads in one step, so the artifact existed before anything inspected it — and `sign-sbom`/`attach-sbom` deliberately do not require `consumer-sbom` to have succeeded. On a real release a rejected document would still have been signed and permanently attached while the run merely went red.

`upload-artifact: false` on both generators plus one explicit upload *after* the assertion closes it. This keeps #529's degradation rather than trading it away: a failed leg produces no artifact, the downstream globs expand to nothing, `attach-sbom` warns, and the repository SBOMs still ship. Gating those jobs on `needs.consumer-sbom.result` would have been worse — the matrix is `fail-fast: false` precisely so one bad leg cannot take the other three with it.

### A guard that performed the attack while reporting it

`assertVersion` blocks a newline-bearing version from reaching `$GITHUB_OUTPUT` — then interpolated it verbatim into its own `::error::` complaint. A workflow command ends at a newline, so:

```
::error::version contains unexpected characters: "1.0.0
::error::FORGED COMMAND"
```

Line two is a live, attacker-authored workflow command. Reproduced before fixing. Both scripts now route untrusted values through a `forLog` helper (`JSON.stringify`), applied to everything sourced from a tarball, a generated document, or a release tag. The same class was already live in `check-consumer-sbom.mjs`, which reports entry names straight out of tarball-derived documents; fixed in the same pass. Tests assert the property — no message may contain a raw newline or a line starting `::`.

### The CycloneDX origin check was not what I said it was

`pkg:npm/name@version` is built by syft from the name and version alone; a CycloneDX document carries `resolved` **nowhere** — not in `externalReferences`, not in `properties`. Checked against a real component rather than reasoned about:

```json
{ "name": "bulma", "version": "1.0.4", "purl": "pkg:npm/bulma@1.0.4",
  "properties": [ {"name": "syft:package:foundBy", "value": "javascript-lock-cataloger"},
                  {"name": "syft:location:0:path", "value": "/package-lock.json"} ] }
```

So that test is an **ecosystem** test. It catches a `pkg:githubactions/…` entry and a file component with no purl — the leak class it was added for — and a git, tarball, private-registry or aliased dependency passes it untouched. Describing it as provenance was the more serious half of the finding, and the claim was mine, not inherited.

**Closed by a fourth assertion:** the two documents must list the same `name@version` set. They are separate syft runs — precisely how the #529 leak lived in every CycloneDX document and no SPDX one — so this is a real check, and it carries the registry claim across: anything the weak purl test would admit must also appear in SPDX, where `downloadLocation` and the strong test are waiting. The script therefore takes both files in one invocation; two separate runs could each pass while disagreeing.

A test asserts that a git dep **passes** the CycloneDX check, so the asymmetry cannot be silently re-read as provenance later. Live agreement counts: 5 / 12 / 98 / 93.

### Anchoring the semver check had a trap in it

Swapping the prefix regex for the anchored grammar made the **character test unreachable** — every string the grammar accepts is already within `[0-9A-Za-z.+-]`. That would have left the security-relevant check as dead code wearing the label of the control that matters most here (it is what stops a newline reaching `$GITHUB_OUTPUT` and syft's config heredoc).

The checks are therefore ordered character-test-first. Both stay live, and each error names the real problem: a value carrying a newline reports as an injection attempt rather than a formatting quibble. The tests assert *which* check catches *which* input — rejected-for-the-wrong-reason is exactly how the prefix bug survived the first review.

### One more thing the heredoc was doing

The syft config heredoc is unquoted (it interpolates `$PACKAGE`/`$VERSION`), so an existing backticked phrase in a comment was being **executed as a command** and substituted away — the generated config read `publishing without  field`. Inert inside a YAML comment; not inert in general. Backticks are gone from that heredoc, with a note saying why.

## Verification

**A green check on this PR proves nothing about any of it.** `consumer-sbom` runs on `release`, `schedule` and `workflow_dispatch` only, so no PR exercises it. Every defect in #529 was found by dispatching and reading the generated JSON, never by a green job — so that is how this was verified.

Run [33265296155](https://github.com/allxsmith/bestax/actions/runs/33265296155) (`workflow_dispatch` on this branch), green on all four legs. Artifacts downloaded and read:

| package | closure | SPDX entries | CycloneDX entries | non-registry origins |
| --- | --- | --- | --- | --- |
| `@allxsmith/bestax-bulma` | 5 | 7 | 6 | 0 |
| `create-bestax` | 12 | 14 | 13 | 0 |
| `bestax-migrate` | 98 | 100 | 99 | 0 |
| `bestax-mcp` | 93 | 95 | 94 | 0 |

CycloneDX carries one fewer entry because it states its subject in `metadata.component` rather than as a component. No absolute path in any document, in either format.

Both structural entries present in each document, `source.name`/`source.version` correct, no drift warnings, artifact filenames carrying the right version. The artifact store holds one archive per leg named `bestax-consumer-sbom-<slug>-<version>`, which still matches the `bestax-*sbom*` pattern `sign-sbom` and `attach-sbom` download by.

Locally: `pnpm all` exits 0; `node --test "scripts/*.test.mjs"` passes 640 tests.

### What only dispatching found

1. **Item 5 as specified in #530 does not work as written.** `sbom-action` prefixes whatever `path` receives with syft's `dir:` scheme, so pointing `path` at the lockfile fails with `not a directory source` on every leg — run [33260609524](https://github.com/allxsmith/bestax/actions/runs/33260609524). The `file` input does take a file, but a file source made syft emit the scanned file as a component. Both dead ends are recorded in the workflow so nobody re-walks them; the shipped version copies the lockfile into an otherwise empty directory.
2. **The CycloneDX leak**, and that it predates the branch — neither visible without downloading and reading a `.cdx.json`, which nothing had done since #529.
3. **The header comment's `bestax-mcp 94 (95)` was never self-consistent** — two structural entries cannot turn 94 into 95. The measured closure is 93. Corrected, and the block now cites the run it was measured from and states plainly that these are live registry closures which drift, so the next reader re-measures rather than trusting them. Nothing enforces the numbers, deliberately: pinning counts as a gate is what 48c57d5 reverted.

### What this PR cannot verify

- **Item 1's pinned path fires only on a real `release` event**, so no dispatch reaches it. Coverage is the unit tests on `parseReleaseTag`/`installSpec` — including the two-`@` scoped-package case, which three of the four packages would hide, and a release naming a package outside the matrix.
- **`sign-sbom` and `attach-sbom` gate on `github.event_name == 'release'`** and were skipped on the dispatch. Item 4's glob behaviour is verified by reading plus the `ARTIFACT_PREFIX` test, not by running — a further reason not to touch `attach-sbom` here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consumer software bills of materials (SBOMs) are now generated in both SPDX and CycloneDX formats.
  * Published SBOM artifacts include the installed package version and are grouped for easier retrieval.
* **Bug Fixes**
  * Improved package-version selection, installation retries, and release-version validation.
  * Prevented generated SBOMs from including runner-specific filesystem paths.
  * Added consistency checks for package identity, provenance, versions, and dependency closure across formats.
* **Tests**
  * Expanded validation coverage for malformed, inconsistent, and unsafe SBOM data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->