### PR TITLE
ci: enforce egress-block on the last three AI jobs, closing the audit group

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -73,13 +73,12 @@ regardless of how convenient it is.
   `claude-pr-loop` (`fix`/`verify`), `claude-review`, `claude` and `bestaxbot-reply` all check
   out a branch and run repository code in the same job as that token, and they must — fixing and
   reviewing code is the job. What holds them is a different, weaker set: the tool allowlist, the
-  protected-path deny rules, the trusted-labeler gates, and an enforced egress policy — which as
-  of #578 covers `claude`, `claude-implement` and `bestaxbot-reply`, while `claude-review` and
-  `claude-pr-loop`'s `fix`/`verify` are still at `audit` and so have that last leg only in name.
-  Check the rule 10 inventory before citing it for a specific job rather than reading this
-  sentence as a group claim. Saying I1 covers those jobs would be the exact overstatement the
-  checklist at the bottom of this file ends on. It covers the pipeline that was designed around
-  it.
+  protected-path deny rules, the trusted-labeler gates, and — as of #578, for all five of them —
+  an enforced egress policy on a measured allowlist. Read that last leg for exactly what rule 10
+  says it delivers: it bounds **where** a session can send data, and `api.github.com` is
+  necessarily on every one of those allowlists, so it does not bound what the session can do
+  through a tool. Saying I1 covers those jobs would be the exact overstatement the checklist at
+  the bottom of this file ends on. It covers the pipeline that was designed around it.
 
   harden-runner's egress block enforces again as of #487 — `block` used to degrade silently to
   `audit`, and now enforces and is asserted (rule 10). **Do not promote it to a third leg of
@@ -341,13 +340,13 @@ Copy the full version from any block job — the three shapes above are each loa
 
 - **The `-e` check comes first** because harden-runner has deliberate paths that install nothing
   and still exit 0 (a StepSecurity outage, the `skip-harden-runner` repo property, a container or
-  slim runner). Without it a vendor outage fails every block job at once — sixteen of them as of
+  slim runner). Without it a vendor outage fails every block job at once — nineteen of them as of
   the inventory below, not the seven this line said before the `ai-scan`/`ai-triage` job splits —
   with a bare `jq: could not open file`. It still fails, because a job holding a credential must
   not run unprotected, but it says why. Do not hand-maintain that number: it is the count of
   block-mode jobs, and it has been wrong once already. Derive it, and grep for the **key** rather
   than the string — `grep -rn "^ *egress-policy: block$"`. A plain `grep egress-policy: block`
-  returns seventeen: `deploy-worker.yml` names the policy in a comment, which is the same way a
+  returns twenty: `deploy-worker.yml` names the policy in a comment, which is the same way a
   `node -e` in a comment misclassifies a job below.
 - **The status check polls** rather than testing once. The pre-step waits only for the file to
   _exist_ and gives up after ~9s, while the agent resolves every allow-listed host before writing
