### PR TITLE
feat(bulma-ui): add group size modifier to Buttons, Tags, Message

### DIFF
--- a/bestax-mcp/data/catalog.json
+++ b/bestax-mcp/data/catalog.json
@@ -216,8 +216,8 @@
       "slug": "elements/buttons",
       "import": "import { Buttons } from '@allxsmith/bestax-bulma';",
       "compound": true,
-      "propCount": 52,
-      "exampleCount": 7
+      "propCount": 53,
+      "exampleCount": 8
     },
     {
       "name": "Card",
@@ -634,7 +634,7 @@
       "slug": "components/message",
       "import": "import { Message } from '@allxsmith/bestax-bulma';",
       "compound": true,
-      "propCount": 11,
+      "propCount": 12,
       "exampleCount": 8
     },
     {
@@ -953,8 +953,8 @@
       "slug": "elements/tags",
       "import": "import { Tags } from '@allxsmith/bestax-bulma';",
       "compound": true,
-      "propCount": 13,
-      "exampleCount": 7
+      "propCount": 14,
+      "exampleCount": 8
     },
     {
       "name": "TextArea",

--- a/bestax-mcp/data/components/Buttons.json
+++ b/bestax-mcp/data/components/Buttons.json
@@ -18,6 +18,10 @@
       "code": "<Buttons>\n  {['small', 'normal', 'medium', 'large'].map(size => (\n    <Button key={size} size={size}>\n      {size.charAt(0).toUpperCase() + size.slice(1)}\n    </Button>\n  ))}\n</Buttons>"
     },
     {
+      "title": "Group Size",
+      "code": "<>\n  <Buttons size=\"small\">\n    <Button color=\"primary\">Small</Button>\n    <Button color=\"info\">Small</Button>\n  </Buttons>\n  <Buttons size=\"medium\">\n    <Button color=\"primary\">Medium</Button>\n    <Button color=\"info\">Medium</Button>\n  </Buttons>\n  <Buttons size=\"large\">\n    <Button color=\"primary\">Large</Button>\n    <Button color=\"info\">Large</Button>\n  </Buttons>\n</>"
+    },
+    {
       "title": "Add-ons (No Spacing Between Buttons)",
       "code": "<Buttons hasAddons>\n  <Button color=\"primary\">Left</Button>\n  <Button color=\"primary\">Center</Button>\n  <Button color=\"primary\">Right</Button>\n</Buttons>"
     },
@@ -108,6 +112,15 @@
           "type": "boolean",
           "default": "false",
           "description": "Group buttons together as addons (removes spacing between them).",
+          "required": false,
+          "inherited": false,
+          "deprecated": false
+        },
+        {
+          "name": "size",
+          "type": "'small' | 'medium' | 'large'",
+          "default": null,
+          "description": "Size of the button group.",
           "required": false,
           "inherited": false,
           "deprecated": false

--- a/bestax-mcp/data/components/Message.json
+++ b/bestax-mcp/data/components/Message.json
@@ -19,7 +19,7 @@
     },
     {
       "title": "Sizes",
-      "code": "<>\n  <Message title=\"Default Size\">This is the default size message.</Message>\n  <Message title=\"Small\">This is a small message.</Message>\n  <Message title=\"Medium\">This is a medium message.</Message>\n  <Message title=\"Large\">This is a large message.</Message>\n</>"
+      "code": "<>\n  <Message title=\"Default Size\">This is the default size message.</Message>\n  <Message size=\"small\" title=\"Small\">\n    This is a small message.\n  </Message>\n  <Message size=\"medium\" title=\"Medium\">\n    This is a medium message.\n  </Message>\n  <Message size=\"large\" title=\"Large\">\n    This is a large message.\n  </Message>\n</>"
     },
     {
       "title": "Compound (dot-notation) usage",
@@ -97,6 +97,15 @@
           "inherited": false,
           "deprecated": false,
           "valuesRef": "helpers/valid-values"
+        },
+        {
+          "name": "size",
+          "type": "'small' | 'medium' | 'large'",
+          "default": null,
+          "description": "Size of the message.",
+          "required": false,
+          "inherited": false,
+          "deprecated": false
         },
         {
           "name": "onClose",

--- a/bestax-mcp/data/components/Tags.json
+++ b/bestax-mcp/data/components/Tags.json
@@ -18,6 +18,10 @@
       "code": "<Tags isMultiline>\n  <Tag color=\"primary\">Bulma</Tag>\n  <Tag color=\"success\">React</Tag>\n  <Tag color=\"warning\">Typescript</Tag>\n  <Tag color=\"danger\">Library</Tag>\n  <Tag color=\"link\">UI</Tag>\n</Tags>"
     },
     {
+      "title": "Group Size",
+      "code": "<>\n  <Tags size=\"medium\">\n    <Tag color=\"primary\">Medium</Tag>\n    <Tag color=\"info\">Medium</Tag>\n  </Tags>\n  <Tags size=\"large\">\n    <Tag color=\"primary\">Large</Tag>\n    <Tag color=\"info\">Large</Tag>\n  </Tags>\n</>"
+    },
+    {
       "title": "With Margin",
       "code": "<Tags m=\"4\">\n  <Tag color=\"primary\">With Margin</Tag>\n</Tags>"
     },
