### PR TITLE
docs: document icon-only buttons in the Icons guide

### DIFF
--- a/docs/docs/guides/getting-started/alternative-icons.md
+++ b/docs/docs/guides/getting-started/alternative-icons.md
@@ -522,6 +522,26 @@ If you haven't started your project yet, `pnpm create bestax@latest` will instal
 
 ---
 
+## Icon-Only Buttons
+
+Toolbars and card actions often want a button whose whole label is an icon. Nest the `Icon` directly inside the `Button` — no wrapper element is needed, and the button's own padding keeps the glyph centred:
+
+```tsx live
+import { Button, Icon } from '@allxsmith/bestax-bulma';
+
+function IconOnlyExample() {
+  return (
+    <Button color="danger">
+      <Icon name="trash" />
+    </Button>
+  );
+}
+```
+
+This works the same way in every library on this page — swap the `library` prop and the icon `name` to match. See the [Icon API](/docs/api/elements/icon) for the full prop list.
+
+---
+
 ## Choosing the Right Icon Library
 
 | Library                   | Icons Count | File Size | Best For                        |


### PR DESCRIPTION
## Test PR — not for merge

This exists to drive a `claude-pr-loop` **`verify`** run so that job's egress can be measured for
#578. It is the one job of the six with no audit-mode measurement, because `verify` fires only
when a deep review files a blocking inline finding (#593), and every deep review since #577 merged
has returned zero blocking.

It will be closed unmerged and the branch deleted once the run is captured. Please don't merge it.

## What it changes

Adds a short "Icon-Only Buttons" subsection to the Icons guide, covering the
icon-inside-`Button` pattern the page did not show anywhere.

Refs #593, #578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating icon-only buttons.
  * Included a live example using icons directly within buttons.
  * Documented support for switching between icon libraries and icon names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->