@@ -479,13 +478,15 @@ jobs (`ci.yml`, `deploy.yml`, `test-deploy.yml`, `visual-regression.yml`, `story
   `ai-triage` jobs (`gate`, `triage`, `publish`, `cleanup`), `claude-repro` (`author` **only**),
   `deploy-worker` (`deploy`), `supply-chain` (`consumer-sbom` and `sign-sbom`),
   `security-txt-expiry` (`check`), `auto-close-duplicates` (`auto-close`), `claude` (`claude`),
-  `claude-implement` (`implement`), `bestaxbot-reply` (`respond`). Sixteen jobs; the command
-  below is the check.
-- **Audit, deliberately, pending a measured allowlist** — `claude-pr-loop` (`fix` and `verify`)
-  and `claude-review`. These run repo code with a model token; their block flip is the remainder
-  of the follow-up this rule owes, tracked in #578. `fix` and `review` are measured and waiting
-  only on their own PR; `verify` is the one job with no measurement yet, because it runs only
-  when a deep review files a blocking inline finding (#593).
+  `claude-implement` (`implement`), `bestaxbot-reply` (`respond`), `claude-review` (`review`),
+  `claude-pr-loop` (`fix` and `verify`). Nineteen jobs; the command below is the check.
+- **Audit, deliberately, pending a measured allowlist** — none, as of #578. That issue closed the
+  group by measuring all six of its members instead of guessing for them, and all six landed on
+  the same eight hosts the Claude-session jobs above already used. Keep the group here rather
+  than deleting it: audit remains the correct starting point for an **existing** live job whose
+  egress has never been observed, and the recipe under this rule is what keeps it a short state
+  rather than an open-ended one. What it is not is a resting place, which is the whole reason
+  #578 existed.
 - **No harden-runner at all**, and these are two different groups — do not merge them into one
   "API-only" line, which understates the second:
   - _Genuinely API-only_ — no checkout, no repository code: `on-slop`, `auto-label-claude-prs`,
@@ -563,14 +564,14 @@ Two things about reading its output, both learned assembling the #578 lists:
   `productionresultssa<N>.blob.core.windows.net`,
   `run-actions-<N>-azure-*.actions.githubusercontent.com` and `hosted-compute-*.githubapp.com`
   are the runner talking to its own control plane. The blob host cannot be pinned even in
-  principle — its name rotates per run (sa3, sa6, sa7, sa9 and sa11 across five runs). Run
+  principle — its name rotates per run (sa3, sa6, sa7, sa9, sa11 and sa13 across six runs). Run
   33221210633 is the evidence that omitting them is right: `auto-close-duplicates` at `block`
   with the five-host list observed only `api.github.com` and `github.com`, and completed all
   fifteen of its API calls under the firewall. The visible cost is an Actions cache miss, which
   degrades rather than fails.
 - **One run is not a measurement.** Vendor telemetry samples, so a host can be absent from four
   runs and present in the fifth — `telemetry.vercel.com` (turbo) showed up exactly once across
-  the five #578 runs. Prefer denying telemetry at the source (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`,
+  the six #578 runs. Prefer denying telemetry at the source (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`,
   `TURBO_TELEMETRY_DISABLED`) over allow-listing a host you would rather not talk to; that is the
   standing call here, and it also keeps the next audit report clean for whoever reads it.
 

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -348,8 +348,12 @@ jobs:
       # `pnpm run` on nearly every iteration, so turbo is invoked constantly, and
       # turbo samples its telemetry. The Actions cache blob host cannot be pinned
       # at all: its name rotates per run (productionresultssa3/6/7/9/11/13 across
-      # six runs), so a cache miss is accepted and degrades to a
-      # registry.npmjs.org refetch.
+      # six runs). It does not need to be — harden-runner does not gate the
+      # runner's own control-plane traffic, and run 33286967625 showed
+      # claude-review at block restoring its pnpm cache and completing
+      # pnpm install --frozen-lockfile with neither that host nor
+      # results-receiver.actions.githubusercontent.com allow-listed. This job
+      # runs the same checkout/setup/install sequence.
       #
       # Resolve any host before adding it here. An unresolvable entry is not inert:
       # the agent reverts the firewall while the pre-step still exits 0, which is

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -468,10 +468,17 @@ jobs:
         # it (#487). It also covers feature-flag evaluation, which is why
         # statsig.anthropic.com is gone.
         #
-        # On this `audit` job the point is the MEASUREMENT: audit mode exists to
-        # produce the endpoint list a block flip will use (#578), and leaving
-        # telemetry on would put the Datadog host in that report, inviting whoever
-        # reads it to allow-list a host we have just decided to deny.
+        # This job now enforces `block` (#578), so the denial is doing two jobs at
+        # once and both matter. The allowlist above refuses the Datadog host, and
+        # this setting stops the CLI trying to reach it, which keeps a denied call
+        # out of the run rather than merely blocked. Leaving telemetry on and
+        # relying on the allowlist alone would fill the logs with refused traffic
+        # and invite the next reader to "fix" it by allow-listing the host.
+        #
+        # It also earned the allowlist: this was set during the audit phase
+        # precisely so the endpoint list the flip was built from reflected the
+        # intended end state, rather than recording a host we had already decided
+        # to deny.
         #
         # A step `env:` rather than the action's `settings:` input, and here that
         # is load-bearing rather than tidiness: `settings:` is written to the
@@ -849,10 +856,17 @@ jobs:
         # it (#487). It also covers feature-flag evaluation, which is why
         # statsig.anthropic.com is gone.
         #
