### PR TITLE
docs: record the lessons from the rbx migration source before the next one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@ pnpm storybook      # Storybook dev server :6006
 pnpm exec turbo run test --filter=@allxsmith/bestax-bulma   # scope any task to one package
 ```
 
+Run `pnpm format` before `pnpm lint` when running a subset by hand: lint includes prettier
+(`eslint-plugin-prettier`), so an unformatted tree fails lint while typecheck and tests pass, and
+turbo reports "1 of 3 successful" with the cause several screens up. `pnpm all` orders them.
+
 ## Quality gates
 
 Enforced by CI (`.github/workflows/ci.yml`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,9 @@ pnpm storybook      # Storybook dev server :6006
 pnpm exec turbo run test --filter=@allxsmith/bestax-bulma   # scope any task to one package
 ```
 
-Run `pnpm format` before `pnpm lint`: lint includes prettier (`eslint-plugin-prettier`), so an
-unformatted tree fails lint while typecheck and tests pass. `pnpm all` runs lint before
-`format:check` and never formats, so it fails the same way. In a multi-task `turbo run` the
-summary reads ` Tasks: 1 successful, 3 total` with the cause several screens up.
+- Run `pnpm format` before `pnpm lint`: lint includes prettier (`eslint-plugin-prettier`), so an
+  unformatted tree fails lint while typecheck and tests pass, and `pnpm all` runs lint before
+  `format:check` without formatting, so it fails there too. A multi-task `turbo run` buries the cause.
 
 ## Quality gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,10 @@ pnpm storybook      # Storybook dev server :6006
 pnpm exec turbo run test --filter=@allxsmith/bestax-bulma   # scope any task to one package
 ```
 
-Run `pnpm format` before `pnpm lint` when running a subset by hand: lint includes prettier
-(`eslint-plugin-prettier`), so an unformatted tree fails lint while typecheck and tests pass, and
-turbo reports "1 of 3 successful" with the cause several screens up. `pnpm all` orders them.
+Run `pnpm format` before `pnpm lint`: lint includes prettier (`eslint-plugin-prettier`), so an
+unformatted tree fails lint while typecheck and tests pass. `pnpm all` runs lint before
+`format:check` and never formats, so it fails the same way. In a multi-task `turbo run` the
+summary reads ` Tasks: 1 successful, 3 total` with the cause several screens up.
 
 ## Quality gates
 

--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -37,22 +37,19 @@ each source library registers in `src/sources/registry.ts`. Two are shipped —
   statement + a report entry — never a silent skip, never a best-guess rewrite of dynamic
   values.
 - **A TODO message is a claim about bestax; read the component before writing it.** Four
-  shipped on #613 were false (Modal "always closes on Escape"; a Field TODO naming `isGrouped`,
-  which does not exist). The rbx e2e fails on an undocumented rule (the RBC e2e has no such
-  check); nothing checks that the guidance is true.
+  shipped on #613 were false (Modal "always closes on Escape"; a Field TODO naming `isGrouped`).
+  The rbx e2e fails on an undocumented rule (RBC's does not); nothing checks the guidance is true.
 - **A defect in one source's `transform.ts` is almost certainly in the other.** Nine fixes were
   ported RBC↔rbx on #613 and review kept finding the unported half. Fix the sibling in the same
   commit, or move the logic into `_shared/`.
 - **Resolve references by binding, not by identifier text.** Every serious bug on #613 came
-  from a name-keyed map (`function F(Header)` rewritten to `F(Card.Header)`). Use the owner-keyed
-  `aliasAt` resolver in each `transform.ts` (duplicated; hoist to `_shared/` before a third
-  source): ancestors decide ownership, then `scope.lookup` vetoes a nearer binding.
+  from a name-keyed map (`function F(Header)` became `F(Card.Header)`). Use `aliasAt` in each
+  `transform.ts` (duplicated; hoist it): ancestors decide ownership, `scope.lookup` vetoes a nearer binding.
 - **The report may only describe what actually happened.** The manifest headline said "bumped
   bulma" in most manifest shapes where nothing was bumped. Track each mutation; phrase from it.
-- **The stylesheet pass and the manifest pass must agree on what is removable.** Both report
-  rather than remove the `bulma-*` extensions, since markup outside the source may still use
-  their classes. The set is defined three times (`rbx/deps.ts`, `rbx/transform.ts`,
-  `_shared/make-styles-transform.ts`); keep them agreeing, and RBC's manifest pass has none.
+- **The stylesheet and manifest passes must agree on what is removable.** Both report rather
+  than remove `bulma-*` extensions, since markup outside the source may still use their classes.
+  rbx enumerates its four in `deps.ts` and `transform.ts`; the shared Sass pass flags any `bulma-*`.
 - **Never change `bulma-ui` to make a migration cleaner.** Map onto the library as it is and
   emit a TODO otherwise. A gap earns a `bulma-ui` issue only if it is a bestax defect or the
   source is genuinely better, not merely different (#616 to #622 are the worked example).
@@ -111,10 +108,9 @@ each source library registers in `src/sources/registry.ts`. Two are shipped —
   sees bestax's _real_ prop names. Both are needed — the rbx e2e's typecheck caught six
   mapping errors that 254 clean Playgrounds had not.
 
-- After editing a test file, check the total test count did not drop. A range replacement
-  between two `describe` blocks that were not adjacent deleted 868 lines on #613 and the suite
-  stayed green at 699 tests instead of 781. Compare the `Tests:` line from `pnpm test` in
-  `bestax-migrate/` (bare `jest` breaks on ESM and reports a different count).
+- After editing a test file, check the total test count did not drop: a range replacement
+  between two non-adjacent `describe` blocks deleted 868 lines on #613 and the suite stayed green
+  at 699 instead of 781. Compare the `Tests:` line from `pnpm test` (bare `jest` miscounts on ESM).
 
 ## Releases
 

--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -36,6 +36,25 @@ each source library registers in `src/sources/registry.ts`. Two are shipped —
 - Anything unsafe gets a `// TODO(bestax-migrate): <hint>` comment on the enclosing
   statement + a report entry — never a silent skip, never a best-guess rewrite of dynamic
   values.