@@ -70,6 +74,15 @@
           "type": "boolean",
           "default": "false",
           "description": "Allow tags to wrap onto multiple lines.",
+          "required": false,
+          "inherited": false,
+          "deprecated": false
+        },
+        {
+          "name": "size",
+          "type": "'medium' | 'large'",
+          "default": null,
+          "description": "Size of every tag in the group.",
           "required": false,
           "inherited": false,
           "deprecated": false

--- a/bulma-ui/src/components/Message.stories.tsx
+++ b/bulma-ui/src/components/Message.stories.tsx
@@ -113,6 +113,7 @@ export const DefaultSize: StoryObj<MessageProps> = {
 
 export const Small: StoryObj<MessageProps> = {
   args: {
+    size: 'small',
     title: 'Small',
     children: declarationLatin,
   },
@@ -120,6 +121,7 @@ export const Small: StoryObj<MessageProps> = {
 
 export const Medium: StoryObj<MessageProps> = {
   args: {
+    size: 'medium',
     title: 'Medium',
     children: declarationLatin,
   },
@@ -127,6 +129,7 @@ export const Medium: StoryObj<MessageProps> = {
 
 export const Large: StoryObj<MessageProps> = {
   args: {
+    size: 'large',
     title: 'Large',
     children: declarationLatin,
   },

--- a/bulma-ui/src/components/Message.tsx
+++ b/bulma-ui/src/components/Message.tsx
@@ -12,13 +12,19 @@ import {
 } from '../helpers/useBulmaClasses';
 import { useConfig } from '../helpers/Config';
 
+const validMessageSizes = ['small', 'medium', 'large'] as const;
+/**
+ * Valid size values for the Message component (Bulma message sizes).
+ */
+export type MessageSize = (typeof validMessageSizes)[number];
+
 /**
  * Props for the Message component.
  */
 export interface MessageProps
   extends
     Omit<React.HTMLAttributes<HTMLElement>, 'title'>,
-    Omit<BulmaClassesProps, 'color' | 'backgroundColor'> {
+    Omit<BulmaClassesProps, 'color' | 'backgroundColor' | 'size'> {
   /** Additional CSS classes. */
   className?: string;
   /** Title string/node (renders header section). */
@@ -29,6 +35,8 @@ export interface MessageProps
   color?: 'primary' | 'link' | 'info' | 'success' | 'warning' | 'danger';
   /** Background color for the message (Bulma helper). */
   bgColor?: (typeof validColors)[number] | 'inherit' | 'current';
+  /** Size of the message. */
+  size?: MessageSize;
   /** Callback for the close ("X") button. */
   onClose?: () => void;
   /** Body content for the message. */
@@ -49,6 +57,7 @@ const MessageComponent: React.FC<MessageProps> = ({
   textColor,
   color,
   bgColor,
+  size,
   onClose,
   children,
   ...props
@@ -63,6 +72,7 @@ const MessageComponent: React.FC<MessageProps> = ({
   // Generate Bulma classes with prefix
   const bulmaClasses = usePrefixedClassNames('message', {
     [`is-${color}`]: color,
+    [`is-${size}`]: size && validMessageSizes.includes(size),
   });
   const deleteClass = usePrefixedClassNames('delete');
 

--- a/bulma-ui/src/components/__tests__/Message.test.tsx
+++ b/bulma-ui/src/components/__tests__/Message.test.tsx
@@ -15,6 +15,21 @@ describe('Message', () => {
     expect(screen.getByTestId('message')).toHaveClass('is-danger');
   });
 
+  it.each(['small', 'medium', 'large'] as const)(
+    'applies is-%s when size is set',
+    size => {
+      render(<Message size={size} title="Sized" />);
+      expect(screen.getByTestId('message')).toHaveClass(`is-${size}`);
+    }
+  );
+
+  it('does not apply a size class when size is unset', () => {
+    render(<Message title="Unsized" />);
+    expect(screen.getByTestId('message').className).not.toMatch(
+      /\bis-(small|medium|large)\b/
+    );
+  });
+
   it('calls onClose when close button clicked', () => {
     const onClose = jest.fn();
     render(

--- a/bulma-ui/src/elements/Buttons.stories.tsx
+++ b/bulma-ui/src/elements/Buttons.stories.tsx
@@ -28,6 +28,7 @@ const meta: Meta<typeof Buttons> = {
     isCentered: { control: 'boolean' },
     isRight: { control: 'boolean' },
     hasAddons: { control: 'boolean' },
+    size: { control: 'select', options: ['small', 'medium', 'large'] },
   },
   parameters: {
     docs: {
@@ -92,6 +93,34 @@ export const RightAligned: Story = {
     docs: {
       description: {
         story: 'Buttons wrapper with right alignment using is-right.',
+      },
+    },
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <>
+      <Buttons size="small">
+        <Button>Small</Button>
+        <Button color="info">Small</Button>
+      </Buttons>
+      <Buttons size="medium">
+        <Button>Medium</Button>
+        <Button color="info">Medium</Button>
+      </Buttons>
+      <Buttons size="large">
+        <Button>Large</Button>
+        <Button color="info">Large</Button>
+      </Buttons>
+    </>
+  ),
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Buttons wrapper with the group size modifier (are-small/are-medium/are-large) applied to all buttons at once.',
       },
     },
   },

--- a/bulma-ui/src/elements/Buttons.tsx
+++ b/bulma-ui/src/elements/Buttons.tsx
@@ -9,11 +9,19 @@ import {
   validColors,
 } from '../helpers/useBulmaClasses';
 
+const validButtonsSizes = ['small', 'medium', 'large'] as const;
+/**
+ * Valid size values for the Buttons component (Bulma button group sizes).
+ */
+export type ButtonsSize = (typeof validButtonsSizes)[number];
+
 /**
  * Props for the Buttons component.
  */
 interface ButtonsProps
-  extends React.HTMLAttributes<HTMLDivElement>, BulmaClassesProps {
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    Omit<BulmaClassesProps, 'size'> {
   /** Additional CSS classes to apply. */
   className?: string;
   /** Text color helper for the button group. */
@@ -33,6 +41,8 @@ interface ButtonsProps
   isRight?: boolean;
   /** Group buttons together as addons (removes spacing between them). */
   hasAddons?: boolean;
+  /** Size of the button group. */
+  size?: ButtonsSize;
   /** The button elements to render inside the group. */
   children: React.ReactNode;
 }
@@ -53,6 +63,7 @@ const ButtonsComponent: React.FC<ButtonsProps> = ({
   isCentered,
   isRight,
   hasAddons,
+  size,
   children,
   ...props
 }) => {
@@ -60,6 +71,7 @@ const ButtonsComponent: React.FC<ButtonsProps> = ({
     'is-centered': isCentered,
     'is-right': isRight,
     'has-addons': hasAddons,
+    [`are-${size}`]: size && validButtonsSizes.includes(size),
   });
 
   /**

--- a/bulma-ui/src/elements/Tags.stories.tsx
+++ b/bulma-ui/src/elements/Tags.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta<typeof Tags> = {
   argTypes: {
     hasAddons: { control: 'boolean' },
     isMultiline: { control: 'boolean' },
+    size: { control: 'select', options: ['medium', 'large'] },
     m: {
       control: 'select',
       options: ['0', '1', '2', '3', '4', '5', '6', 'auto'],
@@ -80,6 +81,21 @@ export const Multiline: Story = {
       </>
     ),
   },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <>
+      <Tags size="medium">
+        <Tag color="primary">Medium</Tag>
+        <Tag color="info">Medium</Tag>
+      </Tags>
+      <Tags size="large">
+        <Tag color="primary">Large</Tag>
+        <Tag color="info">Large</Tag>
+      </Tags>
+    </>
+  ),
 };
 
 export const WithMargin: Story = {

--- a/bulma-ui/src/elements/Tags.tsx
+++ b/bulma-ui/src/elements/Tags.tsx
@@ -4,19 +4,27 @@ import { withSubComponents } from '../helpers/withSubComponents';
 import { useBulmaClasses, BulmaClassesProps } from '../helpers/useBulmaClasses';
 import { Tag } from './Tag';
 
+const validTagsSizes = ['medium', 'large'] as const;
+/**
+ * Valid size values for the Tags component (Bulma tag group sizes).
+ */
+export type TagsSize = (typeof validTagsSizes)[number];
+
 /**
  * Props for the Tags component.
  */
 export interface TagsProps
   extends
     Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>,
-    Omit<BulmaClassesProps, 'backgroundColor' | 'color'> {
+    Omit<BulmaClassesProps, 'backgroundColor' | 'color' | 'size'> {
   /** Additional CSS classes to apply. */
   className?: string;
   /** Group tags together as add-ons (no spacing). */
   hasAddons?: boolean;
   /** Allow tags to wrap onto multiple lines. */
   isMultiline?: boolean;
+  /** Size of every tag in the group. */
+  size?: TagsSize;
   /** Tag elements to render inside the container. */
   children?: React.ReactNode;
 }
@@ -33,6 +41,7 @@ const TagsComponent: React.FC<TagsProps> = ({
   className,
   hasAddons,
   isMultiline,
+  size,
   children,
   ...props
 }) => {
@@ -44,6 +53,7 @@ const TagsComponent: React.FC<TagsProps> = ({
   const bulmaClasses = usePrefixedClassNames('tags', {
     'has-addons': hasAddons,
     'are-multiline': isMultiline,
+    [`are-${size}`]: size && validTagsSizes.includes(size),
   });
 
   const tagsClasses = classNames(bulmaClasses, bulmaHelperClasses, className);

--- a/bulma-ui/src/elements/__tests__/Buttons.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Buttons.test.tsx
@@ -59,6 +59,29 @@ describe('Buttons Component', () => {
     expect(buttons).toHaveClass('buttons has-addons');
   });
 
+  it.each(['small', 'medium', 'large'] as const)(
+    'applies are-%s when size is set',
+    size => {
+      render(
+        <Buttons size={size}>
+          <Button>Click Me</Button>
+        </Buttons>
+      );
+      const buttons = screen.getByText('Click Me').parentElement;
+      expect(buttons).toHaveClass(`are-${size}`);
+    }
+  );
+
+  it('does not apply a size class when size is unset', () => {
+    render(
+      <Buttons>
+        <Button>Click Me</Button>
+      </Buttons>
+    );
+    const buttons = screen.getByText('Click Me').parentElement;
+    expect(buttons?.className).not.toMatch(/\bare-/);
+  });
+
   it('applies textColor using useBulmaClasses', () => {
     render(
       <Buttons textColor="primary">

--- a/bulma-ui/src/elements/__tests__/Tags.test.tsx
+++ b/bulma-ui/src/elements/__tests__/Tags.test.tsx
@@ -28,6 +28,21 @@ describe('Tags Component', () => {
     expect(tags).toHaveClass('tags are-multiline');
   });
 
+  test.each(['medium', 'large'] as const)(
+    'applies are-%s when size is set',
+    size => {
+      render(<Tags {...defaultProps} size={size} />);
+      const tags = screen.getByText('Test Tag').parentElement;
+      expect(tags).toHaveClass(`are-${size}`);
+    }
+  );
+
+  test('does not apply a size class when size is unset', () => {
+    render(<Tags {...defaultProps} />);
+    const tags = screen.getByText('Test Tag').parentElement;
+    expect(tags?.className).not.toMatch(/\bare-(medium|large)\b/);
+  });
+
   test('applies Bulma helper classes (e.g., margin)', () => {
     render(<Tags {...defaultProps} m="4" />);
     const tags = screen.getByText('Test Tag').parentElement;

--- a/docs/docs/api/components/message.md
+++ b/docs/docs/api/components/message.md
@@ -102,14 +102,20 @@ function example() {
 
 ### Sizes
 
-You can use Bulma size helpers or custom styles to adjust the size of the message box for different contexts.
+Use the `size` prop (`'small'`, `'medium'`, `'large'`) to adjust the size of the message box for different contexts.
 
 ```tsx live
 <>
   <Message title="Default Size">This is the default size message.</Message>
-  <Message title="Small">This is a small message.</Message>
-  <Message title="Medium">This is a medium message.</Message>
-  <Message title="Large">This is a large message.</Message>
+  <Message size="small" title="Small">
+    This is a small message.
+  </Message>
+  <Message size="medium" title="Medium">
+    This is a medium message.
+  </Message>
+  <Message size="large" title="Large">
+    This is a large message.
+  </Message>
 </>
 ```
 
@@ -222,6 +228,7 @@ You can use all [Bulma helper props](../helpers/usebulmaclasses.md) with `<Messa
 | `textColor` | [Bulma color](../helpers/valid-values.md) \| `'inherit'` \| `'current'`         | —       | Text color for the message (Bulma helper).        |
 | `color`     | `'primary'` \| `'link'` \| `'info'` \| `'success'` \| `'warning'` \| `'danger'` | —       | Bulma color modifier for the message.             |
 | `bgColor`   | [Bulma color](../helpers/valid-values.md) \| `'inherit'` \| `'current'`         | —       | Background color for the message (Bulma helper).  |
+| `size`      | `'small'` \| `'medium'` \| `'large'`                                            | —       | Size of the message.                              |
 | `onClose`   | `() => void`                                                                    | —       | Callback for the close ("X") button.              |
 | `children`  | `React.ReactNode`                                                               | —       | Body content for the message.                     |
 | `...`       | All standard HTML attributes and Bulma helper props                             | —       | See [Helper Props](../helpers/usebulmaclasses.md) |

--- a/docs/docs/api/elements/buttons.md
+++ b/docs/docs/api/elements/buttons.md
@@ -76,6 +76,27 @@ Demonstrates a group of buttons with different `size` props (`small`, `normal`, 
 </Buttons>
 ```
 
+### Group Size
+
+Set the `size` prop (`'small'`, `'medium'`, `'large'`) on `Buttons` to size every button in the group at once, instead of setting `size` on each `Button` individually.
+
+```tsx live
+<>
+  <Buttons size="small">
+    <Button color="primary">Small</Button>
+    <Button color="info">Small</Button>
+  </Buttons>
+  <Buttons size="medium">
+    <Button color="primary">Medium</Button>
+    <Button color="info">Medium</Button>
+  </Buttons>
+  <Buttons size="large">
+    <Button color="primary">Large</Button>
+    <Button color="info">Large</Button>
+  </Buttons>
+</>
+```
+
 ### Add-ons (No Spacing Between Buttons)
 
 The `hasAddons` prop removes spacing between buttons, making them appear as a single connected group. This is useful for segmented controls or tightly grouped actions.
@@ -165,6 +186,7 @@ You can use all Bulma helper props (spacing, color, alignment) with `Buttons` fo
 | `isCentered` | `boolean`                                                                       | `false` | Center the group of buttons.                                                                                                                                                                                                                                                   |
 | `isRight`    | `boolean`                                                                       | `false` | Align the group of buttons to the right.                                                                                                                                                                                                                                       |
 | `hasAddons`  | `boolean`                                                                       | `false` | Group buttons together as addons (removes spacing between them).                                                                                                                                                                                                               |
+| `size`       | `'small'` \| `'medium'` \| `'large'`                                            | —       | Size of the button group.                                                                                                                                                                                                                                                      |
 | `children`   | `React.ReactNode`                                                               | —       | The button elements to render inside the group.                                                                                                                                                                                                                                |
 | `...`        | All standard `<div>` attributes and Bulma helper props                          | —       | See [Helper Props](../helpers/usebulmaclasses.md)                                                                                                                                                                                                                              |
 

--- a/docs/docs/api/elements/tags.md
+++ b/docs/docs/api/elements/tags.md
@@ -74,6 +74,23 @@ Use the `isMultiline` prop to allow tags to wrap onto multiple lines, making the
 </Tags>
 ```
 
+### Group Size
+
+Set the `size` prop (`'medium'`, `'large'`) on `Tags` to size every tag in the group at once, instead of setting `size` on each `Tag` individually. Bulma has no `.tags.are-small` class, so `'small'` is not a valid value here.
+
+```tsx live
+<>
+  <Tags size="medium">
+    <Tag color="primary">Medium</Tag>
+    <Tag color="info">Medium</Tag>
+  </Tags>
+  <Tags size="large">
+    <Tag color="primary">Large</Tag>
+    <Tag color="info">Large</Tag>
+  </Tags>
+</>
+```
+
 ### With Margin
 
 You can use Bulma helper props like `m="4"` to add margin around the tag group for spacing within layouts.
@@ -170,6 +187,7 @@ Use `hasAddons` for tightly grouped tags (no space between them).
 | `className`   | `string`                                               | —       | Additional CSS classes to apply.                  |
 | `hasAddons`   | `boolean`                                              | `false` | Group tags together as add-ons (no spacing).      |
 | `isMultiline` | `boolean`                                              | `false` | Allow tags to wrap onto multiple lines.           |
+| `size`        | `'medium'` \| `'large'`                                | —       | Size of every tag in the group.                   |
 | `children`    | `React.ReactNode`                                      | —       | Tag elements to render inside the container.      |
 | `...`         | All standard `<div>` attributes and Bulma helper props | —       | See [Helper Props](../helpers/usebulmaclasses.md) |
 


### PR DESCRIPTION
## Summary

- `Buttons` gains `size?: 'small' | 'medium' | 'large'`, emitting `are-${size}` (`ButtonsSize`)
- `Tags` gains `size?: 'medium' | 'large'`, emitting `are-${size}` (`TagsSize`) — no `'small'`, since Bulma ships no `.tags.are-small`
- `Message` gains `size?: 'small' | 'medium' | 'large'`, emitting `is-${size}` (`MessageSize`)

Each type is its own per-component constant (matching the `TagSize` precedent on `Tag.tsx`), not a shared helper-prop `size` on `BulmaClassesProps` — that generic helper is an explicit non-goal in the issue.

Fixes #620

## Changes

- `bulma-ui/src/elements/Buttons.tsx`, `bulma-ui/src/elements/Tags.tsx`, `bulma-ui/src/components/Message.tsx` — the new prop + class emission
- Tests in `Buttons.test.tsx`, `Tags.test.tsx`, `Message.test.tsx` asserting each emitted class and that an unset `size` emits nothing
- A `Sizes` story for `Buttons`/`Tags`; `Message.stories.tsx`'s pre-existing `Small`/`Medium`/`Large` stories now actually pass `size` (they previously rendered identically to `DefaultSize`)
- `docs/docs/api/elements/buttons.md`, `tags.md`, `docs/docs/api/components/message.md` — a hand-written "Group Size" usage section each (Message's existing "Sizes" section is fixed the same way); generated Props tables and `bestax-mcp/data` refreshed via `pnpm gen`

## Test plan

- [x] `pnpm --filter @allxsmith/bestax-bulma run lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm --filter @allxsmith/bestax-bulma run typecheck` — clean
- [x] `pnpm --filter @allxsmith/bestax-bulma run test:coverage` — 3967 tests pass, `Buttons.tsx`/`Tags.tsx`/`Message.tsx` at 100% coverage, package-wide 99.62%
- [x] `pnpm run format:check` — clean
- [x] `pnpm run gen:catalog:check` — clean
- [x] `pnpm run check:conformance` — all checks pass
- [x] `pnpm --filter @allxsmith/bestax-bulma run build` and `run build-storybook` — both succeed

Generated with [Claude Code](https://claude.ai/code)