-        # On this `audit` job the point is the MEASUREMENT: audit mode exists to
-        # produce the endpoint list a block flip will use (#578), and leaving
-        # telemetry on would put the Datadog host in that report, inviting whoever
-        # reads it to allow-list a host we have just decided to deny.
+        # This job now enforces `block` (#578), so the denial is doing two jobs at
+        # once and both matter. The allowlist above refuses the Datadog host, and
+        # this setting stops the CLI trying to reach it, which keeps a denied call
+        # out of the run rather than merely blocked. Leaving telemetry on and
+        # relying on the allowlist alone would fill the logs with refused traffic
+        # and invite the next reader to "fix" it by allow-listing the host.
+        #
+        # It also earned the allowlist: this was set during the audit phase
+        # precisely so the endpoint list the flip was built from reflected the
+        # intended end state, rather than recording a host we had already decided
+        # to deny.
         #
         # A step `env:` rather than the action's `settings:` input, and here that
         # is load-bearing rather than tidiness: `settings:` is written to the

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -326,22 +326,95 @@ jobs:
       id-token: write # OIDC exchange for claude[bot] auth
       actions: write # read CI logs + self-dispatch in the terminal step
     steps:
-      # AUDIT, not block, and rule 10's "existing live job" clause is why: this
-      # job checks out a PR branch, installs dependencies and runs a Claude
-      # session with a model token, and none of that egress has ever been
-      # measured. A guessed allowlist would break the loop on its first miss;
-      # audit mode reports every endpoint the run touches without refusing any,
-      # which is what produces the list a block flip needs. That flip is the
-      # follow-up rule 10 owes (#578) — audit is a starting point here, not a
-      # resting place. Six jobs run repo code alongside the model token (rule 10
-      # lists them); this is one of them, not the only one.
+      # BLOCK, with the allowlist MEASURED rather than guessed (#578). This job's
+      # audit run was 33233097667; all six runs the flip is built on are recorded
+      # on that issue, each read out of its own `Post Harden runner` log rather
+      # than transcribed from the StepSecurity UI.
       #
       # The sibling sweep/gate/handoff/halt jobs make GitHub API calls only and
       # carry no harden-runner; only `fix` and `verify` execute repo code.
+      #
+      # The eight hosts are the set already enforcing on ai-scan/scan,
+      # ai-triage/triage and claude-repro/author, and the measurement came out a
+      # strict subset of it: objects.githubusercontent.com and
+      # release-assets.githubusercontent.com never appeared, because the Node 24
+      # toolcache hit on every run. They stay for the toolcache-miss path, exactly
+      # as those three jobs already carry them.
+      #
+      # Two observed hosts are deliberately absent. telemetry.vercel.com is turbo's
+      # telemetry, denied via TURBO_TELEMETRY_DISABLED below rather than
+      # allow-listed — the same call this repo already makes for the CLI's Datadog
+      # host. That one matters most here: this job's session runs `pnpm test` and
+      # `pnpm run` on nearly every iteration, so turbo is invoked constantly, and
+      # turbo samples its telemetry. The Actions cache blob host cannot be pinned
+      # at all: its name rotates per run (productionresultssa3/6/7/9/11/13 across
+      # six runs), so a cache miss is accepted and degrades to a
+      # registry.npmjs.org refetch.
+      #
+      # Resolve any host before adding it here. An unresolvable entry is not inert:
+      # the agent reverts the firewall while the pre-step still exits 0, which is
+      # how statsig.anthropic.com silently disabled the policy on #577 (rule 10).
       - name: Harden runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.anthropic.com:443
