### PR TITLE
fix: collapse the duplicated docs route segment so Grid and Columns URLs resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The published packages are versioned and released independently.
 - **[Components](https://bestax.io/docs/api/components/modal)** — Navbar, Modal, Card, Dropdown, Menu, Message, Pagination, Panel, Tabs, Breadcrumb, Toast, Tooltip, Steps, Sidebar, Carousel, Collapse, Dialog, Loading
 - **[Form](https://bestax.io/docs/api/form/input)** — Field/Control, Input, Select, TextArea, Checkbox(es), Radio(s), Switch, Slider, Rate, File, Numberinput, Autocomplete, Taginput, and DateInput / TimeInput / DateTimeInput pickers
 - **[Layout](https://bestax.io/docs/api/layout/container)** — Container, Section, Hero, Level, Media, Footer
-- **[Columns](https://bestax.io/docs/api/columns/columns)** & **[Grid](https://bestax.io/docs/api/grid/grid)** — classic 12-column flexbox columns and the Bulma v1 CSS Grid
+- **[Columns](https://bestax.io/docs/api/columns)** & **[Grid](https://bestax.io/docs/api/grid)** — classic 12-column flexbox columns and the Bulma v1 CSS Grid
 - **[Helpers](https://bestax.io/docs/api/helpers/theme)** — `Theme`, `ConfigProvider`, `useBulmaClasses`, `classNames`
 
 > Migrating from v2? Snackbar was merged into [Toast](https://bestax.io/docs/api/components/toast) in v3 — see the [migration guides](https://bestax.io/docs/guides/getting-started/migration).

--- a/bestax-mcp/data/components/Columns.json
+++ b/bestax-mcp/data/components/Columns.json
@@ -3,7 +3,7 @@
   "kind": "component",
   "category": "columns",
   "slug": "columns/columns",
-  "docsUrl": "https://bestax.io/docs/api/columns/columns",
+  "docsUrl": "https://bestax.io/docs/api/columns",
   "examples": [
     {
       "title": "Basic Columns",

--- a/bestax-mcp/data/components/Grid.json
+++ b/bestax-mcp/data/components/Grid.json
@@ -3,7 +3,7 @@
   "kind": "component",
   "category": "grid",
   "slug": "grid/grid",
-  "docsUrl": "https://bestax.io/docs/api/grid/grid",
+  "docsUrl": "https://bestax.io/docs/api/grid",
   "examples": [
     {
       "title": "Smart Grid",

--- a/bestax-mcp/data/skills.json
+++ b/bestax-mcp/data/skills.json
@@ -10,7 +10,7 @@
         {
           "id": "component-catalog",
           "file": "references/component-catalog.md",
-          "bytes": 17442
+          "bytes": 17429
         },
         {
           "id": "library-contributor",
@@ -99,7 +99,7 @@
         {
           "id": "unmappables",
           "file": "references/unmappables.md",
-          "bytes": 4866
+          "bytes": 4861
         }
       ],
       "examples": []

--- a/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/todos-unmappable.output.tsx
+++ b/bestax-migrate/src/sources/react-bulma-components/__testfixtures__/todos-unmappable.output.tsx
@@ -3,7 +3,7 @@ import { Box } from "@allxsmith/bestax-bulma";
 import { Element, Tile } from 'react-bulma-components';
 
 // TODO(bestax-migrate): `Element` — no generic Element in bestax-bulma; use a semantic component (Block, Box, …) with helper props, or plain JSX with classNames — see https://bestax.io/docs/api/helpers/usebulmaclasses
-// TODO(bestax-migrate): `Tile` — Bulma v1 replaced tiles with the Grid/Cell components — see https://bestax.io/docs/api/grid/grid and the migration guide https://bestax.io/docs/guides/getting-started/migration/bulma-0-9-to-1
+// TODO(bestax-migrate): `Tile` — Bulma v1 replaced tiles with the Grid/Cell components — see https://bestax.io/docs/api/grid and the migration guide https://bestax.io/docs/guides/getting-started/migration/bulma-0-9-to-1
 // TODO(bestax-migrate): `colorVariant` — no direct equivalent; use isLight (Button/Notification) or a color shade like textColor='primary-dark'
 export const Legacy = ({ align }: { align: 'left' | 'right' }) => (
   <div>

--- a/bestax-migrate/src/sources/react-bulma-components/mapping.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/mapping.ts
@@ -780,7 +780,7 @@ export const MAPPING: Record<string, ComponentMapping> = {
   },
   Tile: {
     status: 'todo',
-    todo: `Bulma v1 replaced tiles with the Grid/Cell components — see ${DOCS}/api/grid/grid and the migration guide ${DOCS}/guides/getting-started/migration/bulma-0-9-to-1`,
+    todo: `Bulma v1 replaced tiles with the Grid/Cell components — see ${DOCS}/api/grid and the migration guide ${DOCS}/guides/getting-started/migration/bulma-0-9-to-1`,
   },
 };
 

--- a/create-bestax/CLAUDE.md
+++ b/create-bestax/CLAUDE.md
@@ -29,6 +29,14 @@ path (`-y` + flags, no TTY) must never hang or regress (#192).
   `SKILL_ROSTERS` in `scripts/check-conformance.mjs` is the authoritative list, and its failure
   names each file you missed. **Never edit the bundled copy** — change `skills/` at the repo
   root; the build re-syncs.
+- **A correction to a skill's _content_ does not reach `npm create bestax` until this
+  package itself releases.** `release.config.js` refuses every commit scoped to something
+  else (`{ scope: '!(create-bestax)', release: false }`), and the bundled copy under
+  `templates/skills` is a gitignored build artifact, so it carries no tracked diff that
+  could trigger one. A fix landed as `fix(bestax-migrate)` therefore ships to that CLI's
+  users and to the MCP server while scaffolded apps keep the old text until an unrelated
+  release happens by. When a `skills/` change corrects something users would otherwise
+  keep receiving, land a `fix(create-bestax)` commit with it (#597).
 - The `CLAUDE_MD` template in `constants.ts` is what every generated app tells its AI agents.
   When library conventions, skills, or the canonical docs entrypoint change (#203), check
   whether this template must change too.

--- a/create-bestax/CLAUDE.md
+++ b/create-bestax/CLAUDE.md
@@ -34,8 +34,8 @@ path (`-y` + flags, no TTY) must never hang or regress (#192).
   else (`{ scope: '!(create-bestax)', release: false }`), and the bundled copy under
   `templates/skills` is a gitignored build artifact, so it carries no tracked diff that
   could trigger one. A fix landed as `fix(bestax-migrate)` therefore ships to that CLI's
-  users and to the MCP server while scaffolded apps keep the old text until an unrelated
-  release happens by. When a `skills/` change corrects something users would otherwise
+  users and to the MCP server while scaffolded apps keep the old text until some unrelated
+  create-bestax release comes along. When a `skills/` change corrects something users would otherwise
   keep receiving, land a `fix(create-bestax)` commit with it (#597).
 - The `CLAUDE_MD` template in `constants.ts` is what every generated app tells its AI agents.
   When library conventions, skills, or the canonical docs entrypoint change (#203), check

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -3374,12 +3374,15 @@ export function isSkippedDocsUrlPath(rel) {
  */
 export function docsUrlViolations(rel, src) {
   const violations = [];
-  const re = /bestax\.io\/docs\/api\/([a-z0-9-]+)\/\1(?![a-z0-9-])/g;
+  // `<x>/<x>`, plus the index/README folder-index forms Docusaurus
+  // collapses the same way.
+  const re =
+    /bestax\.io\/docs\/api\/([a-z0-9-]+)\/(\1|index|readme)(?![a-z0-9-])/gi;
   src.split(/\r?\n/).forEach((line, i) => {
     for (const m of line.matchAll(re)) {
       violations.push(
-        `${rel}:${i + 1} links https://bestax.io/docs/api/${m[1]}/${m[1]}, ` +
-          `which 404s: Docusaurus serves docs/docs/api/${m[1]}/${m[1]}.md at ` +
+        `${rel}:${i + 1} links https://bestax.io/docs/api/${m[1]}/${m[2]}, ` +
+          `which 404s: Docusaurus serves docs/docs/api/${m[1]}/${m[2]}.md at ` +
           `/docs/api/${m[1]}. Drop the repeated segment. If this file is ` +
           `generated, fix it via scripts/lib/docs-url.mjs and re-run \`pnpm gen\`.`
       );

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -56,7 +56,7 @@
  *                        (templates, flavors, icons, sources, css modes, PMs)
  */
 import { readFile, readdir, writeFile, access } from 'node:fs/promises';
-import { join, relative, dirname, isAbsolute } from 'node:path';
+import { join, relative, dirname, isAbsolute, extname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 // The registration parser lives in lib/ so the API-docs generator shares it —
@@ -3326,18 +3326,34 @@ export async function checkTelemetryAllowlists() {
  * hand-written copies. The pattern is structural rather than a list of the two
  * pages that qualify today, so a future one is covered on arrival.
  */
-// Extensions that can carry a published URL. Everything else (lockfiles,
-// images, SCSS) either cannot hold one or is not a surface users read.
-const DOCS_URL_EXTS = [
-  '.md',
-  '.mdx',
-  '.ts',
-  '.tsx',
-  '.js',
-  '.mjs',
-  '.json',
-  '.txt',
-];
+// Inverted deliberately. An allowlist of "extensions that can carry a URL"
+// was wrong twice: it missed package READMEs and then .jsx, which
+// create-bestax ships as a scaffold template. Anything that is not a known
+// binary is text a URL can hide in, so the rule scans it.
+const DOCS_URL_BINARY_EXTS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.icns',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.eot',
+  '.pdf',
+  '.mp4',
+  '.webm',
+  '.mov',
+  '.zip',
+  '.gz',
+  '.tgz',
+  '.br',
+  '.node',
+  '.wasm',
+]);
 
 // Build output and vendored trees. `bestax-mcp/data/skills` and
 // `create-bestax/templates/skills` are gitignored copies of `skills/`, so the
@@ -3411,7 +3427,7 @@ async function docsUrlFiles(dir, root, out = []) {
       if (isSkippedDocsUrlPath(rel)) continue;
       await docsUrlFiles(full, root, out);
     } else if (
-      DOCS_URL_EXTS.some(ext => entry.name.endsWith(ext)) &&
+      !DOCS_URL_BINARY_EXTS.has(extname(entry.name).toLowerCase()) &&
       !isSkippedDocsUrlPath(rel)
     ) {
       out.push(rel);

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -38,10 +38,10 @@
  *                        package that actually releases (#536)
  *   style-mapping-sync   the inline-style → helper-prop mapping (#350) says
  *                        the same thing in all three deliberate copies
- *   docs-api-urls        no absolute docs URL repeats a path segment, which
- *                        404s because Docusaurus collapses <x>/<x>.md (#597)
  *                        (CLAUDE_MD template + both JSX-generating skills),
  *                        and names only props that really exist
+ *   docs-api-urls        no absolute docs URL repeats a path segment, which
+ *                        404s because Docusaurus collapses <x>/<x>.md (#597)
  *   publishable-manifests  no published package ships a specifier consumers
  *                        cannot resolve (#412). Which packages publish with
  *                        `pnpm publish` is declared, not inferred (#436,
@@ -3326,56 +3326,97 @@ export async function checkTelemetryAllowlists() {
  * hand-written copies. The pattern is structural rather than a list of the two
  * pages that qualify today, so a future one is covered on arrival.
  */
-const DOCS_URL_ROOTS = [
-  ['README.md', null],
-  ['skills', '.md'],
-  ['bestax-migrate/src', '.ts'],
-  ['bestax-mcp/data', '.json'],
-  ['docs/docs', '.md'],
+// Extensions that can carry a published URL. Everything else (lockfiles,
+// images, SCSS) either cannot hold one or is not a surface users read.
+const DOCS_URL_EXTS = [
+  '.md',
+  '.mdx',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.mjs',
+  '.json',
+  '.txt',
 ];
 
-// Synced copies of `skills/`, both gitignored build artifacts. The source they
-// are copied from is scanned instead, so a hit here would only be a duplicate.
-const DOCS_URL_SKIP = [
+// Build output and vendored trees. `bestax-mcp/data/skills` and
+// `create-bestax/templates/skills` are gitignored copies of `skills/`, so the
+// source is scanned and the artifact skipped rather than reported twice.
+const DOCS_URL_EXCLUDED_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.turbo',
+  '.e2e-tmp',
+  'dist',
+  'build',
+  'coverage',
+  'storybook-static',
+]);
+const DOCS_URL_SKIP_PATHS = [
   'bestax-mcp/data/skills',
   'create-bestax/templates/skills',
+  // This rule's own failing-case fixtures. A detector's test has to contain
+  // the string it detects, so scanning it would make the suite unrunnable.
+  'scripts/docs-api-urls.test.mjs',
 ];
 
-async function checkDocsApiUrls() {
+/** True for a repo-relative path whose URLs are a copy of another file's. */
+export function isSkippedDocsUrlPath(rel) {
+  return DOCS_URL_SKIP_PATHS.some(
+    skip => rel === skip || rel.startsWith(`${skip}/`)
+  );
+}
+
+/**
+ * Violations for one file. Exported so the failing case has real coverage: the
+ * tree is clean by construction, so without this the rule's own violation
+ * branch would never execute in CI and could rot into a no-op.
+ */
+export function docsUrlViolations(rel, src) {
   const violations = [];
-  for (const [root, ext] of DOCS_URL_ROOTS) {
-    const abs = join(REPO, root);
-    let files;
-    if (ext === null) {
-      files = [abs];
-    } else {
-      try {
-        files = await walk(abs, ext);
-      } catch {
-        continue; // a root that does not exist is not a violation
-      }
+  const re = /bestax\.io\/docs\/api\/([a-z0-9-]+)\/\1(?![a-z0-9-])/g;
+  src.split(/\r?\n/).forEach((line, i) => {
+    for (const m of line.matchAll(re)) {
+      violations.push(
+        `${rel}:${i + 1} links https://bestax.io/docs/api/${m[1]}/${m[1]}, ` +
+          `which 404s: Docusaurus serves docs/docs/api/${m[1]}/${m[1]}.md at ` +
+          `/docs/api/${m[1]}. Drop the repeated segment. If this file is ` +
+          `generated, fix it via scripts/lib/docs-url.mjs and re-run \`pnpm gen\`.`
+      );
     }
-    for (const file of files) {
-      const rel = relative(REPO, file).split('\\').join('/');
-      if (DOCS_URL_SKIP.some(skip => rel.startsWith(`${skip}/`))) continue;
-      let src;
-      try {
-        src = await readFile(file, 'utf8');
-      } catch {
-        continue;
-      }
-      const re = /bestax\.io\/docs\/api\/([a-z0-9-]+)\/\1(?![a-z0-9-])/g;
-      src.split(/\r?\n/).forEach((line, i) => {
-        for (const m of line.matchAll(re)) {
-          violations.push(
-            `${rel}:${i + 1} links https://bestax.io/docs/api/${m[1]}/${m[1]}, ` +
-              `which 404s: Docusaurus serves docs/docs/api/${m[1]}/${m[1]}.md at ` +
-              `/docs/api/${m[1]}. Drop the repeated segment. If this file is ` +
-              `generated, fix it via scripts/lib/docs-url.mjs and re-run \`pnpm gen\`.`
-          );
-        }
-      });
+  });
+  return violations;
+}
+
+async function docsUrlFiles(dir, root, out = []) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') && entry.name !== '.github') continue;
+    const full = join(dir, entry.name);
+    const rel = relative(root, full).split('\\').join('/');
+    if (entry.isDirectory()) {
+      if (DOCS_URL_EXCLUDED_DIRS.has(entry.name)) continue;
+      if (isSkippedDocsUrlPath(rel)) continue;
+      await docsUrlFiles(full, root, out);
+    } else if (
+      DOCS_URL_EXTS.some(ext => entry.name.endsWith(ext)) &&
+      !isSkippedDocsUrlPath(rel)
+    ) {
+      out.push(rel);
     }
+  }
+  return out;
+}
+
+async function checkDocsApiUrls(root = REPO) {
+  const violations = [];
+  for (const rel of await docsUrlFiles(root, root)) {
+    let src;
+    try {
+      src = await readFile(join(root, rel), 'utf8');
+    } catch {
+      continue;
+    }
+    violations.push(...docsUrlViolations(rel, src));
   }
   return violations;
 }

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -3377,13 +3377,16 @@ export function docsUrlViolations(rel, src) {
   // The leading lookbehind pins the host: without it `notbestax.io` matches
   // and gets reported as a broken bestax.io link. A lookbehind rather than a
   // literal `https://` so the bare and http forms are still caught.
+  // A single terminal slash is allowed before the boundary check:
+  // .../grid/grid/ is just as dead, and rejecting it let a hand-written
+  // variant walk past the guard.
   // Mirror docsRoute exactly: the collapsing segment must END the path, and
   // it may sit under any number of category segments (form/datetime/... is a
   // live nested category). Anchoring to the first segment after /api both
   // missed real nested collapses and flagged valid paths like /api/a/a/card,
   // where the repeat is not trailing.
   const re =
-    /(?<![a-z0-9.-])bestax\.io\/docs\/api\/((?:[a-z0-9-]+\/)*?)([a-z0-9-]+)\/(\2|index|readme)(?![a-z0-9\-/])/gi;
+    /(?<![a-z0-9.-])bestax\.io\/docs\/api\/((?:[a-z0-9-]+\/)*?)([a-z0-9-]+)\/(\2|index|readme)\/?(?![a-z0-9\-/])/gi;
   src.split(/\r?\n/).forEach((line, i) => {
     for (const m of line.matchAll(re)) {
       violations.push(

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -3374,13 +3374,16 @@ export function isSkippedDocsUrlPath(rel) {
  */
 export function docsUrlViolations(rel, src) {
   const violations = [];
+  // The leading lookbehind pins the host: without it `notbestax.io` matches
+  // and gets reported as a broken bestax.io link. A lookbehind rather than a
+  // literal `https://` so the bare and http forms are still caught.
   // Mirror docsRoute exactly: the collapsing segment must END the path, and
   // it may sit under any number of category segments (form/datetime/... is a
   // live nested category). Anchoring to the first segment after /api both
   // missed real nested collapses and flagged valid paths like /api/a/a/card,
   // where the repeat is not trailing.
   const re =
-    /bestax\.io\/docs\/api\/((?:[a-z0-9-]+\/)*?)([a-z0-9-]+)\/(\2|index|readme)(?![a-z0-9\-/])/gi;
+    /(?<![a-z0-9.-])bestax\.io\/docs\/api\/((?:[a-z0-9-]+\/)*?)([a-z0-9-]+)\/(\2|index|readme)(?![a-z0-9\-/])/gi;
   src.split(/\r?\n/).forEach((line, i) => {
     for (const m of line.matchAll(re)) {
       violations.push(

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -3358,11 +3358,21 @@ const DOCS_URL_BINARY_EXTS = new Set([
 // Build output and vendored trees. `bestax-mcp/data/skills` and
 // `create-bestax/templates/skills` are gitignored copies of `skills/`, so the
 // source is scanned and the artifact skipped rather than reported twice.
+// Named generated and vendored trees only. Hidden directories are NOT skipped
+// as a class: .husky, .github, .vscode and bulma-ui/.storybook are tracked
+// source a URL can live in, so a blanket dot-skip left real holes.
+// `.claude` is excluded because it is untracked and holds whole worktree
+// copies of this repo, which would report stale findings from another branch.
 const DOCS_URL_EXCLUDED_DIRS = new Set([
   'node_modules',
   '.git',
   '.turbo',
   '.e2e-tmp',
+  '.docusaurus',
+  '.cache',
+  '.next',
+  '.claude',
+  '.sync-skills',
   'dist',
   'build',
   'coverage',
@@ -3419,7 +3429,6 @@ export function docsUrlViolations(rel, src) {
 
 async function docsUrlFiles(dir, root, out = []) {
   for (const entry of await readdir(dir, { withFileTypes: true })) {
-    if (entry.name.startsWith('.') && entry.name !== '.github') continue;
     const full = join(dir, entry.name);
     const rel = relative(root, full).split('\\').join('/');
     if (entry.isDirectory()) {

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -3374,17 +3374,21 @@ export function isSkippedDocsUrlPath(rel) {
  */
 export function docsUrlViolations(rel, src) {
   const violations = [];
-  // `<x>/<x>`, plus the index/README folder-index forms Docusaurus
-  // collapses the same way.
+  // Mirror docsRoute exactly: the collapsing segment must END the path, and
+  // it may sit under any number of category segments (form/datetime/... is a
+  // live nested category). Anchoring to the first segment after /api both
+  // missed real nested collapses and flagged valid paths like /api/a/a/card,
+  // where the repeat is not trailing.
   const re =
-    /bestax\.io\/docs\/api\/([a-z0-9-]+)\/(\1|index|readme)(?![a-z0-9-])/gi;
+    /bestax\.io\/docs\/api\/((?:[a-z0-9-]+\/)*?)([a-z0-9-]+)\/(\2|index|readme)(?![a-z0-9\-/])/gi;
   src.split(/\r?\n/).forEach((line, i) => {
     for (const m of line.matchAll(re)) {
       violations.push(
-        `${rel}:${i + 1} links https://bestax.io/docs/api/${m[1]}/${m[2]}, ` +
-          `which 404s: Docusaurus serves docs/docs/api/${m[1]}/${m[2]}.md at ` +
-          `/docs/api/${m[1]}. Drop the repeated segment. If this file is ` +
-          `generated, fix it via scripts/lib/docs-url.mjs and re-run \`pnpm gen\`.`
+        `${rel}:${i + 1} links https://bestax.io/docs/api/${m[1]}${m[2]}/${m[3]}, ` +
+          `which 404s: Docusaurus serves ` +
+          `docs/docs/api/${m[1]}${m[2]}/${m[3]}.md at /docs/api/${m[1]}${m[2]}. ` +
+          `Drop the trailing segment. If this file is generated, fix it via ` +
+          `scripts/lib/docs-url.mjs and re-run \`pnpm gen\`.`
       );
     }
   });

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -38,6 +38,8 @@
  *                        package that actually releases (#536)
  *   style-mapping-sync   the inline-style → helper-prop mapping (#350) says
  *                        the same thing in all three deliberate copies
+ *   docs-api-urls        no absolute docs URL repeats a path segment, which
+ *                        404s because Docusaurus collapses <x>/<x>.md (#597)
  *                        (CLAUDE_MD template + both JSX-generating skills),
  *                        and names only props that really exist
  *   publishable-manifests  no published package ships a specifier consumers
@@ -3312,6 +3314,69 @@ export async function checkTelemetryAllowlists() {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * Docusaurus serves `docs/docs/api/<x>/<x>.md` at `/docs/api/<x>`: a page named
+ * after its own folder collapses. An absolute URL that repeats the segment is
+ * therefore a 404, and nothing else here would notice — `onBrokenLinks: 'throw'`
+ * only resolves links inside the site, and check:urls covers two files in
+ * bulma-ui. That is how dead Grid and Columns links shipped in the migrate
+ * skill, the component catalog, the MCP index and the README (#597).
+ *
+ * The generators collapse it now (scripts/lib/docs-url.mjs); this catches the
+ * hand-written copies. The pattern is structural rather than a list of the two
+ * pages that qualify today, so a future one is covered on arrival.
+ */
+const DOCS_URL_ROOTS = [
+  ['README.md', null],
+  ['skills', '.md'],
+  ['bestax-migrate/src', '.ts'],
+  ['bestax-mcp/data', '.json'],
+  ['docs/docs', '.md'],
+];
+
+// Synced copies of `skills/`, both gitignored build artifacts. The source they
+// are copied from is scanned instead, so a hit here would only be a duplicate.
+const DOCS_URL_SKIP = ['bestax-mcp/data/skills', 'create-bestax/templates/skills'];
+
+async function checkDocsApiUrls() {
+  const violations = [];
+  for (const [root, ext] of DOCS_URL_ROOTS) {
+    const abs = join(REPO, root);
+    let files;
+    if (ext === null) {
+      files = [abs];
+    } else {
+      try {
+        files = await walk(abs, ext);
+      } catch {
+        continue; // a root that does not exist is not a violation
+      }
+    }
+    for (const file of files) {
+      const rel = relative(REPO, file).split('\\').join('/');
+      if (DOCS_URL_SKIP.some(skip => rel.startsWith(`${skip}/`))) continue;
+      let src;
+      try {
+        src = await readFile(file, 'utf8');
+      } catch {
+        continue;
+      }
+      const re = /bestax\.io\/docs\/api\/([a-z0-9-]+)\/\1(?![a-z0-9-])/g;
+      src.split(/\r?\n/).forEach((line, i) => {
+        for (const m of line.matchAll(re)) {
+          violations.push(
+            `${rel}:${i + 1} links https://bestax.io/docs/api/${m[1]}/${m[1]}, ` +
+              `which 404s: Docusaurus serves docs/docs/api/${m[1]}/${m[1]}.md at ` +
+              `/docs/api/${m[1]}. Drop the repeated segment. If this file is ` +
+              `generated, fix it via scripts/lib/docs-url.mjs and re-run \`pnpm gen\`.`
+          );
+        }
+      });
+    }
+  }
+  return violations;
+}
+
 const CHECKS = {
   'listings-sync': checkListingsSync,
   'docs-sections': checkDocsSections,
@@ -3330,6 +3395,7 @@ const CHECKS = {
   'bypass-expiry': checkBypassExpiry,
   'telemetry-core': checkTelemetryCore,
   'telemetry-allowlists': checkTelemetryAllowlists,
+  'docs-api-urls': checkDocsApiUrls,
   'inline-style': null, // handled below (takes the flag)
 };
 

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -3336,7 +3336,10 @@ const DOCS_URL_ROOTS = [
 
 // Synced copies of `skills/`, both gitignored build artifacts. The source they
 // are copied from is scanned instead, so a hit here would only be a duplicate.
-const DOCS_URL_SKIP = ['bestax-mcp/data/skills', 'create-bestax/templates/skills'];
+const DOCS_URL_SKIP = [
+  'bestax-mcp/data/skills',
+  'create-bestax/templates/skills',
+];
 
 async function checkDocsApiUrls() {
   const violations = [];

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -3445,7 +3445,13 @@ async function docsUrlFiles(dir, root, out = []) {
   return out;
 }
 
-async function checkDocsApiUrls(root = REPO) {
+/**
+ * Exported with an injectable root so the traversal has end-to-end coverage.
+ * Testing only the detector left the walker able to regress to scanning zero
+ * files with this suite and the clean-tree run both green, which is the exact
+ * vacuous-guard failure this rule exists to prevent.
+ */
+export async function checkDocsApiUrls(root = REPO) {
   const violations = [];
   for (const rel of await docsUrlFiles(root, root)) {
     let src;

--- a/scripts/docs-api-urls.test.mjs
+++ b/scripts/docs-api-urls.test.mjs
@@ -59,6 +59,16 @@ test('finds every occurrence, including two on one line', () => {
   assert.equal(v.filter(m => m.startsWith('x.md:2 ')).length, 1);
 });
 
+test('flags the index and README folder-index forms too', () => {
+  const src = [
+    'https://bestax.io/docs/api/grid/index',
+    'https://bestax.io/docs/api/columns/README',
+  ].join('\n');
+  const v = docsUrlViolations('x.md', src);
+  assert.equal(v.length, 2);
+  assert.match(v[0], /\/docs\/api\/grid\b/);
+});
+
 test('skips the gitignored copies of skills/, and nothing else', () => {
   assert.ok(isSkippedDocsUrlPath('bestax-mcp/data/skills'));
   assert.ok(

--- a/scripts/docs-api-urls.test.mjs
+++ b/scripts/docs-api-urls.test.mjs
@@ -101,6 +101,28 @@ test('collapses only the trailing pair, agreeing with docsRoute', () => {
   assert.match(v[0], /at \/docs\/api\/grid\/grid\./);
 });
 
+test('does not fire on a host that merely ends with bestax.io', () => {
+  assert.deepEqual(
+    docsUrlViolations('x.md', 'https://notbestax.io/docs/api/grid/grid'),
+    []
+  );
+  assert.deepEqual(
+    docsUrlViolations('x.md', 'https://docs.bestax.io/docs/api/grid/grid'),
+    []
+  );
+});
+
+test('still catches the bare and http forms of the real host', () => {
+  assert.equal(
+    docsUrlViolations('x.md', 'http://bestax.io/docs/api/grid/grid').length,
+    1
+  );
+  assert.equal(
+    docsUrlViolations('x.md', 'see bestax.io/docs/api/grid/grid').length,
+    1
+  );
+});
+
 test('skips the gitignored copies of skills/, and nothing else', () => {
   assert.ok(isSkippedDocsUrlPath('bestax-mcp/data/skills'));
   assert.ok(

--- a/scripts/docs-api-urls.test.mjs
+++ b/scripts/docs-api-urls.test.mjs
@@ -9,7 +9,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
 import {
+  checkDocsApiUrls,
   docsUrlViolations,
   isSkippedDocsUrlPath,
 } from './check-conformance.mjs';
@@ -152,4 +157,32 @@ test('skips the gitignored copies of skills/, and nothing else', () => {
     isSkippedDocsUrlPath('bestax-mcp/data/components/Grid.json'),
     false
   );
+});
+
+test('walks a real tree: reports violations and honours every exclusion', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'docs-api-urls-'));
+  const write = async (rel, body) => {
+    await mkdir(join(root, dirname(rel)), { recursive: true });
+    await writeFile(join(root, rel), body);
+  };
+  const dead = 'https://bestax.io/docs/api/grid/grid\n';
+
+  await write('README.md', dead);
+  await write('pkg/src/App.jsx', `// ${dead}`);
+  await write('pkg/ok.md', 'https://bestax.io/docs/api/grid\n');
+  await write('node_modules/dep/readme.md', dead);
+  await write('pkg/dist/bundle.js', dead);
+  await write('.claude/worktrees/other/README.md', dead);
+  await write('bestax-mcp/data/skills/s/SKILL.md', dead);
+  await write('assets/logo.png', dead);
+  await write('.storybook/preview.ts', dead);
+
+  const violations = await checkDocsApiUrls(root);
+  const files = violations.map(v => v.split(':')[0]).sort();
+
+  assert.deepEqual(files, [
+    '.storybook/preview.ts',
+    'README.md',
+    'pkg/src/App.jsx',
+  ]);
 });

--- a/scripts/docs-api-urls.test.mjs
+++ b/scripts/docs-api-urls.test.mjs
@@ -69,6 +69,38 @@ test('flags the index and README folder-index forms too', () => {
   assert.match(v[0], /\/docs\/api\/grid\b/);
 });
 
+test('matches the trailing pair under a nested category', () => {
+  const v = docsUrlViolations(
+    'x.md',
+    'https://bestax.io/docs/api/form/datetime/datetime'
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /at \/docs\/api\/form\/datetime\./);
+});
+
+test('leaves a nested path whose repeat is not trailing alone', () => {
+  assert.deepEqual(
+    docsUrlViolations('x.md', 'https://bestax.io/docs/api/a/a/card'),
+    []
+  );
+  assert.deepEqual(
+    docsUrlViolations(
+      'x.md',
+      'https://bestax.io/docs/api/form/datetime/dateinput'
+    ),
+    []
+  );
+});
+
+test('collapses only the trailing pair, agreeing with docsRoute', () => {
+  const v = docsUrlViolations(
+    'x.md',
+    'https://bestax.io/docs/api/grid/grid/grid'
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /at \/docs\/api\/grid\/grid\./);
+});
+
 test('skips the gitignored copies of skills/, and nothing else', () => {
   assert.ok(isSkippedDocsUrlPath('bestax-mcp/data/skills'));
   assert.ok(

--- a/scripts/docs-api-urls.test.mjs
+++ b/scripts/docs-api-urls.test.mjs
@@ -1,0 +1,76 @@
+/**
+ * Failing-case coverage for the `docs-api-urls` conformance rule.
+ *
+ * The tree is clean by construction, so a full run only ever exercises the
+ * passing branch: a broken regex, root list or skip condition would leave the
+ * guard vacuous while CI stayed green. These tests drive the violation branch
+ * directly, which is the only way the rule is known to still work.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  docsUrlViolations,
+  isSkippedDocsUrlPath,
+} from './check-conformance.mjs';
+
+test('flags a URL that repeats its path segment', () => {
+  const v = docsUrlViolations(
+    'README.md',
+    'see [Grid](https://bestax.io/docs/api/grid/grid) for more\n'
+  );
+  assert.equal(v.length, 1);
+  assert.match(v[0], /^README\.md:1 /);
+  assert.match(v[0], /404s/);
+  assert.match(v[0], /\/docs\/api\/grid\b/);
+});
+
+test('reports the line the URL is actually on', () => {
+  const src = ['one', 'two', 'https://bestax.io/docs/api/columns/columns'].join(
+    '\n'
+  );
+  const v = docsUrlViolations('a/b.md', src);
+  assert.equal(v.length, 1);
+  assert.match(v[0], /^a\/b\.md:3 /);
+});
+
+test('accepts the collapsed URL and other real pages', () => {
+  const src = [
+    'https://bestax.io/docs/api/grid',
+    'https://bestax.io/docs/api/columns',
+    'https://bestax.io/docs/api/components/card',
+    'https://bestax.io/docs/api/helpers/usebulmaclasses',
+  ].join('\n');
+  assert.deepEqual(docsUrlViolations('x.md', src), []);
+});
+
+test('does not fire on a segment that merely starts the same', () => {
+  const src = 'https://bestax.io/docs/api/grid/gridcell\n';
+  assert.deepEqual(docsUrlViolations('x.md', src), []);
+});
+
+test('finds every occurrence, including two on one line', () => {
+  const src =
+    'https://bestax.io/docs/api/grid/grid and https://bestax.io/docs/api/columns/columns\n' +
+    'https://bestax.io/docs/api/grid/grid\n';
+  const v = docsUrlViolations('x.md', src);
+  assert.equal(v.length, 3);
+  assert.equal(v.filter(m => m.startsWith('x.md:1 ')).length, 2);
+  assert.equal(v.filter(m => m.startsWith('x.md:2 ')).length, 1);
+});
+
+test('skips the gitignored copies of skills/, and nothing else', () => {
+  assert.ok(isSkippedDocsUrlPath('bestax-mcp/data/skills'));
+  assert.ok(
+    isSkippedDocsUrlPath('bestax-mcp/data/skills/bestax-migrate/SKILL.md')
+  );
+  assert.ok(
+    isSkippedDocsUrlPath('create-bestax/templates/skills/bestax-form/SKILL.md')
+  );
+  assert.ok(isSkippedDocsUrlPath('scripts/docs-api-urls.test.mjs'));
+  assert.equal(isSkippedDocsUrlPath('skills/bestax-migrate/SKILL.md'), false);
+  assert.equal(
+    isSkippedDocsUrlPath('bestax-mcp/data/components/Grid.json'),
+    false
+  );
+});

--- a/scripts/docs-api-urls.test.mjs
+++ b/scripts/docs-api-urls.test.mjs
@@ -123,6 +123,21 @@ test('still catches the bare and http forms of the real host', () => {
   );
 });
 
+test('catches the trailing-slash spelling, and still allows a valid one', () => {
+  assert.equal(
+    docsUrlViolations('x.md', 'https://bestax.io/docs/api/grid/grid/').length,
+    1
+  );
+  assert.equal(
+    docsUrlViolations('x.md', 'https://bestax.io/docs/api/grid/index/').length,
+    1
+  );
+  assert.deepEqual(
+    docsUrlViolations('x.md', 'https://bestax.io/docs/api/grid/'),
+    []
+  );
+});
+
 test('skips the gitignored copies of skills/, and nothing else', () => {
   assert.ok(isSkippedDocsUrlPath('bestax-mcp/data/skills'));
   assert.ok(

--- a/scripts/docs-url.test.mjs
+++ b/scripts/docs-url.test.mjs
@@ -19,6 +19,16 @@ test('collapses only the trailing pair, not repeats further up', () => {
   assert.equal(docsRoute('a/b/a'), 'a/b/a');
 });
 
+test('collapses the index and README folder-index forms', () => {
+  assert.equal(docsRoute('grid/index'), 'grid');
+  assert.equal(docsRoute('grid/README'), 'grid');
+  assert.equal(docsRoute('components/index'), 'components');
+});
+
+test('does not collapse index further up the path', () => {
+  assert.equal(docsRoute('index/card'), 'index/card');
+});
+
 test('handles degenerate input without throwing', () => {
   assert.equal(docsRoute('grid'), 'grid');
   assert.equal(docsRoute(''), '');

--- a/scripts/docs-url.test.mjs
+++ b/scripts/docs-url.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { docsRoute } from './lib/docs-url.mjs';
+
+test('collapses a page named after its own folder', () => {
+  assert.equal(docsRoute('grid/grid'), 'grid');
+  assert.equal(docsRoute('columns/columns'), 'columns');
+});
+
+test('leaves every other page alone', () => {
+  assert.equal(docsRoute('components/card'), 'components/card');
+  assert.equal(docsRoute('elements/button'), 'elements/button');
+  assert.equal(docsRoute('helpers/config'), 'helpers/config');
+});
+
+test('collapses only the trailing pair, not repeats further up', () => {
+  assert.equal(docsRoute('grid/grid/grid'), 'grid/grid');
+  assert.equal(docsRoute('a/b/a'), 'a/b/a');
+});
+
+test('handles degenerate input without throwing', () => {
+  assert.equal(docsRoute('grid'), 'grid');
+  assert.equal(docsRoute(''), '');
+  assert.equal(docsRoute('grid/'), 'grid');
+});

--- a/scripts/gen-component-catalog.mjs
+++ b/scripts/gen-component-catalog.mjs
@@ -30,6 +30,8 @@ import { readFile, readdir, writeFile } from 'node:fs/promises';
 import { join, relative, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { docsRoute } from './lib/docs-url.mjs';
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..');
 const API_DIR = join(REPO, 'docs', 'docs', 'api');
@@ -214,7 +216,7 @@ async function main() {
     total += rows.length;
     const lines = rows.map(
       r =>
-        `- [${r.title}](${DOCS_BASE}/${r.slug})` +
+        `- [${r.title}](${DOCS_BASE}/${docsRoute(r.slug)})` +
         (r.purpose ? ` — ${r.purpose}` : '')
     );
     sections.push(`## ${label}\n\n${lines.join('\n')}`);

--- a/scripts/gen-mcp-index.mjs
+++ b/scripts/gen-mcp-index.mjs
@@ -43,6 +43,7 @@ import { createRequire } from 'node:module';
 
 import { sectionSpans, sectionBody, firstSentence } from './lib/api-page.mjs';
 import { readSkillNames } from './lib/skills.mjs';
+import { docsRoute } from './lib/docs-url.mjs';
 import { extractComponent, varRootCandidates } from './lib/props-extract.mjs';
 import { componentVars } from './lib/scss-vars.mjs';
 import {
@@ -469,7 +470,9 @@ export async function build() {
       const find = re => sections.find(s => re.test(s.heading));
       const purpose = purposeOf(fm, sections, lines);
       const slug = relPath.replace(/\.md$/, '');
-      const docsUrl = `${DOCS_BASE}/api/${slug}`;
+      // `slug` stays the file-path identity; the URL takes the route
+      // Docusaurus actually serves, which collapses `grid/grid` (#597).
+      const docsUrl = `${DOCS_BASE}/api/${docsRoute(slug)}`;
 
       // `helpers/` documents hooks and utilities: four of its six pages use
       // `## API` with a signature block and have no props interface at all.

--- a/scripts/lib/docs-url.mjs
+++ b/scripts/lib/docs-url.mjs
@@ -1,0 +1,32 @@
+/**
+ * Docusaurus publishes `<folder>/<folder>.md` as that folder's own route: the
+ * duplicated trailing segment collapses, so `docs/api/grid/grid.md` serves at
+ * `/docs/api/grid` and never at `/docs/api/grid/grid`.
+ *
+ * Generators that build a docs URL out of a file path have to collapse it too,
+ * or they emit a 404 for exactly the pages named after their category. Two
+ * pages qualify today (`grid`, `columns`), and both shipped dead links into the
+ * MCP index, the component catalog and the migrate skill before #597.
+ *
+ * The site's own `onBrokenLinks: 'throw'` cannot catch this: these URLs are
+ * absolute and live in other packages, so nothing resolves them at build time.
+ */
+
+/**
+ * Collapse a duplicated trailing path segment.
+ *
+ *   docsRoute('grid/grid')       // 'grid'
+ *   docsRoute('components/card') // 'components/card'
+ *
+ * Only the last pair collapses, matching Docusaurus: the rule is about a file
+ * named after its own directory, not about repeated names further up the path.
+ *
+ * @param {string} slug Route-ish path with no extension, `/`-separated.
+ * @returns {string} The path Docusaurus actually serves.
+ */
+export function docsRoute(slug) {
+  const parts = String(slug).split('/').filter(Boolean);
+  const n = parts.length;
+  if (n >= 2 && parts[n - 1] === parts[n - 2]) parts.pop();
+  return parts.join('/');
+}

--- a/scripts/lib/docs-url.mjs
+++ b/scripts/lib/docs-url.mjs
@@ -12,14 +12,23 @@
  * absolute and live in other packages, so nothing resolves them at build time.
  */
 
+// Docusaurus treats three filenames as a folder's index: `<folder>.md`,
+// `index.md` and `README.md`. All three serve at the folder's own route.
+// Verified locally for the index form: docs/docs/guides/llms/index.md builds to
+// build/docs/guides/llms.html with no nested index.html.
+const FOLDER_INDEX_NAMES = new Set(['index', 'readme']);
+
 /**
- * Collapse a duplicated trailing path segment.
+ * Collapse a trailing folder-index segment.
  *
  *   docsRoute('grid/grid')       // 'grid'
+ *   docsRoute('grid/index')      // 'grid'
  *   docsRoute('components/card') // 'components/card'
  *
- * Only the last pair collapses, matching Docusaurus: the rule is about a file
- * named after its own directory, not about repeated names further up the path.
+ * Only the last segment collapses, matching Docusaurus: the rule is about a
+ * file that indexes its own directory, not about repeated names further up the
+ * path. No API page uses the index or README form today, so that half is
+ * covering the shape rather than a live URL.
  *
  * @param {string} slug Route-ish path with no extension, `/`-separated.
  * @returns {string} The path Docusaurus actually serves.
@@ -27,6 +36,10 @@
 export function docsRoute(slug) {
   const parts = String(slug).split('/').filter(Boolean);
   const n = parts.length;
-  if (n >= 2 && parts[n - 1] === parts[n - 2]) parts.pop();
+  if (n < 2) return parts.join('/');
+  const last = parts[n - 1];
+  if (last === parts[n - 2] || FOLDER_INDEX_NAMES.has(last.toLowerCase())) {
+    parts.pop();
+  }
   return parts.join('/');
 }

--- a/skills/bestax-custom-component/references/component-catalog.md
+++ b/skills/bestax-custom-component/references/component-catalog.md
@@ -123,12 +123,12 @@ component is guaranteed to appear (the generator fails if one lacks an API page)
 ## Columns
 
 - [Column](https://bestax.io/docs/api/columns/column) — The `Column` component provides a single responsive layout column using Bulma's flexbox-based column system.
-- [Columns](https://bestax.io/docs/api/columns/columns) — The `Columns` component provides Bulma's flexible, responsive grid container for aligning and distributing [`Column`](./column.md) components.
+- [Columns](https://bestax.io/docs/api/columns) — The `Columns` component provides Bulma's flexible, responsive grid container for aligning and distributing [`Column`](./column.md) components.
 
 ## Grid
 
 - [Cell](https://bestax.io/docs/api/grid/cell) — The `Cell` component provides a single Bulma grid cell for use inside the [`Grid`](./grid.md) component.
-- [Grid](https://bestax.io/docs/api/grid/grid) — The `Grid` component provides Bulma's advanced CSS Grid layout for complex, modern layouts.
+- [Grid](https://bestax.io/docs/api/grid) — The `Grid` component provides Bulma's advanced CSS Grid layout for complex, modern layouts.
 
 ## Layout
 

--- a/skills/bestax-migrate/references/unmappables.md
+++ b/skills/bestax-migrate/references/unmappables.md
@@ -32,7 +32,7 @@ matches the usage, or plain JSX with classes:
 ## `Tile` — Bulma v1 replaced tiles with Grid
 
 Convert ancestor/parent/child tile trees to `Grid`/`Cell` (docs:
-https://bestax.io/docs/api/grid/grid):
+https://bestax.io/docs/api/grid):
 
 ```tsx
 // Before


### PR DESCRIPTION
Closes #597.

`https://bestax.io/docs/api/grid/grid` and `https://bestax.io/docs/api/columns/columns` are 404s. Docusaurus publishes a page named after its own folder at the folder's route, so those two serve at `/docs/api/grid` and `/docs/api/columns`.

The one with user reach: every `bestax-migrate` run that touches a `Tile` wrote that dead link into the user's source as a `TODO(bestax-migrate)` comment and printed it again in the run report.

## Root cause, and why this is not two stale strings

Both generators built the URL straight from the file path (`gen-mcp-index.mjs:472`, `gen-component-catalog.mjs:217`), so every future page named after its category would inherit the bug. Fixed at the source: `docsRoute()` in the new `scripts/lib/docs-url.mjs` collapses the trailing folder-index segment, and both generators route through it. The MCP index's `slug` field is deliberately untouched, since that is the file-path identity rather than a route; only `docsUrl` changes.

`docsRoute` handles all three filenames Docusaurus treats as a folder index: `<folder>.md`, `index.md` and `README.md`. Only the first has a live instance today; the other two are covered so the next one does not reintroduce the same silent 404. Verified the index form collapses by building: `docs/docs/guides/llms/index.md` emits `build/docs/guides/llms.html` with no nested `index.html`.

Three hand-written copies are corrected directly: the `Tile` hint in `mapping.ts`, the migrate skill's `unmappables.md`, and the README.

Not touched, and correct as they stand: the relative `../../../api/grid/grid.md` links in the docs migration guides. Docusaurus resolves a file reference to the real route and `onBrokenLinks: 'throw'` already validates them.

## Why nothing caught it, and what does now

`onBrokenLinks` only resolves links inside the docs site; these are absolute URLs in other packages. `check:conformance` matched no `bestax.io` URL at all, and `check:urls` covers two files in bulma-ui.

The new `docs-api-urls` conformance sub-check closes the class. It walks the repo with explicit build-output exclusions rather than an allowlist, and its detector mirrors `docsRoute` exactly: the collapsing segment must end the URL, it may sit under any number of category segments (`form/datetime/` is a live nested category), a terminal slash counts, and the host is pinned so `notbestax.io` is not misreported. `docsUrlViolations` and `isSkippedDocsUrlPath` are exported and covered directly, because the tree is clean by construction and CI would otherwise only ever run the passing branch.

## Scoping

Split so every affected package releases:

- `fix(bestax-migrate)` — the `Tile` hint and the skill reference, which change the CLI's user-facing output
- `fix(bestax-mcp)` — the generators and the regenerated index and catalog it ships
- `fix(create-bestax)` — the bundled migrate skill. This package only releases on its own scope (`{ scope: '!(create-bestax)', release: false }`) and the bundled copy is gitignored, so without this commit scaffolded apps would keep the dead link until an unrelated release. The gap is now documented in its sync rules.
- `ci` / `docs` / `test` — the guard, the README, and the regenerated fixture, none of which release

The synced copies under `bestax-mcp/data/skills/` and `create-bestax/templates/skills/` are gitignored build artifacts rebuilt from `skills/`; I confirmed both pick up the fix, and the conformance check skips them so the source is what gets scanned.

## Verification

- `pnpm all` green
- `pnpm check:conformance` green, including the new sub-check
- `pnpm gen:catalog:check` and `pnpm gen:mcp:check` green
- `node --test scripts/docs-url.test.mjs scripts/docs-api-urls.test.mjs` green
- `pnpm --filter bestax-migrate validate:corpus` green: 32 files, 31 transformed, 0 crashes, no unknown-component TODOs
- Zero occurrences of either dead URL remain anywhere in the tree

The `todos-unmappable` fixture output moved one line, regenerated by running the built transform over its input per the package's testing rules rather than hand-edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Columns and Grid documentation links to use the valid, shorter URLs.
  * Updated migration guidance and component catalog references to point to the corrected Grid and Columns pages.
  * Improved documentation link generation so future links match the routes served by the documentation site.

* **Bug Fixes**
  * Added validation to detect malformed documentation URLs before they are published.
  * Added coverage for valid, invalid, and edge-case documentation routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->