### PR TITLE
docs: point the X links at the correct handle

### DIFF
--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -5,7 +5,7 @@ asmith:
   image_url: https://github.com/allxsmith.png
   page: true
   socials:
-    x: asmith62378
+    x: allxsmith
     linkedin: allxsmith
     github: allxsmith
     newsletter: https://dev.to/allxsmith

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -254,7 +254,7 @@ const config = {
               },
               {
                 label: 'X',
-                href: 'https://x.com/asmith62378',
+                href: 'https://x.com/allxsmith',
               },
             ],
           },


### PR DESCRIPTION
Fixes #599.

Both X profile links on the docs site pointed at `asmith62378`. The correct handle is
`allxsmith` — https://x.com/allxsmith.

| File | What it drives |
| --- | --- |
| `docs/docusaurus.config.js` | The **X** entry in the footer's Community column |
| `docs/blog/authors.yml` | The blog author card's social link — visible on every post and on the author page (`page: true`) |

`authors.yml` already used `allxsmith` for `url`, `image_url`, `linkedin`, `github` and the
dev.to newsletter, so the `x:` value was the lone outlier rather than a second account.

**Deliberately untouched:** `grep -rn asmith62378` also matches four `release.config.js`
files, but those hold the author **email** for the npm release-notes template, not an X
handle. Changing them would be wrong and release-affecting.

Docs-only; two one-line changes. `pnpm check:conformance` and `prettier --check` pass locally.