+- **A TODO message is a claim about bestax; read the component before writing it.** Four
+  shipped on #613 were false (Modal "always closes on Escape"; a Field TODO naming `isGrouped`,
+  which does not exist). The e2e fails on an undocumented rule; nothing checks the guidance is true.
+- **A defect in one source's `transform.ts` is almost certainly in the other.** Nine fixes were
+  ported RBC↔rbx on #613 and review kept finding the unported half. Fix the sibling in the same
+  commit, or move the logic into `_shared/`.
+- **Resolve references by binding, not by identifier text.** Name-keyed maps produced every
+  serious bug on #613 (a shadowing parameter rewritten to `F(Card.Header)`; two scopes
+  destructuring one name). Use the alias/scope machinery in `_shared/imports.ts`. `path.scope`
+  is not identity-stable and a pruned declaration vanishes from `scope.lookup`, which is why
+  ownership is keyed by the owner node and resolved by walking the reference's ancestors.
+- **The report may only describe what actually happened.** The manifest headline said "bumped
+  bulma" in three of four shapes where nothing was bumped. Track each mutation; phrase from it.
+- **The stylesheet pass and the manifest pass must agree on what is removable.** Both report
+  rather than remove the `bulma-*` extensions, since markup outside the source may still use
+  their classes. One policy for both.
+- **Never change `bulma-ui` to make a migration cleaner.** Map onto the library as it is and
+  emit a TODO otherwise. A gap earns a `bulma-ui` issue only if it is a bestax defect or the
+  source is genuinely better, not merely different (#616 to #622 are the worked example).
 
 ## Architecture
 
@@ -90,6 +109,10 @@ each source library registers in `src/sources/registry.ts`. Two are shipped —
   The corpus is the only check that sees breadth; the kitchen-sink e2e is the only one that
   sees bestax's _real_ prop names. Both are needed — the rbx e2e's typecheck caught six
   mapping errors that 254 clean Playgrounds had not.
+
+- After editing a test file, check the total test count did not drop. A range replacement
+  between two `describe` blocks that were not adjacent deleted 868 lines on #613 and the suite
+  stayed green at 699 tests instead of 781. Green alone does not catch it; the count does.
 
 ## Releases
 

--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -38,20 +38,21 @@ each source library registers in `src/sources/registry.ts`. Two are shipped —
   values.
 - **A TODO message is a claim about bestax; read the component before writing it.** Four
   shipped on #613 were false (Modal "always closes on Escape"; a Field TODO naming `isGrouped`,
-  which does not exist). The e2e fails on an undocumented rule; nothing checks the guidance is true.
+  which does not exist). The rbx e2e fails on an undocumented rule (the RBC e2e has no such
+  check); nothing checks that the guidance is true.
 - **A defect in one source's `transform.ts` is almost certainly in the other.** Nine fixes were
   ported RBC↔rbx on #613 and review kept finding the unported half. Fix the sibling in the same
   commit, or move the logic into `_shared/`.
