### PR TITLE
docs: document how deep-review findings route to the loop's verify job

### DIFF
--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -150,17 +150,17 @@ marker), because an inline thread is an actionable work item and advisories must
 loop.
 
 One consequence is worth knowing before reading a run's job list: **a deep review that reports
-`0 blocking` files no inline threads**, and most reviews do land at zero blocking — so an absent
+`0 blocking` posts no inline threads**, and most reviews do land at zero blocking — so an absent
 `verify` job is usually just that, not a stalled loop.
 
 It is not the only cause, though, and the gate's decision line (it logs `fail=`, `pend=`,
-`actionable=`, `verify=` and `rebut=` counts) is what tells the cases apart. The gate reads the
-PR's whole set of unresolved threads rather than the latest review's output, so a re-run deep
-review that finds nothing can still meet an open thread from an earlier pass and route to
-`verify` on that. And it picks a single mode per run: red or pending CI and threads still
-awaiting the fixer outrank `verify`. A paused loop stops it outright, since the gate requires
-the `ai-loop` label — but the iteration cap does not, because the cap only rewrites
-`fix-ci`/`fix-reviews` into `halt`, so a `verify` selected at iteration 4 still runs.
+`actionable=`, `verify=` and `rebut=` counts) is what tells the cases apart. The gate classifies
+the unresolved threads on the PR (the first 100 it reads) rather than the latest review's
+output, so a re-run deep review that finds nothing can still meet an open thread from an earlier
+pass and route to `verify` on that. And it picks a single mode per run: red or pending CI and
+threads still awaiting the fixer outrank `verify`. A paused loop stops it outright, since the
+gate requires the `ai-loop` label — but the iteration cap does not, because the cap only
+rewrites `fix-ci`/`fix-reviews` into `halt`, so a `verify` selected at iteration 4 still runs.
 
 **Screenshots at handoff.** When the loop flips a PR to `needs-human-review` it also
 dispatches a screenshot pass (`story-screenshots.yml`): Playwright captures the Storybook

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -137,6 +137,21 @@ re-verify their own findings against the pushed code (nothing is closed on the f
 alone) → after at most 4 fix rounds, the PR either converges (CI green, all review threads
 resolved) or is handed to a human with the open disagreements listed.
 
+**How deep-review findings reach the fixer.** The deep review posts on two channels, and which
+one a finding takes decides whether the loop acts on it. Blocking findings (🔴 Critical, 🟠
+Major, 🟡 Minor) are filed as **inline review comments** on the lines they concern; those
+threads are the fix agent's work items, and it answers each with `Fixed in <sha>` and
+deliberately does not resolve it — the reviewer re-checks that claim in its `verify` pass and
+resolves only what is genuinely fixed. 🔵 Advisory findings never go inline: they appear only as
+rows in the summary review (the one carrying the `<!-- claude-deep-review -->` marker), because
+an inline thread is an actionable work item and advisories must not spin the loop.
+
+One consequence is worth knowing before reading a run's job list: **a deep review that reports
+`0 blocking` creates no threads, so the `verify` pass has nothing to check and does not run.**
+That is the design working rather than a stalled loop — most reviews do land at zero blocking.
+`verify` missing from a run means the review found nothing that blocks, not that verification
+was skipped.
+
 **Screenshots at handoff.** When the loop flips a PR to `needs-human-review` it also
 dispatches a screenshot pass (`story-screenshots.yml`): Playwright captures the Storybook
 stories affected by the PR's changed files — once light, once dark — and posts them to the PR

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -150,12 +150,15 @@ marker), because an inline thread is an actionable work item and advisories must
 loop.
 
 One consequence is worth knowing before reading a run's job list: **a deep review that reports