+            claude.ai:443
+            downloads.claude.ai:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+
+      # Asserts the policy the pre-step decided (agent.json) AND that the agent
+      # actually came up (agent.status, written only once the firewall rules are
+      # installed). Either alone is a false pass: #487 was the first kind, and an
+      # unresolvable host in an allowlist is the second.
+      #
+      # Scope it honestly: this proves enforcement was armed AT THIS STEP. It does
+      # NOT prove the policy stays armed — the agent writes `Initialized` and then
+      # serves, and a later runtime error makes it revert the firewall with both
+      # files still reading exactly as they do here. Rule 10 in .github/CLAUDE.md
+      # carries the mechanism and what to check when a session looks wrong.
+      #
+      # The poll is not defensive programming on this job specifically: its
+      # measured time from pre-step to `Initialized` was 9.97s, past the ~9s the
+      # pre-step gives up after. A single-shot check would have failed it.
+      #
+      # Placement is rule 10's default (immediately after harden-runner): nothing
+      # `always()`-guarded keys off this job's outputs, and the job is not itself
+      # a fail-closed path, so neither placement exception applies.
+      #
+      # Linux-only paths (macOS uses /opt/step-security); all runners are ubuntu-latest.
+      - name: Assert egress policy is enforced
+        run: |
+          set -uo pipefail
+          # harden-runner has several deliberate "install nothing, exit 0" paths
+          # (StepSecurity unavailable, the skip-harden-runner repo property, a
+          # container or slim runner). None of them writes agent.json, so name
+          # that case rather than leaving a bare jq "could not open file".
+          if [ ! -e /home/agent/agent.json ]; then
+            echo "::error::harden-runner installed no agent, so nothing is enforcing egress. Usual causes: a StepSecurity outage (its pre-step returns green without installing), the skip-harden-runner repo property, or a container/slim runner. This job holds bestaxbot's PAT, an SSH signing key and a model token, and will not run unprotected (#487)."
+            exit 1
+          fi
+          if ! jq -e '.egress_policy == "block"' /home/agent/agent.json; then
+            echo "::error::effective egress policy is not block — harden-runner downgraded it (#487)."
+            exit 1
+          fi
+          # Poll rather than test once: the pre-step waits only for the file to
+          # EXIST and gives up after ~9s, while the agent resolves every
+          # allow-listed host before writing its status, so a cold resolver or a
+          # long list can leave the file absent or still empty here.
+          for _ in $(seq 1 30); do
+            if grep -q '^Initialized' /home/agent/agent.status 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::agent.json reads block but the agent never reported Initialized — the firewall is not up. Check the agent log for 'Reverted changes' (usually an unresolvable allow-listed host)."
+          exit 1
 
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -395,6 +468,12 @@ jobs:
         # under `with:`.
         env:
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+          # Same call, second vendor: turbo phones telemetry.vercel.com from the
+          # pnpm commands this session runs, and this loop runs them on nearly
+          # every iteration. It appeared in only one of the six audit runs because
+          # turbo samples, which is precisely the intermittent that reddens a
+          # block job weeks after a flip. Denied, not allow-listed (#578).
+          TURBO_TELEMETRY_DISABLED: '1'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           # Fix/refute as the bestaxbot machine account (Stage 2): its
@@ -405,7 +484,7 @@ jobs:
           github_token: ${{ secrets.AI_LOOP_PAT }}
           ssh_signing_key: ${{ secrets.AI_LOOP_SSH_SIGNING_KEY }}
           bot_name: bestaxbot
-          bot_id: "300268469"
+          bot_id: '300268469'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Trigger actors are bots by design: coderabbitai[bot] (reviews),
           # claude[bot] (CI workflow_run after its own pushes), and
@@ -650,14 +729,75 @@ jobs:
       id-token: write # OIDC exchange for claude[bot] auth
       actions: write # self-dispatch in the continue step
     steps:
-      # AUDIT, not block — same reasoning as the `fix` job above: this job checks
-      # out a PR branch, installs dependencies and runs a Claude session with a
-      # model token, and its egress is unmeasured. Audit mode produces the list a
-      # block flip needs. Tracked as the follow-up rule 10 owes (#578).
+      # BLOCK, same measured allowlist as the `fix` job above (#578). This job was
+      # the last of the six to get a run, and #593 is why: `verify` fires only on
+      # `PENDING_VERIFY` or `REBUTTABLE`, both of which need a claude-opened
+      # review thread, and blocking deep-review findings are rare. Run
+      # 33284876176 is the measurement, reached through `REBUTTABLE` — a
+      # maintainer replying to an inline finding, which needs no fix round at all.
+      # #593 carries the four-step recipe if this ever needs re-measuring.
+      #
+      # Its endpoints came out identical to `fix`, which is the expected result
+      # and not an assumed one: the two jobs check out the same way, install the
+      # same way, and run the same tooling. #578 was right to refuse to derive one
+      # from the other, and the derivation turned out to be correct anyway.
       - name: Harden runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.anthropic.com:443
