### PR TITLE
docs: add an accessible icon-only button example to the Icons guide

### DIFF
--- a/docs/docs/guides/getting-started/alternative-icons.md
+++ b/docs/docs/guides/getting-started/alternative-icons.md
@@ -540,10 +540,12 @@ function IconOnlyExample() {
 }
 ```
 
-Both halves matter, and the second one is easy to miss:
+The two attributes do different jobs, and only the first one names the button:
 
-- **`aria-label` on the `Button`** is what a screen reader announces. Make it name the action ("Delete item"), not the picture ("Trash icon").
-- **`aria-hidden` on the `Icon`** stops it contributing a second, competing name. `Icon` sets `aria-label="icon"` by default, so an icon-only button without this announces the literal word "icon".
+- **`aria-label` on the `Button`** is the accessible name. It takes precedence over anything inside the button, so this is the whole of what a screen reader announces. Make it name the action ("Delete item"), not the picture ("Trash icon").
+- **`aria-hidden` on the `Icon`** does not change that name. It keeps the icon out of the accessibility tree entirely, so assistive technology never exposes a stray `"icon"` node when moving through the page element by element. Correct decorative markup, not part of the naming.
+
+Leave the `aria-label` off and the name falls back to the button's contents, which is where `Icon` bites: it sets `aria-label="icon"` by default, so the button ends up announcing the single word "icon".
 
 The same pattern applies to every library on this page. Only the `library` prop and the icon `name` change:
 

--- a/docs/docs/guides/getting-started/alternative-icons.md
+++ b/docs/docs/guides/getting-started/alternative-icons.md
@@ -524,7 +524,7 @@ If you haven't started your project yet, `pnpm create bestax@latest` will instal
 
 ## Icon-Only Buttons
 
-Every example above pairs its icon with visible text. When the icon _is_ the whole label — a toolbar or a card action with no room for words — the accessible name has to come from somewhere else, because there is no text for a screen reader to announce.
+Every button example above pairs its icon with visible text. When the icon _is_ the whole label — a toolbar or a card action with no room for words — the accessible name has to come from somewhere else, because there is no text for a screen reader to announce.
 
 Put the name on the `Button` with `aria-label`, and hide the `Icon` from assistive technology with `aria-hidden`:
 

--- a/docs/docs/guides/getting-started/alternative-icons.md
+++ b/docs/docs/guides/getting-started/alternative-icons.md
@@ -522,6 +522,59 @@ If you haven't started your project yet, `pnpm create bestax@latest` will instal
 
 ---
 
+## Icon-Only Buttons
+
+Every example above pairs its icon with visible text. When the icon _is_ the whole label — a toolbar or a card action with no room for words — the accessible name has to come from somewhere else, because there is no text for a screen reader to announce.
+
+Put the name on the `Button` with `aria-label`, and hide the `Icon` from assistive technology with `aria-hidden`:
+
+```tsx live
+import { Button, Icon } from '@allxsmith/bestax-bulma';
+
+function IconOnlyExample() {
+  return (
+    <Button color="danger" aria-label="Delete item">
+      <Icon name="trash" aria-hidden="true" />
+    </Button>
+  );
+}
+```
+
+Both halves matter, and the second one is easy to miss:
+
+- **`aria-label` on the `Button`** is what a screen reader announces. Make it name the action ("Delete item"), not the picture ("Trash icon").
+- **`aria-hidden` on the `Icon`** stops it contributing a second, competing name. `Icon` sets `aria-label="icon"` by default, so an icon-only button without this announces the literal word "icon".
+
+The same pattern applies to every library on this page. Only the `library` prop and the icon `name` change:
+
+```tsx live
+import { Button, Buttons, Icon } from '@allxsmith/bestax-bulma';
+
+function IconOnlyLibraries() {
+  return (
+    <Buttons>
+      <Button color="primary" aria-label="Edit profile">
+        <Icon library="mdi" name="pencil" aria-hidden="true" />
+      </Button>
+      <Button color="info" aria-label="Open settings">
+        <Icon library="ion" name="settings" aria-hidden="true" />
+      </Button>
+      <Button color="success" aria-label="Add to favorites">
+        <Icon library="material-icons" name="favorite" aria-hidden="true" />
+      </Button>
+    </Buttons>
+  );
+}
+```
+
+:::tip Icons alongside text
+When the button already has visible text, the icon is decorative and needs only `aria-hidden` — no `aria-label` on the button, since the visible text is already the name. Adding `aria-hidden` there stops the default `"icon"` label being announced next to the word it duplicates.
+:::
+
+See [Button Accessibility](/docs/api/elements/button#accessibility) and the [Icon API](/docs/api/elements/icon) for the full prop lists.
+
+---
+
 ## Choosing the Right Icon Library
 
 | Library                   | Icons Count | File Size | Best For                        |

--- a/docs/docs/guides/getting-started/alternative-icons.md
+++ b/docs/docs/guides/getting-started/alternative-icons.md
@@ -542,7 +542,7 @@ function IconOnlyExample() {
 
 The two attributes do different jobs, and only the first one names the button:
 
-- **`aria-label` on the `Button`** is the accessible name. It takes precedence over anything inside the button, so this is the whole of what a screen reader announces. Make it name the action ("Delete item"), not the picture ("Trash icon").
+- **`aria-label` on the `Button`** is the accessible name. It takes precedence over anything inside the button, so it alone supplies the name a screen reader reads out (alongside the "button" role and any state, which come from the element itself). Make it name the action ("Delete item"), not the picture ("Trash icon").
 - **`aria-hidden` on the `Icon`** does not change that name. It keeps the icon out of the accessibility tree entirely, so assistive technology never exposes a stray `"icon"` node when moving through the page element by element. Correct decorative markup, not part of the naming.
 
 Leave the `aria-label` off and the name falls back to the button's contents, which is where `Icon` bites: it sets `aria-label="icon"` by default, so the button ends up announcing the single word "icon".


### PR DESCRIPTION
Every example in the Icons guide pairs its icon with visible text, so the guide never showed the
icon-only case. That is the one case that actually needs care, because there is no text for a
screen reader to announce.

## The defect this closes

`Icon` defaults `ariaLabel` to the literal string `'icon'` (`Icon.tsx:195`) and emits it as
`aria-label` on the container span. So an icon-only button with no further markup announces as
**"icon"** — a name that says nothing. `button.md:298` already tells readers to use `aria-label`
here; the guide just never demonstrated it, and a reader copying the page's existing
icon-plus-text examples and dropping the `<span>` lands exactly in the hole.

## What it adds

A section showing both halves, because the second is the one people miss:

- `aria-label` on the `Button`, naming the **action** ("Delete item") rather than the picture
- `aria-hidden` on the `Icon`, so its default `"icon"` label does not compete with it

Plus a multi-library example (the pattern is identical across all five, only `library` and `name`
change) and a tip covering the icon-alongside-text case, where only `aria-hidden` is wanted since
the visible text is already the accessible name.

## Provenance

Found while driving a `verify` run for #593. That session swept every `<Button>`+`<Icon>` pair
across `docs/docs/**` and `skills/**` and confirmed this is the only place the shape is missing, so
there is no wider cleanup owed. `skills/bestax-icons/examples/icon-usage.tsx:42` already carries
the correct decorative pattern, which is what this section now matches.

Verified locally: `prettier --check`, `check:conformance` (including `docs-api-urls`, which covers
the two new doc links), and `pnpm lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating accessible icon-only buttons.
  * Documented how to provide accessible names and hide decorative icons from assistive technologies.
  * Added live examples covering individual buttons and groups using multiple icon libraries.
  * Included a tip and links to related button and icon accessibility documentation.
  * Clarified accessibility requirements for icons used with visible button text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->