-`0 blocking` creates no threads, so the `verify` pass has nothing to check.** Most reviews do
-land at zero blocking, which makes this the usual reason `verify` is absent from a run — but it
-is not the only one. The gate picks a single mode per run, and red or pending CI and threads
-still awaiting the fixer all outrank `verify`; a capped or paused loop stops before it too. So
-an absent `verify` is normal rather than a stalled loop, and the gate's decision line (it logs
-`fail=`, `pend=`, `actionable=`, `verify=` and `rebut=` counts) says which case applied.
+`0 blocking` files no inline threads**, and most reviews do land at zero blocking — so an absent
+`verify` job is usually just that, not a stalled loop.
+
+It is not the only cause, though, and the gate's decision line (it logs `fail=`, `pend=`,
+`actionable=`, `verify=` and `rebut=` counts) is what tells the cases apart. The gate reads the
+PR's whole set of unresolved threads rather than the latest review's output, so a re-run deep
+review that finds nothing can still meet an open thread from an earlier pass and route to
+`verify` on that. And it picks a single mode per run: red or pending CI and threads still
+awaiting the fixer outrank `verify`, while a capped or paused loop stops before it.
 
 **Screenshots at handoff.** When the loop flips a PR to `needs-human-review` it also
 dispatches a screenshot pass (`story-screenshots.yml`): Playwright captures the Storybook

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -139,18 +139,23 @@ resolved) or is handed to a human with the open disagreements listed.
 
 **How deep-review findings reach the fixer.** The deep review posts on two channels, and which
 one a finding takes decides whether the loop acts on it. Blocking findings (🔴 Critical, 🟠
-Major, 🟡 Minor) are filed as **inline review comments** on the lines they concern; those
-threads are the fix agent's work items, and it answers each with `Fixed in <sha>` and
-deliberately does not resolve it — the reviewer re-checks that claim in its `verify` pass and
-resolves only what is genuinely fixed. 🔵 Advisory findings never go inline: they appear only as
-rows in the summary review (the one carrying the `<!-- claude-deep-review -->` marker), because
-an inline thread is an actionable work item and advisories must not spin the loop.
+Major, 🟡 Minor) are filed as **inline review comments** on the lines they concern, and those
+threads are the fix agent's work items. It answers each either with `Fixed in <sha>` when it
+makes the fix, or with a refutation when it judges the finding wrong — and in neither case does
+it resolve the thread. The reviewer picks it up from there in its `verify` pass: it re-checks a
+`Fixed in` claim and resolves only what is genuinely fixed, and answers a refutation with one
+rebuttal-or-concede round before a human rules. 🔵 Advisory findings never go inline: they
+appear only as rows in the summary review (the one carrying the `<!-- claude-deep-review -->`
+marker), because an inline thread is an actionable work item and advisories must not spin the
+loop.
 
 One consequence is worth knowing before reading a run's job list: **a deep review that reports
-`0 blocking` creates no threads, so the `verify` pass has nothing to check and does not run.**
-That is the design working rather than a stalled loop — most reviews do land at zero blocking.
-`verify` missing from a run means the review found nothing that blocks, not that verification
-was skipped.
+`0 blocking` creates no threads, so the `verify` pass has nothing to check.** Most reviews do
+land at zero blocking, which makes this the usual reason `verify` is absent from a run — but it
+is not the only one. The gate picks a single mode per run, and red or pending CI and threads
+still awaiting the fixer all outrank `verify`; a capped or paused loop stops before it too. So
+an absent `verify` is normal rather than a stalled loop, and the gate's decision line (it logs
+`fail=`, `pend=`, `actionable=`, `verify=` and `rebut=` counts) says which case applied.
 
 **Screenshots at handoff.** When the loop flips a PR to `needs-human-review` it also
 dispatches a screenshot pass (`story-screenshots.yml`): Playwright captures the Storybook

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -158,7 +158,9 @@ It is not the only cause, though, and the gate's decision line (it logs `fail=`,
 PR's whole set of unresolved threads rather than the latest review's output, so a re-run deep
 review that finds nothing can still meet an open thread from an earlier pass and route to
 `verify` on that. And it picks a single mode per run: red or pending CI and threads still
-awaiting the fixer outrank `verify`, while a capped or paused loop stops before it.
+awaiting the fixer outrank `verify`. A paused loop stops it outright, since the gate requires
+the `ai-loop` label — but the iteration cap does not, because the cap only rewrites
+`fix-ci`/`fix-reviews` into `halt`, so a `verify` selected at iteration 4 still runs.
 
 **Screenshots at handoff.** When the loop flips a PR to `needs-human-review` it also
 dispatches a screenshot pass (`story-screenshots.yml`): Playwright captures the Storybook


### PR DESCRIPTION
Refs #593.

#593 was filed on the theory that `claude-pr-loop`'s `verify` job was structurally
unreachable, because `claude-review.yml` "files no inline comments, so no claude-authored
thread is ever created." That turned out to be wrong on both counts — the deep review has
filed inline comments since #216, and `verify` has run end to end (runs `32857163749` on
#564 and `32913565697` on #569). The issue is now re-scoped to what is actually true.

The reason a careful reader reached the wrong conclusion is that nothing documented how the
deep review routes its findings. This adds that to the ai-development guide:

- Blocking findings (🔴/🟠/🟡) are filed as **inline review comments**; those threads are the
  fix agent's work items, answered with `Fixed in <sha>` and left unresolved for the
  reviewer's `verify` pass to check and close.
- 🔵 Advisory findings never go inline — they appear only as rows in the
  `<!-- claude-deep-review -->` summary review, because an inline thread is an actionable
  work item and advisories must not spin the loop.
- Therefore a review reporting `0 blocking` creates no threads and `verify` does not run.
  Its absence from a run's job list is the design working, not a stalled loop.

That last point is the one worth writing down: across the 24 deep reviews posted on
#560–#592, only 4 reported a blocking finding, and all 4 produced a `claude[bot]` inline
thread. Zero blocking, zero threads — 4/4, no exceptions.

Docs-only; no workflow, config or source changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the AI-assisted development guide with details on how security scan findings are surfaced and addressed.
  * Clarified the difference between blocking and advisory findings, including when inline review comments are created.
  * Documented gate decision indicators, unresolved-thread handling, paused loops, and iteration limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->