+            claude.ai:443
+            downloads.claude.ai:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+
+      # Asserts the policy the pre-step decided (agent.json) AND that the agent
+      # actually came up (agent.status, written only once the firewall rules are
+      # installed). Either alone is a false pass: #487 was the first kind, and an
+      # unresolvable host in an allowlist is the second.
+      #
+      # Scope it honestly: this proves enforcement was armed AT THIS STEP. It does
+      # NOT prove the policy stays armed — the agent writes `Initialized` and then
+      # serves, and a later runtime error makes it revert the firewall with both
+      # files still reading exactly as they do here. Rule 10 in .github/CLAUDE.md
+      # carries the mechanism and what to check when a session looks wrong.
+      #
+      # Placement is rule 10's default (immediately after harden-runner): nothing
+      # `always()`-guarded keys off this job's outputs, and the job is not itself
+      # a fail-closed path, so neither placement exception applies.
+      #
+      # Linux-only paths (macOS uses /opt/step-security); all runners are ubuntu-latest.
+      - name: Assert egress policy is enforced
+        run: |
+          set -uo pipefail
+          # harden-runner has several deliberate "install nothing, exit 0" paths
+          # (StepSecurity unavailable, the skip-harden-runner repo property, a
+          # container or slim runner). None of them writes agent.json, so name
+          # that case rather than leaving a bare jq "could not open file".
+          if [ ! -e /home/agent/agent.json ]; then
+            echo "::error::harden-runner installed no agent, so nothing is enforcing egress. Usual causes: a StepSecurity outage (its pre-step returns green without installing), the skip-harden-runner repo property, or a container/slim runner. This job holds a model token and runs as claude[bot] with pull-requests write, and will not run unprotected (#487)."
+            exit 1
+          fi
+          if ! jq -e '.egress_policy == "block"' /home/agent/agent.json; then
+            echo "::error::effective egress policy is not block — harden-runner downgraded it (#487)."
+            exit 1
+          fi
+          # Poll rather than test once: the pre-step waits only for the file to
+          # EXIST and gives up after ~9s, while the agent resolves every
+          # allow-listed host before writing its status, so a cold resolver or a
+          # long list can leave the file absent or still empty here.
+          for _ in $(seq 1 30); do
+            if grep -q '^Initialized' /home/agent/agent.status 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::agent.json reads block but the agent never reported Initialized — the firewall is not up. Check the agent log for 'Reverted changes' (usually an unresolvable allow-listed host)."
+          exit 1
 
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -708,6 +848,12 @@ jobs:
         # under `with:`.
         env:
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+          # Same call, second vendor: turbo phones telemetry.vercel.com from the
+          # pnpm commands this session runs, and this loop runs them on nearly
+          # every iteration. It appeared in only one of the six audit runs because
+          # turbo samples, which is precisely the intermittent that reddens a
+          # block job weeks after a flip. Denied, not allow-listed (#578).
+          TURBO_TELEMETRY_DISABLED: '1'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -334,12 +334,21 @@ jobs:
       # The sibling sweep/gate/handoff/halt jobs make GitHub API calls only and
       # carry no harden-runner; only `fix` and `verify` execute repo code.
       #
-      # The eight hosts are the set already enforcing on ai-scan/scan,
+      # Eight of the nine hosts are the set already enforcing on ai-scan/scan,
       # ai-triage/triage and claude-repro/author, and the measurement came out a
-      # strict subset of it: objects.githubusercontent.com and
-      # release-assets.githubusercontent.com never appeared, because the Node 24
-      # toolcache hit on every run. They stay for the toolcache-miss path, exactly
-      # as those three jobs already carry them.
+      # strict subset of it: objects.githubusercontent.com,
+      # release-assets.githubusercontent.com and nodejs.org never appeared, because
+      # the Node 24 toolcache hit on every run. All three stay for the
+      # toolcache-miss path, and they are not interchangeable: the first two carry
+      # the actions/node-versions manifest and its release assets, while nodejs.org
+      # is setup-node v7's own fallback when that lookup misses.
+      #
+      # nodejs.org is the ninth, and the one NOT in the Claude-session set copied
+      # above. Worth stating so it does not get trimmed back out: none of
+      # ai-scan/scan, ai-triage/triage or claude-repro/author runs setup-node at
+      # all, so that set never needed it. This job does. Every block job in this
+      # repo that runs setup-node allows it (auto-close-duplicates,
+      # security-txt-expiry, deploy-worker, supply-chain/consumer-sbom).
       #
       # Two observed hosts are deliberately absent. telemetry.vercel.com is turbo's
       # telemetry, denied via TURBO_TELEMETRY_DISABLED below rather than
@@ -371,6 +380,7 @@ jobs:
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             registry.npmjs.org:443
+            nodejs.org:443
 
       # Asserts the policy the pre-step decided (agent.json) AND that the agent
       # actually came up (agent.status, written only once the firewall rules are
