### PR TITLE
docs: add the OpenSSF Best Practices badge, and ship it to the four packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/@allxsmith/bestax-bulma)](https://socket.dev/npm/package/@allxsmith/bestax-bulma/overview)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361/badge)](https://www.bestpractices.dev/projects/14361)
 [![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma#provenance)
 [![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,13 @@ Measures active in this repository and its release pipeline:
   `codeql.yml` in `.github/workflows/`.
 - **OpenSSF Scorecard** — `.github/workflows/scorecard.yml` scores this
   repository's supply-chain posture weekly and publishes the result publicly.
+- **OpenSSF Best Practices** — bestax holds the OpenSSF (formerly CII) Best
+  Practices badge at the **passing** level
+  ([project 14361](https://www.bestpractices.dev/projects/14361)). The
+  questionnaire covers the documented contribution process, vulnerability
+  reporting, automated testing, static analysis, secure delivery, and release
+  practice; each answer is public and cites the evidence in this repository.
+  Where Scorecard measures repository mechanics, this covers process.
 - **Dependency review** — a workflow blocks PRs that introduce dependencies
   with known advisories.
 - **Dependabot** — weekly, grouped dependency update PRs.

--- a/bestax-mcp/README.md
+++ b/bestax-mcp/README.md
@@ -1,5 +1,14 @@
 # bestax-mcp
 
+[![npm version](https://img.shields.io/npm/v/bestax-mcp.svg)](https://www.npmjs.com/package/bestax-mcp)
+[![npm downloads](https://img.shields.io/npm/dm/bestax-mcp.svg)](https://www.npmjs.com/package/bestax-mcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/bestax-mcp)](https://socket.dev/npm/package/bestax-mcp/overview)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361/badge)](https://www.bestpractices.dev/projects/14361)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/bestax-mcp#provenance)
+[![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
+
 The official [MCP](https://modelcontextprotocol.io) server for
 [`@allxsmith/bestax-bulma`](https://www.npmjs.com/package/@allxsmith/bestax-bulma) —
 React components for Bulma v1.

--- a/bestax-mcp/data/catalog.json
+++ b/bestax-mcp/data/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generatedFrom": {
     "package": "@allxsmith/bestax-bulma",
-    "version": "5.11.4"
+    "version": "5.11.5"
   },
   "docsBase": "https://bestax.io/docs",
   "categories": [

--- a/bestax-migrate/README.md
+++ b/bestax-migrate/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/bestax-migrate)](https://socket.dev/npm/package/bestax-migrate/overview)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361/badge)](https://www.bestpractices.dev/projects/14361)
 [![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/bestax-migrate#provenance)
 [![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
 

--- a/bulma-ui/README.md
+++ b/bulma-ui/README.md
@@ -9,6 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/@allxsmith/bestax-bulma)](https://socket.dev/npm/package/@allxsmith/bestax-bulma/overview)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361/badge)](https://www.bestpractices.dev/projects/14361)
 [![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/@allxsmith/bestax-bulma#provenance)
 [![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
 

--- a/create-bestax/README.md
+++ b/create-bestax/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/create-bestax)](https://socket.dev/npm/package/create-bestax/overview)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/allxsmith/bestax/badge)](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361/badge)](https://www.bestpractices.dev/projects/14361)
 [![npm provenance](https://img.shields.io/badge/npm-provenance-3fb950.svg)](https://www.npmjs.com/package/create-bestax#provenance)
 [![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/allxsmith/bestax/blob/main/SECURITY.md)
 

--- a/docs/docs/guides/security.md
+++ b/docs/docs/guides/security.md
@@ -71,6 +71,30 @@ The monorepo applies defense-in-depth against supply-chain attacks:
   gate blocks PRs that introduce dependencies with known advisories; grouped
   Dependabot PRs keep the tree current on a weekly cadence.
 
+## OpenSSF assessments
+
+Two OpenSSF programs cover this repository, and both publish their results
+publicly:
+
+- **[OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361)** —
+  bestax holds the **passing** badge. The questionnaire behind it covers the
+  documented contribution process, vulnerability reporting, automated testing,
+  static analysis, secure delivery, and unique versioning with release notes.
+  Every answer is public and cites the evidence in this repository, so each
+  claim can be checked against what is actually here rather than taken on
+  faith.
+- **[OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/allxsmith/bestax)** —
+  an automated scan that runs weekly from
+  [`.github/workflows/scorecard.yml`](https://github.com/allxsmith/bestax/blob/main/.github/workflows/scorecard.yml)
+  and publishes to the public viewer. It reads branch protection, pinned
+  dependencies, token permissions, code review, signed releases, and known
+  vulnerabilities straight out of the repository and scores them.
+
+Both badges are at the top of the
+[README](https://github.com/allxsmith/bestax#bestax) and of the README of each
+published package. The npm package pages pick them up on each package's next
+release.
+
 ## Reporting a vulnerability
 
 Please report privately — don't open a public issue:


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> **Merge this with "Create a merge commit" or "Rebase and merge" — not "Squash and merge".**
>
> This PR carries four separately-scoped `fix()` commits so each published package cuts its own patch release. A squash collapses them into a single commit with a single scope (`squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`), and because this PR's title is a `docs:` header, squashing would produce **zero** releases and the badge would never reach npmjs.com.

## Description

bestax holds the [OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361) badge at the **passing** level (project 14361). This publishes it, gives it a home in the security documentation, and ships it to the four npm package pages.

**Documentation (`docs:`, no release)**

- Badge added to the root README badge block, immediately after the OpenSSF Scorecard badge so the two OpenSSF badges sit together.
- `SECURITY.md` gains a bullet in the Supply-Chain Security list, directly after the Scorecard bullet.
- `docs/docs/guides/security.md` gains a new `## OpenSSF assessments` section between "How the repository is protected" and "Reporting a vulnerability". It covers **both** OpenSSF programs — Scorecard was previously absent from the docs site entirely, existing only as a badge, a workflow, and one line in `SECURITY.md`. This section is the URL to hand an outside security reviewer.

**Package releases (four `fix()` commits, four patch releases)**

| Commit | Package | Why it releases |
| --- | --- | --- |
| `fix(bulma-ui)` | `@allxsmith/bestax-bulma` | badge in the package README |
| `fix(create-bestax)` | `create-bestax` | badge in the package README |
| `fix(bestax-migrate)` | `bestax-migrate` | badge in the package README |
| `fix(bestax-mcp)` | `bestax-mcp` | badge block in the package README |

npm renders each README from the latest published tarball, so a release is the only way the badge reaches the package pages. `bestax-mcp` had no badge block at all — it was the only published package without one — and now carries the same row as its siblings.

## The MCP index: resolved on main, not here

`fix(bestax-mcp)` originally also carried a regeneration of `bestax-mcp/data/catalog.json`. **That is now a no-op** — `main` restamped the index independently in `e8fe948`, to the same value, so after merging main this branch no longer changes that file. The effective diff is pure markdown.

Recording what happened, because an earlier revision of this description got the cause wrong:

`chore(release): 5.11.5` bumped `bulma-ui/package.json` while `catalog.json` still recorded 5.11.4, and every PR building against main failed `gen:mcp:check` until it was restamped. It is **not** true that nothing regenerates the index on release: `ci.yml` has a "Regenerate the MCP index" step that runs last in the publish job, deliberately after every publish has succeeded, and commits the result. It worked — it just ran at the end of four sequential releases, leaving a window in which main was stale. The defect, if it is one, is the width of that window, not a missing mechanism.

`fix(bestax-mcp)` still earns its patch release on the README badge block alone: that package was the only published one with no badge block at all.

- [x] bulma-ui (`@allxsmith/bestax-bulma`)
- [x] create-bestax (`create-bestax`)
- [x] docs (`@allxsmith/bestax-docs`)
- [x] Other (please specify): `SECURITY.md`, root `README.md`, `bestax-migrate`, `bestax-mcp`

## Related Issue(s)

Closes #415

Refs #406 (Scorecard workflow), #407 (the Scorecard badge and README security sections this follows), #413 (the synced supply-chain blocks, deliberately untouched)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] Build tooling
- [x] Other (please describe): four scoped patch releases so the badge reaches the npm package pages

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, markdown plus one generated data file
- [x] I have added/updated documentation as needed
- [ ] I have updated Storybook stories as needed (bulma-ui) — n/a
- [x] My changes require a change to the documentation
- [x] All new and existing tests passed
- [ ] Any relevant dependencies are updated — n/a
- [ ] If this PR changes commands, conventions, or package structure, the affected `CLAUDE.md` files are updated — n/a, no command or convention changes

## Screenshots / Demos

The badge is live and renders `openssf best practices | passing`:

[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14361/badge)](https://www.bestpractices.dev/projects/14361)

## Additional Context

The four synced supply-chain blocks (README "Hardened by default", `llmsSecurityBlock` in `docs/docusaurus.config.js`, `bulma-ui/llms.txt`, `bulma-ui/AGENTS.md`, per #413) are deliberately **not** touched. That list is enforced technical controls, each verifiable by machine; a badge is a different kind of claim and would be the weakest line in it.

The unmet silver criteria are recorded on #415 rather than in the public docs.