-- **Resolve references by binding, not by identifier text.** Name-keyed maps produced every
-  serious bug on #613 (a shadowing parameter rewritten to `F(Card.Header)`; two scopes
-  destructuring one name). Use the alias/scope machinery in `_shared/imports.ts`. `path.scope`
-  is not identity-stable and a pruned declaration vanishes from `scope.lookup`, which is why
-  ownership is keyed by the owner node and resolved by walking the reference's ancestors.
+- **Resolve references by binding, not by identifier text.** Every serious bug on #613 came
+  from a name-keyed map (`function F(Header)` rewritten to `F(Card.Header)`). Use the owner-keyed
+  `aliasAt` resolver in each `transform.ts` (duplicated; hoist to `_shared/` before a third
+  source): ancestors decide ownership, then `scope.lookup` vetoes a nearer binding.
 - **The report may only describe what actually happened.** The manifest headline said "bumped
-  bulma" in three of four shapes where nothing was bumped. Track each mutation; phrase from it.
+  bulma" in most manifest shapes where nothing was bumped. Track each mutation; phrase from it.
 - **The stylesheet pass and the manifest pass must agree on what is removable.** Both report
   rather than remove the `bulma-*` extensions, since markup outside the source may still use
-  their classes. One policy for both.
+  their classes. The set is defined three times (`rbx/deps.ts`, `rbx/transform.ts`,
+  `_shared/make-styles-transform.ts`); keep them agreeing, and RBC's manifest pass has none.
 - **Never change `bulma-ui` to make a migration cleaner.** Map onto the library as it is and
   emit a TODO otherwise. A gap earns a `bulma-ui` issue only if it is a bestax defect or the
   source is genuinely better, not merely different (#616 to #622 are the worked example).
@@ -63,12 +64,12 @@ each source library registers in `src/sources/registry.ts`. Two are shipped —
   in-process runner (NOT jscodeshift's worker Runner: fragile from ESM, hides per-file
   stats). `src/runner.ts` is shared by CLI and tests. `--css bestax|bulma|keep` picks the
   stylesheet target; `--no-deps` skips the manifest step.
-- `src/sources/react-bulma-components/`: `transform.ts` (orchestration: imports + css →
-  per-element special/rename/responsive/props → import rewrite), `mapping.ts` (data),
-  `specials.ts` (structural handlers), `props.ts` (PropAction interpreter), `responsive.ts`
-  (breakpoint-object flattening), `styles.ts` (line-based SCSS/SASS transform — Sass has
-  no jscodeshift parser, so it only rewrites provably-safe patterns), `deps.ts`
-  (package.json updater; never runs an install), `jsx-utils.ts` (AST helpers).
+- `src/sources/react-bulma-components/` (and `rbx/`, same shape): `transform.ts`
+  (orchestration: imports + css → per-element special/rename/responsive/props → import
+  rewrite), `mapping.ts` (data), `specials.ts` (structural handlers), `responsive.ts`
+  (breakpoint-object flattening), `styles.ts` (a thin call into `_shared/make-styles-transform.ts`,
+  line-based because Sass has no jscodeshift parser), `deps.ts` (package.json updater; never
+  runs an install). The PropAction interpreter and AST helpers live in `_shared/`.
 - Components with no bestax equivalent (Element, Tile) keep a trimmed, TODO-annotated RBC
   import so the code still runs during gradual migration.
 - `src/telemetry-core.ts` is a byte-for-byte copy of
@@ -112,7 +113,8 @@ each source library registers in `src/sources/registry.ts`. Two are shipped —
 
 - After editing a test file, check the total test count did not drop. A range replacement
   between two `describe` blocks that were not adjacent deleted 868 lines on #613 and the suite
-  stayed green at 699 tests instead of 781. Green alone does not catch it; the count does.
+  stayed green at 699 tests instead of 781. Compare the `Tests:` line from `pnpm test` in
+  `bestax-migrate/` (bare `jest` breaks on ESM and reports a different count).
 
 ## Releases
 


### PR DESCRIPTION
Closes #623.

Eight bullets, one to three lines each, under existing headings. No new sections.

**`bestax-migrate/CLAUDE.md`, Hard rules (6):** a TODO message is a claim about bestax; a defect in one source's transform is in the other; resolve references by binding, not name; the report may only describe what happened; stylesheet and manifest passes agree on what is removable; never change `bulma-ui` to make a migration cleaner.

**`bestax-migrate/CLAUDE.md`, Testing (1):** check the test count did not drop after editing a test file.

**Root `CLAUDE.md`, Commands (1):** run `pnpm format` before `pnpm lint` when hand-running a subset; lint includes prettier (`eslint-plugin-prettier`, verified in `eslint.config.js:6`).

Each bullet names the #613 incident behind it. `bestax-migrate/CLAUDE.md` grows by 22 lines, under the 25-line cap in the issue. `pnpm format:check` is green on both files. Docs-only; releases nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development command guidance to clarify formatting and linting order when running selected tasks manually.
  - Added migration guidance covering TODO verification, defect handling, reference resolution, accurate reporting, stylesheet and manifest consistency, and avoiding unnecessary source changes.
  - Added testing guidance to verify test counts after editing test files and help prevent accidental test removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->