@@ -758,6 +768,7 @@ jobs:
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             registry.npmjs.org:443
+            nodejs.org:443
 
       # Asserts the policy the pre-step decided (agent.json) AND that the agent
       # actually came up (agent.status, written only once the firewall rules are

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,17 +66,85 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # AUDIT, not block, and rule 10's "existing live job" clause is why: this
-      # job checks out a PR head, installs dependencies and runs a Claude session
-      # with a model token, and none of that egress has ever been measured. A
-      # guessed allowlist would break the review on its first miss; audit mode
-      # reports every endpoint the run touches without refusing any, which is
-      # what produces the list a block flip needs. That flip is the follow-up
-      # rule 10 owes (#578) — audit is a starting point here, not a resting place.
+      # BLOCK, with the allowlist MEASURED rather than guessed (#578). This job's
+      # audit runs were 33230210532 and 33230112308; all six runs the flip is
+      # built on are recorded on that issue, each read out of its own
+      # `Post Harden runner` log rather than transcribed from the StepSecurity UI.
+      #
+      # The eight hosts are the set already enforcing on ai-scan/scan,
+      # ai-triage/triage and claude-repro/author, and the measurement came out a
+      # strict subset of it: objects.githubusercontent.com and
+      # release-assets.githubusercontent.com never appeared, because the Node 24
+      # toolcache hit on every run. They stay for the toolcache-miss path, exactly
+      # as those three jobs already carry them.
+      #
+      # Two observed hosts are deliberately absent. telemetry.vercel.com is turbo's
+      # telemetry, denied via TURBO_TELEMETRY_DISABLED below rather than
+      # allow-listed — the same call this repo already makes for the CLI's Datadog
+      # host. The Actions cache blob host cannot be pinned at all: its name rotates
+      # per run (productionresultssa3/6/7/9/11/13 across six runs), so a cache miss
+      # is accepted and degrades to a registry.npmjs.org refetch.
+      #
+      # Resolve any host before adding it here. An unresolvable entry is not inert:
+      # the agent reverts the firewall while the pre-step still exits 0, which is
+      # how statsig.anthropic.com silently disabled the policy on #577 (rule 10).
       - name: Harden runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.anthropic.com:443
+            claude.ai:443
+            downloads.claude.ai:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+
+      # Asserts the policy the pre-step decided (agent.json) AND that the agent
+      # actually came up (agent.status, written only once the firewall rules are
+      # installed). Either alone is a false pass: #487 was the first kind, and an
+      # unresolvable host in an allowlist is the second.
+      #
+      # Scope it honestly: this proves enforcement was armed AT THIS STEP. It does
+      # NOT prove the policy stays armed — the agent writes `Initialized` and then
+      # serves, and a later runtime error makes it revert the firewall with both
+      # files still reading exactly as they do here. Rule 10 in .github/CLAUDE.md
+      # carries the mechanism and what to check when a session looks wrong.
+      #
+      # Placement is rule 10's default (immediately after harden-runner): nothing
+      # `always()`-guarded keys off this job's outputs, and the job is not itself
+      # a fail-closed path, so neither placement exception applies.
+      #
+      # Linux-only paths (macOS uses /opt/step-security); all runners are ubuntu-latest.
+      - name: Assert egress policy is enforced
+        run: |
+          set -uo pipefail
+          # harden-runner has several deliberate "install nothing, exit 0" paths
+          # (StepSecurity unavailable, the skip-harden-runner repo property, a
+          # container or slim runner). None of them writes agent.json, so name
+          # that case rather than leaving a bare jq "could not open file".
+          if [ ! -e /home/agent/agent.json ]; then
+            echo "::error::harden-runner installed no agent, so nothing is enforcing egress. Usual causes: a StepSecurity outage (its pre-step returns green without installing), the skip-harden-runner repo property, or a container/slim runner. This job holds a model token and reviews PR-authored code as claude[bot], and will not run unprotected (#487)."
+            exit 1
+          fi
+          if ! jq -e '.egress_policy == "block"' /home/agent/agent.json; then
+            echo "::error::effective egress policy is not block — harden-runner downgraded it (#487)."
+            exit 1
+          fi
+          # Poll rather than test once: the pre-step waits only for the file to
+          # EXIST and gives up after ~9s, while the agent resolves every
+          # allow-listed host before writing its status, so a cold resolver or a
+          # long list can leave the file absent or still empty here.
+          for _ in $(seq 1 30); do
+            if grep -q '^Initialized' /home/agent/agent.status 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::agent.json reads block but the agent never reported Initialized — the firewall is not up. Check the agent log for 'Reverted changes' (usually an unresolvable allow-listed host)."
+          exit 1
 
       # For the opt-in `deep-review` label only: GitHub already restricts
       # labeling to triage+, but re-verify the labeler's live role
@@ -280,6 +348,12 @@ jobs:
         # under `with:`.
         env:
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+          # Same call, second vendor: turbo phones telemetry.vercel.com from the
+          # pnpm commands this session runs. It appeared in only one of the six
+          # audit runs because turbo samples, which is precisely the intermittent
+          # that reddens a block job weeks after a flip. Denied, not allow-listed
+          # (#578).
+          TURBO_TELEMETRY_DISABLED: '1'
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -71,12 +71,21 @@ jobs:
       # built on are recorded on that issue, each read out of its own
       # `Post Harden runner` log rather than transcribed from the StepSecurity UI.
       #
