### PR TITLE
docs: correct rule 10's host count and generalise the deep-review skip condition

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -482,7 +482,13 @@ jobs (`ci.yml`, `deploy.yml`, `test-deploy.yml`, `visual-regression.yml`, `story
   `claude-pr-loop` (`fix` and `verify`). Nineteen jobs; the command below is the check.
 - **Audit, deliberately, pending a measured allowlist** — none, as of #578. That issue closed the
   group by measuring all six of its members instead of guessing for them, and all six landed on
-  the same eight hosts the Claude-session jobs above already used. Keep the group here rather
+  the same nine hosts: the eight the Claude-session jobs above already used, plus `nodejs.org`.
+  That ninth is the interesting one, and it is why "measured" is not the same as "complete". None
+  of `ai-scan`/`scan`, `ai-triage`/`triage` or `claude-repro`/`author` runs `actions/setup-node`,
+  so their eight-host list never needed it; all six of #578's jobs do run it, and setup-node falls
+  back to `nodejs.org/dist` when the toolcache misses and the `actions/node-versions` lookup fails.
+  Six audit runs could not surface that, because the toolcache hit every time and an unexercised
+  path leaves no endpoint in any log. Review caught it, not measurement. Keep the group here rather
   than deleting it: audit remains the correct starting point for an **existing** live job whose
   egress has never been observed, and the recipe under this rule is what keeps it a short state
   rather than an open-ended one. What it is not is a resting place, which is the whole reason
@@ -564,7 +570,8 @@ Two things about reading its output, both learned assembling the #578 lists:
   `productionresultssa<N>.blob.core.windows.net`,
   `run-actions-<N>-azure-*.actions.githubusercontent.com` and `hosted-compute-*.githubapp.com`
   are the runner talking to its own control plane. The blob host cannot be pinned even in
-  principle — its name rotates per run (sa3, sa6, sa7, sa9, sa11 and sa13 across six runs). Run
+  principle — its name rotates per run (sa3, sa6, sa7, sa9, sa11, sa13 and sa17 so far, and the
+  list keeps growing every time anyone looks). Run
   33221210633 is the evidence that omitting them is right: `auto-close-duplicates` at `block`
   with the five-host list observed only `api.github.com` and `github.com`, and completed all
   fifteen of its API calls under the firewall.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -481,9 +481,11 @@ jobs (`ci.yml`, `deploy.yml`, `test-deploy.yml`, `visual-regression.yml`, `story
   `claude-implement` (`implement`), `bestaxbot-reply` (`respond`), `claude-review` (`review`),
   `claude-pr-loop` (`fix` and `verify`). Nineteen jobs; the command below is the check.
 - **Audit, deliberately, pending a measured allowlist** — none, as of #578. That issue closed the
-  group by measuring all six of its members instead of guessing for them, and all six landed on
-  the same nine hosts: the eight the Claude-session jobs above already used, plus `nodejs.org`.
-  That ninth is the interesting one, and it is why "measured" is not the same as "complete". None
+  group by measuring all six of its members instead of guessing for them. All six now **use** the
+  same nine-host allowlist, and the gap between that and what the measurement produced is the part
+  worth keeping: the runs surfaced six application hosts, a strict subset of the eight the
+  Claude-session jobs above already used, and `nodejs.org` appeared in no run at all. It is on the
+  list anyway, and that ninth host is why "measured" is not the same as "complete". None
   of `ai-scan`/`scan`, `ai-triage`/`triage` or `claude-repro`/`author` runs `actions/setup-node`,
   so their eight-host list never needed it; all six of #578's jobs do run it, and setup-node falls
   back to `nodejs.org/dist` when the toolcache misses and the `actions/node-versions` lookup fails.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -531,9 +531,16 @@ jobs:
       # usage-limit failure on the very first call). The PR then silently
       # gets no review while the run shows green, and the AI loop's
       # deep-review gate waits on a review that never comes. Fail loudly.
-      # An empty/missing execution file is tolerated: the action skips
-      # without a session when the PR modifies this workflow file (its
-      # OIDC exchange requires the file to match the default branch).
+      # An empty/missing execution file is tolerated: the action skips without
+      # a session whenever the PR HEAD's copy of this file differs from the
+      # default branch's (its OIDC exchange requires them to match).
+      #
+      # Read that as written. It is NOT "when the PR modifies this file" — that
+      # narrower version is what CLAUDE.md said until #578's own flip changed
+      # this workflow and every PR still carrying the pre-flip copy started
+      # getting silently skipped reviews. The branch never touched the file;
+      # it just had not caught up. Age is not the criterion either: a branch
+      # that has since merged or rebased the current version is fine.
       - name: Fail on silent session error
         if: steps.claude.outcome == 'success'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,12 +150,14 @@ green and every AI review thread is resolved.
   posts nothing while the job still goes green — so check for the review comment, never the job's
   conclusion. Read that condition as written, because the narrower version ("a PR that _modifies_
   `claude-review.yml`") is what this line said until it bit. The workflow runs from the **PR
-  head's** copy, so a branch that merely PREDATES a change to that file is equally stale and
-  equally silent. #578's flip changed the file, and every PR opened before it inherited a
-  skipped review; #605 reproduced it (`"egress_policy":"audit"` from the branch's own old copy,
-  session skipped) and merging `main` into the branch fixed it. Expect this after any edit to
-  `claude-review.yml`, and bring a branch up to date before trusting a green deep-review job on
-  it. That is a
+  head's** copy, so what matters is only whether that copy still matches the default branch —
+  never the branch's age, and never whether the PR touched the file. An old branch that has since
+  merged or rebased the current version is fine; a branch opened five minutes ago off a stale
+  base is not. #578's flip changed the file, so every PR still carrying the pre-flip copy
+  inherited a skipped review; #605 reproduced it (`"egress_policy":"audit"` read from the branch's
+  own retained copy, session skipped) and merging `main` in fixed it. Expect this after any edit
+  to `claude-review.yml`, and confirm the head's copy matches before trusting a green
+  deep-review job. That is a
   consequence of configuration rather than a property of the action: the validation lives on
   the OIDC to app-token exchange, and `setupGitHubToken()` returns before reaching it whenever
   a `github_token` input is supplied — the same early return `ai-triage.yml` already documents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,9 +145,17 @@ green and every AI review thread is resolved.
   lands as a PR review from `claude` marked `<!-- claude-deep-review -->`; it reviewed the
   code checked out when its workflow started, which a racing push may have superseded — so
   look for that review comment (not the current head's checks) and verify its findings
-  against current code. **Today a PR that modifies `claude-review.yml` is not deep-reviewed:**
-  the run logs `Skipping action due to workflow validation` and posts nothing while the job
-  still goes green — so check for the review comment, never the job's conclusion. That is a
+  against current code. **Today a PR whose copy of `claude-review.yml` differs from the default
+  branch's is not deep-reviewed:** the run logs `Skipping action due to workflow validation` and
+  posts nothing while the job still goes green — so check for the review comment, never the job's
+  conclusion. Read that condition as written, because the narrower version ("a PR that _modifies_
+  `claude-review.yml`") is what this line said until it bit. The workflow runs from the **PR
+  head's** copy, so a branch that merely PREDATES a change to that file is equally stale and
+  equally silent. #578's flip changed the file, and every PR opened before it inherited a
+  skipped review; #605 reproduced it (`"egress_policy":"audit"` from the branch's own old copy,
+  session skipped) and merging `main` into the branch fixed it. Expect this after any edit to
+  `claude-review.yml`, and bring a branch up to date before trusting a green deep-review job on
+  it. That is a
   consequence of configuration rather than a property of the action: the validation lives on
   the OIDC to app-token exchange, and `setupGitHubToken()` returns before reaching it whenever
   a `github_token` input is supplied — the same early return `ai-triage.yml` already documents


### PR DESCRIPTION
Two inaccuracies now on `main`, both found by **exercising** the jobs #578 flipped rather than by
reading the files. Docs only, no workflow behaviour changes.

## 1. Rule 10 said "the same eight hosts". It is nine.

Copilot caught during #602's review that the eight-host Claude-session list omits `nodejs.org`,
which `actions/setup-node` falls back to when the toolcache misses and the `actions/node-versions`
lookup fails. The workflows were fixed; that sentence in rule 10 was not, so `main` currently
claims eight while all six jobs carry nine.

The corrected text also says **why measurement could not have found it**, which matters more than
the number: none of `ai-scan`/`scan`, `ai-triage`/`triage` or `claude-repro`/`author` runs
`setup-node`, so their list never needed the host. Across six audit runs the toolcache hit every
time, so the fallback never executed and left no endpoint in any log. Review caught it, measurement
could not have. That is worth stating plainly next to a rule whose entire subject is measuring
allowlists.

Caught by the `respond` verification session, which quoted the stale line back while confirming its
own job's state.

## 2. The deep-review skip condition was too narrow, and it is biting right now

`CLAUDE.md` said a PR that **modifies** `claude-review.yml` is not deep-reviewed. The real
condition is a PR whose **copy** of that file differs from the default branch's, because the
workflow runs from the PR head. A branch that merely *predates* a change to the file is equally
stale and equally silent: green job, no review, no signal.

Not hypothetical. #578's flip changed `claude-review.yml`, so every PR opened before e5ed56b now
inherits a skipped deep review. Reproduced on #605:

- [33289561563](https://github.com/allxsmith/bestax/actions/runs/33289561563) — `"egress_policy":"audit"` (the branch's own stale copy), session skipped, job green
- merged `main` into the branch, re-ran: [33289641518](https://github.com/allxsmith/bestax/actions/runs/33289641518) — `block`, assertion green, session ran

At the time of writing #601, #584, #551, #469 and #461 are all in that state.

## 3. Blob host rotation, seventh name

The `claude` verification run produced `productionresultssa17`, joining sa3/6/7/9/11/13. Recorded,
since it strengthens the existing "cannot be pinned even in principle" argument. Phrased as a
growing list rather than a fixed enumeration, because it will keep growing.

## Verification evidence this came out of

Three of the six #578 jobs are now confirmed under enforcement, each read from a real run rather
than from YAML — assertion green, `"egress_policy":"block"`, zero `Reverted changes`/`timed out`
in the **agent log**, and the session completing real work:

| Job | Run |
| --- | --- |
| `claude-review` / `review` | [33289641518](https://github.com/allxsmith/bestax/actions/runs/33289641518) |
| `bestaxbot-reply` / `respond` | [33314880876](https://github.com/allxsmith/bestax/actions/runs/33314880876) |
| `claude` / `claude` | [33314864756](https://github.com/allxsmith/bestax/actions/runs/33314864756) |

Tracked in #607, along with a gotcha worth keeping: grep the `Post Harden runner` section for
`Reverted changes`, not the whole run log — the assertion step's own error string contains that
phrase, so an unscoped grep always self-matches. Same shape as the `grep egress-policy: block`
trap the rule already documents.

Refs #578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded harden-runner inventory guidance with additional measured hosts and rotating Azure blob-host examples.
  * Clarified when deep reviews are skipped due to outdated workflow configuration.
  * Added guidance to update branches before relying on successful deep-review results.
  * Documented relevant incident references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->