-      # The eight hosts are the set already enforcing on ai-scan/scan,
+      # Eight of the nine hosts are the set already enforcing on ai-scan/scan,
       # ai-triage/triage and claude-repro/author, and the measurement came out a
-      # strict subset of it: objects.githubusercontent.com and
-      # release-assets.githubusercontent.com never appeared, because the Node 24
-      # toolcache hit on every run. They stay for the toolcache-miss path, exactly
-      # as those three jobs already carry them.
+      # strict subset of it: objects.githubusercontent.com,
+      # release-assets.githubusercontent.com and nodejs.org never appeared, because
+      # the Node 24 toolcache hit on every run. All three stay for the
+      # toolcache-miss path, and they are not interchangeable: the first two carry
+      # the actions/node-versions manifest and its release assets, while nodejs.org
+      # is setup-node v7 own fallback when that lookup misses.
+      #
+      # nodejs.org is the one host NOT in the Claude-session set copied above, and
+      # the reason is worth stating so it does not get trimmed back out: none of
+      # ai-scan/scan, ai-triage/triage or claude-repro/author runs setup-node at
+      # all, so that set never needed it. This job does. Every block job in this
+      # repo that runs setup-node allows it (auto-close-duplicates,
+      # security-txt-expiry, deploy-worker, supply-chain/consumer-sbom).
       #
       # Two observed hosts are deliberately absent. telemetry.vercel.com is turbo's
       # telemetry, denied via TURBO_TELEMETRY_DISABLED below rather than
@@ -106,6 +115,7 @@ jobs:
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             registry.npmjs.org:443
+            nodejs.org:443
 
       # Asserts the policy the pre-step decided (agent.json) AND that the agent
       # actually came up (agent.status, written only once the firewall rules are

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -349,10 +349,17 @@ jobs:
         # it (#487). It also covers feature-flag evaluation, which is why
         # statsig.anthropic.com is gone.
         #
-        # On this `audit` job the point is the MEASUREMENT: audit mode exists to
-        # produce the endpoint list a block flip will use (#578), and leaving
-        # telemetry on would put the Datadog host in that report, inviting whoever
-        # reads it to allow-list a host we have just decided to deny.
+        # This job now enforces `block` (#578), so the denial is doing two jobs at
+        # once and both matter. The allowlist above refuses the Datadog host, and
+        # this setting stops the CLI trying to reach it, which keeps a denied call
+        # out of the run rather than merely blocked. Leaving telemetry on and
+        # relying on the allowlist alone would fill the logs with refused traffic
+        # and invite the next reader to "fix" it by allow-listing the host.
+        #
+        # It also earned the allowlist: this was set during the audit phase
+        # precisely so the endpoint list the flip was built from reflected the
+        # intended end state, rather than recording a host we had already decided
+        # to deny.
         #
         # A step `env:` rather than the action's `settings:` input, and here that
         # is load-bearing rather than tidiness: `settings:` is written to the

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -82,8 +82,13 @@ jobs:
       # telemetry, denied via TURBO_TELEMETRY_DISABLED below rather than
       # allow-listed — the same call this repo already makes for the CLI's Datadog
       # host. The Actions cache blob host cannot be pinned at all: its name rotates
-      # per run (productionresultssa3/6/7/9/11/13 across six runs), so a cache miss
-      # is accepted and degrades to a registry.npmjs.org refetch.
+      # per run (productionresultssa3/6/7/9/11/13 across six runs). It does not need
+      # to be, and this job is where that was proven: run 33286967625 ran it at
+      # block on a branch, with neither that host nor
+      # results-receiver.actions.githubusercontent.com allow-listed, and setup-node
+      # still restored the pnpm cache before pnpm install --frozen-lockfile
+      # completed. harden-runner does not gate the runner's own control-plane
+      # traffic.
       #
       # Resolve any host before adding it here. An unresolvable entry is not inert:
       # the agent reverts the firewall while the pre-step still exits 0, which is


### PR DESCRIPTION
Second half of #578. Flips `review` (`claude-review.yml`) and `fix`/`verify` (`claude-pr-loop.yml`)
to `egress-policy: block` with the rule 10 assertion, which empties rule 10's "audit, deliberately"
group.

> **Stacked on #602.** Based on `ci/578-egress-block-default-branch-jobs` rather than `main`,
> because both PRs edit the same rule 10 inventory lines and counts. Retarget to `main` once #602
> merges. Review this diff on its own; #602's three jobs are not part of it.

## `verify` is measured — and #593's premise turned out to be avoidable

#593 concluded that nothing could be done but wait for a natural blocking deep-review finding.
That is true of the `PENDING_VERIFY` path. It is not true of the gate, which is an OR:

```
elif [ "$PENDING_VERIFY" -gt 0 ] || [ "$REBUTTABLE" -gt 0 ]; then MODE=verify
```

`REBUTTABLE` (`claude-pr-loop.yml:230-234`) wants an unresolved claude-opened thread whose last
comment is from a **non-claude** author with `ccount < 2`. A maintainer replying to the inline
finding satisfies it directly — no fix round, no push, no iteration consumed.

Measurement run: [33284876176](https://github.com/allxsmith/bestax/actions/runs/33284876176)

```
decision: verify (fail=0 pend=0 actionable=0 verify=0 rebut=1 cr=success iter=0)
gate: success   verify: success   (fix / handoff / halt all skipped)
```

**The session was representative, not a stub** — which is the only thing that makes its endpoint
list worth anything. It checked out, ran `pnpm install --frozen-lockfile`, and the Claude session
swept every `<Button>`+`<Icon>` pair across `docs/docs/**` and `skills/**`, read `Icon.tsx:195` to
confirm the `ariaLabel` default, replied on the thread and resolved it. Full protocol end to end.

The four-step recipe is written up in #593 for whoever needs to re-measure this job.

## Endpoints

All three jobs produced the same six application hosts as the other three — `api.anthropic.com`,
`api.github.com`, `claude.ai`, `downloads.claude.ai`, `github.com`, `registry.npmjs.org` — so all
six of #578's jobs get the same eight-host list, the one already enforcing on `ai-scan`/`scan`,
`ai-triage`/`triage` and `claude-repro`/`author`.

`verify` matching `fix` is the expected result rather than an assumed one. #578 was right to refuse
to derive one job's list from another's; the derivation happened to hold, and now it is checked.

`TURBO_TELEMETRY_DISABLED: '1'` joins `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` on all three.
It matters most on this loop: its sessions run `pnpm test`/`pnpm run` on nearly every iteration, so
turbo is invoked constantly, and turbo samples its telemetry — an intermittent that would otherwise
redden the loop weeks after the flip.

The Actions cache blob host stays off, and `verify` supplied fresh evidence for why:
`productionresultssa13` appeared, joining sa3/6/7/9/11 from the earlier runs. Six runs, six
different names.

## `fix` gets one extra comment

Its measured pre-step-to-`Initialized` time was **9.97s**, past the ~9s the pre-step gives up
after. So on this job the polling loop is not defensive programming — a single-shot check would
have failed it. That is recorded next to the assertion rather than left in an issue thread.

## Docs

- Rule 10's inventory: nineteen enforcing jobs, empty audit group. Counts re-derived with the
  greps the rule prescribes (19 key-form, 20 plain-form, 0 audit), not incremented.
- The audit group is **kept rather than deleted**. Audit is still the right starting point for an
  existing live job whose egress has never been observed; what it is not is a resting place, which
  is the whole reason #578 existed.
- I1's egress clause now covers all five code-executing jobs, and restates the scope rule 10 sets
  for it — it bounds where data can go, and `api.github.com` is necessarily allow-listed, so it
  does not bound what a session does through a tool.

## Verification

Local: `prettier --check`, `check:conformance` (19 green), both rule 1 pin greps, and a js-yaml
pass over every workflow asserting that no `block` job lacks an assertion and that all six of
#578's assertions are byte-identical to `auto-close-duplicates.yml`'s apart from the credential
each names. (The seven pre-existing `ai-scan`/`ai-triage` variants differ by design — the `fail()`
wrapper rule 10 documents.)

**Before merge**, unlike #602's three, all three of these can be exercised on the branch:

- `fix` / `verify`: `gh workflow run claude-pr-loop.yml --ref ci/578-egress-block-branch-verifiable-jobs -f branch=<a claude/ PR>`
- `review`: label a PR whose head is this branch. Note the session itself will skip (the OIDC
  exchange requires the workflow to match the default branch when the PR modifies it), so that
  exercises the policy and the assertion, not the session's egress — acceptable, since the session
  egress is already measured.

Watch for: assertion green, `"egress_policy":"block"` in the config, `Initialized` with no
`Reverted changes` or `timed out`, and the session completing real work.

Closes #578
Closes #593