### PR TITLE
fix(bestax-migrate): share the bulma range parser so RBC bumps comparator ranges too

### DIFF
--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -34,13 +34,19 @@ function setIsPreV1(set: string): boolean {
   if (text === '' || /^(\*|x|X|latest)$/.test(text)) return false;
   const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
   if (hyphen) {
+    // Both endpoints must be tokens this parser reads; `not-a-range - 0.9.4`
+    // was accepted on its upper bound alone and overwritten.
+    const lower = majorOf(hyphen[1]);
     const upper = majorOf(hyphen[2]);
+    if (lower === null || upper === null) return false;
     return upper === 0 || (upper === 1 && isPrereleaseOfOne(hyphen[2]));
   }
 
   let cappedBelowOne = false;
   for (const token of text.split(/\s+/)) {
-    const match = token.match(/^(>=|<=|>|<|=)?\s*v?(.*)$/);
+    // Prefix handling (`v`, `^`, `~`, `=`) lives in majorOf alone; stripping a
+    // `v` here too let `vv0.9.4` through as two single strips.
+    const match = token.match(/^(>=|<=|>|<|=)?(.*)$/);
     if (!match) return false;
     const [, op = '', version] = match;
     const major = majorOf(version);
@@ -55,7 +61,7 @@ function setIsPreV1(set: string): boolean {
         // `<1.0.0-0` (below the lowest 1.0.0 prerelease); `<0.9` does too.
         if (
           major === 0 ||
-          (major === 1 && /^1(\.0){0,2}$/.test(version)) ||
+          (major === 1 && /^1(\.0){0,2}(\+[0-9A-Za-z.-]+)?$/.test(version)) ||
           isPrereleaseOfOne(version)
         ) {
           cappedBelowOne = true;
@@ -86,10 +92,11 @@ function setIsPreV1(set: string): boolean {
 }
 
 /**
- * `1.0.0-0`, `1.0.0-rc.1`, `1.0-beta`: a prerelease of exactly 1.0.0 orders
- * below every stable 1.x, so as an upper bound or an exact pin it admits no
- * usable v1. A caret or tilde on one is different (`^1.0.0-rc.1` admits
- * 1.0.4), which is why the callers check the operator first.
+ * `1.0.0-0`, `1.0.0-rc.1`: a prerelease of exactly 1.0.0 orders below every
+ * stable 1.x, so as an upper bound or an exact pin it admits no usable v1.
+ * Three numeric parts only, matching semver; `1.0-beta` is not a token this
+ * parser reads and is left alone. A caret or tilde on one is different
+ * (`^1.0.0-rc.1` admits 1.0.4), which is why the callers check the operator.
  */
 function isPrereleaseOfOne(version: string): boolean {
   return /^1\.0\.0-/.test(version);
@@ -130,8 +137,10 @@ export function isRecognisedRange(range: string): boolean {
  * (`0.x`, `0.7.*`) are accepted in the minor and patch positions.
  */
 function majorOf(version: string): number | null {
+  // At most one of `^`, `~`, `=` and at most one `v`: stripping any run of
+  // them accepted `^^0.9.4` and `vv0.9.4` as major 0 and overwrote them.
   const m = version
-    .replace(/^[~^=v]+/, '')
+    .replace(/^(?:[~^=]v?|v)?/, '')
     .match(
       /^(\d+)(?:\.(?:\d+|x|X|\*)(?:\.(?:x|X|\*|\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?))?)?$/
     );

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -99,7 +99,9 @@ function setIsPreV1(set: string): boolean {
  * (`^1.0.0-rc.1` admits 1.0.4), which is why the callers check the operator.
  */
 function isPrereleaseOfOne(version: string): boolean {
-  return /^1\.0\.0-/.test(version);
+  // `majorOf` accepts a leading `v`, so this must too, or `v1.0.0-rc.1` is
+  // read as a v1 pin and left alone while `1.0.0-rc.1` is bumped.
+  return /^v?1\.0\.0-/.test(version);
 }
 
 function glueOperators(set: string): string {
@@ -139,10 +141,10 @@ export function isRecognisedRange(range: string): boolean {
 function majorOf(version: string): number | null {
   // At most one of `^`, `~`, `=` and at most one `v`: stripping any run of
   // them accepted `^^0.9.4` and `vv0.9.4` as major 0 and overwrote them.
-  const m = version
-    .replace(/^(?:[~^=]v?|v)?/, '')
-    .match(
-      /^(\d+)(?:\.(?:\d+|x|X|\*)(?:\.(?:x|X|\*|\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?))?)?$/
-    );
+  const m = version.replace(/^(?:[~^=]v?|v)?/, '').match(
+    // Numeric parts are `0|[1-9]\d*`: SemVer forbids leading zeros, and
+    // `00.9.4` / `0.07.0` were being read as major 0 and overwritten.
+    /^(0|[1-9]\d*)(?:\.(?:0|[1-9]\d*|x|X|\*)(?:\.(?:x|X|\*|(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?))?)?$/
+  );
   return m ? Number(m[1]) : null;
 }

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -34,7 +34,8 @@ function setIsPreV1(set: string): boolean {
   if (text === '' || /^(\*|x|X|latest)$/.test(text)) return false;
   const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
   if (hyphen) {
-    return majorOf(hyphen[2]) === 0 || isPrereleaseOfOne(hyphen[2]);
+    const upper = majorOf(hyphen[2]);
+    return upper === 0 || (upper === 1 && isPrereleaseOfOne(hyphen[2]));
   }
 
   let cappedBelowOne = false;
@@ -91,7 +92,7 @@ function setIsPreV1(set: string): boolean {
  * 1.0.4), which is why the callers check the operator first.
  */
 function isPrereleaseOfOne(version: string): boolean {
-  return /^1(\.0){0,2}-/.test(version);
+  return /^1\.0\.0-/.test(version);
 }
 
 function glueOperators(set: string): string {
@@ -120,7 +121,19 @@ export function isRecognisedRange(range: string): boolean {
     });
 }
 
+/**
+ * The major of a COMPLETE semver token, or null. Reading only the numeric
+ * prefix accepted a dist-tag like `0.next` as major 0, and the manifest was
+ * then overwritten with `^1.0.4`, which is the one thing this parser must
+ * never do to a value it does not understand. A prerelease or build suffix is
+ * accepted only after three numeric parts, matching semver itself; x-ranges
+ * (`0.x`, `0.7.*`) are accepted in the minor and patch positions.
+ */
 function majorOf(version: string): number | null {
-  const m = version.replace(/^[~^=v]+/, '').match(/^(\d+)(?:\.|$)/);
+  const m = version
+    .replace(/^[~^=v]+/, '')
+    .match(
+      /^(\d+)(?:\.(?:\d+|x|X|\*)(?:\.(?:x|X|\*|\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?))?)?$/
+    );
   return m ? Number(m[1]) : null;
 }

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -1,0 +1,101 @@
+/**
+ * Minimal semver-range reading for the manifest passes, shared by every source.
+ *
+ * Not a semver implementation: the workspace deliberately carries no `semver`
+ * dependency for this, and the two questions the passes ask are narrow. Both
+ * are answered conservatively, so an unrecognised shape is left alone rather
+ * than guessed at.
+ */
+
+/**
+ * True only when `range` PROVABLY admits no version >= 1.0.0.
+ *
+ * The first version of this matched a leading `0` and nothing else, so a range
+ * written as comparators (`>=0.7 <1`) was left on 0.x and then reported as
+ * already v1. It lived in the rbx source only; the react-bulma-components
+ * manifest pass kept the regex until review found the unported half.
+ * This walks each `||` alternative and its comparators: a set is pre-v1 when
+ * some comparator caps it below 1.0.0 and none of them opens it at 1 or above.
+ *
+ * Conservative by design: an unrecognised shape returns false and the range is
+ * left alone (and reported as such). Bumping a range that might already admit
+ * v1 would be the best-guess rewrite this package refuses to make.
+ */
+export function isPreV1(range: string): boolean {
+  const alternatives = range.trim().split(/\s*\|\|\s*/);
+  return alternatives.length > 0 && alternatives.every(setIsPreV1);
+}
+
+function setIsPreV1(set: string): boolean {
+  // npm accepts whitespace between an operator and its version
+  // (`>= 0.7.0 < 1.0.0`); splitting on whitespace first made the operator a
+  // token of its own, so the range parsed as unrecognised and was left alone.
+  const text = glueOperators(set);
+  if (text === '' || /^(\*|x|X|latest)$/.test(text)) return false;
+  const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
+  if (hyphen) return majorOf(hyphen[2]) === 0;
+
+  let cappedBelowOne = false;
+  for (const token of text.split(/\s+/)) {
+    const match = token.match(/^(>=|<=|>|<|=)?\s*v?(.*)$/);
+    if (!match) return false;
+    const [, op = '', version] = match;
+    const major = majorOf(version);
+    if (major === null) return false;
+    switch (op) {
+      case '>':
+      case '>=':
+        if (major >= 1) return false;
+        break;
+      case '<':
+        // `<1`, `<1.0`, `<1.0.0` exclude every v1; `<0.9` does too.
+        if (major === 0 || (major === 1 && /^1(\.0)*$/.test(version))) {
+          cappedBelowOne = true;
+        } else {
+          return false;
+        }
+        break;
+      case '<=':
+        if (major === 0) cappedBelowOne = true;
+        else return false;
+        break;
+      default:
+        // `0.9.4`, `=0.9.4`, `^0.9`, `~0.7.5`, `0.x`: caret and tilde never
+        // cross a major, so major 0 stays below 1.
+        if (major === 0) cappedBelowOne = true;
+        else return false;
+    }
+  }
+  return cappedBelowOne;
+}
+
+function glueOperators(set: string): string {
+  return set.trim().replace(/(>=|<=|>|<|=)\s+/g, '$1');
+}
+
+/**
+ * True when every comparator in every alternative parses to a semver major,
+ * so the headline can tell "already v1" apart from "not a version range at
+ * all" (`latest`, a git URL) rather than calling both v1.
+ */
+export function isRecognisedRange(range: string): boolean {
+  return range
+    .trim()
+    .split(/\s*\|\|\s*/)
+    .every(alt => {
+      const text = glueOperators(alt);
+      if (/^(\*|x|X)$/.test(text)) return true;
+      const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
+      if (hyphen) {
+        return majorOf(hyphen[1]) !== null && majorOf(hyphen[2]) !== null;
+      }
+      return text
+        .split(/\s+/)
+        .every(tok => majorOf(tok.replace(/^(>=|<=|>|<|=)/, '')) !== null);
+    });
+}
+
+function majorOf(version: string): number | null {
+  const m = version.replace(/^[~^=v]+/, '').match(/^(\d+)(?:\.|$)/);
+  return m ? Number(m[1]) : null;
+}

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -143,7 +143,8 @@ function isPrereleaseOfOne(version: string): boolean {
 function glueOperators(set: string): string {
   // Only when what follows starts a plain version. Gluing unconditionally
   // turned the invalid `> =0.7` into a valid `>=0.7`, which was then bumped.
-  return set.trim().replace(/(>=|<=|>|<|=)\s+(?=[0-9vxX*])/g, '$1');
+  // node-semver normalises a spaced tilde or caret (`~ 0.7.5`) the same way.
+  return set.trim().replace(/(>=|<=|>|<|=|~|\^)\s+(?=[0-9vxX*])/g, '$1');
 }
 
 /**

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -4,8 +4,20 @@
  * Not a semver implementation: the workspace deliberately carries no `semver`
  * dependency for this, and the two questions the passes ask are narrow. Both
  * are answered conservatively, so an unrecognised shape is left alone rather
- * than guessed at.
+ * than guessed at. The one thing this file must never do is rewrite a value it
+ * does not understand, so every accepting path below goes through one grammar.
  */
+
+const NUMERIC = String.raw`(?:0|[1-9]\d*)`;
+const WILD = String.raw`(?:x|X|\*)`;
+/**
+ * A plain version or x-range: `N`, `N.N`, `N.N.N[-pre][+build]`, `N.x`,
+ * `N.x.x`, `N.N.x`. SemVer forbids leading zeros in numeric parts, and once a
+ * component is a wildcard everything after it must be a wildcard or omitted.
+ */
+const VERSION = new RegExp(
+  `^(${NUMERIC})(?:\\.(?:${NUMERIC}(?:\\.(?:${WILD}|${NUMERIC}(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?))?|${WILD}(?:\\.${WILD})?))?$`
+);
 
 /**
  * True only when `range` PROVABLY admits no version >= 1.0.0.
@@ -34,34 +46,38 @@ function setIsPreV1(set: string): boolean {
   if (text === '' || /^(\*|x|X|latest)$/.test(text)) return false;
   const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
   if (hyphen) {
-    // Both endpoints must be tokens this parser reads; `not-a-range - 0.9.4`
-    // was accepted on its upper bound alone and overwritten.
-    const lower = majorOf(hyphen[1]);
-    const upper = majorOf(hyphen[2]);
+    // Both endpoints must be plain versions; `not-a-range - 0.9.4` was
+    // accepted on its upper bound alone and overwritten.
+    const lower = versionMajor(hyphen[1]);
+    const upper = versionMajor(hyphen[2]);
     if (lower === null || upper === null) return false;
     return upper === 0 || (upper === 1 && isPrereleaseOfOne(hyphen[2]));
   }
 
   let cappedBelowOne = false;
   for (const token of text.split(/\s+/)) {
-    // Prefix handling (`v`, `^`, `~`, `=`) lives in majorOf alone; stripping a
-    // `v` here too let `vv0.9.4` through as two single strips.
     const match = token.match(/^(>=|<=|>|<|=)?(.*)$/);
     if (!match) return false;
     const [, op = '', version] = match;
-    const major = majorOf(version);
+    // After a comparator only a plain version may follow: `==0.9.4` and
+    // `<^0.9` were each read by stripping a second operator, then overwritten.
+    const major = op ? versionMajor(version) : majorOf(version);
     if (major === null) return false;
+    const plain = version.replace(/^v/, '');
     switch (op) {
       case '>':
       case '>=':
-        if (major >= 1) return false;
+        // A lower bound on a 1.0.0 prerelease (`>=1.0.0-rc.1`) does not open
+        // the range at a stable v1; keep scanning for an upper cap.
+        if (major >= 1 && !isPrereleaseOfOne(version)) return false;
         break;
       case '<':
-        // `<1`, `<1.0`, `<1.0.0` exclude every v1, and so does npm's canonical
-        // `<1.0.0-0` (below the lowest 1.0.0 prerelease); `<0.9` does too.
+        // `<1`, `<1.0`, `<1.0.0` (build metadata carries no precedence, so
+        // `<1.0.0+build.1` is the same) exclude every stable v1, as does a
+        // prerelease of 1.0.0 (`<1.0.0-0`, `<1.0.0-rc.1`); `<0.9` does too.
         if (
           major === 0 ||
-          (major === 1 && /^1(\.0){0,2}(\+[0-9A-Za-z.-]+)?$/.test(version)) ||
+          (major === 1 && /^1(\.0){0,2}(\+[0-9A-Za-z.-]+)?$/.test(plain)) ||
           isPrereleaseOfOne(version)
         ) {
           cappedBelowOne = true;
@@ -70,8 +86,8 @@ function setIsPreV1(set: string): boolean {
         }
         break;
       case '<=':
-        // `<=1.0.0-0` caps at the lowest 1.0.0 prerelease, so it excludes every
-        // stable v1 just as `<1.0.0-0` does.
+        // `<=1.0.0-0` caps at the lowest 1.0.0 prerelease, so it excludes
+        // every stable v1 just as `<1.0.0-0` does.
         if (major === 0 || isPrereleaseOfOne(version)) {
           cappedBelowOne = true;
         } else {
@@ -82,10 +98,16 @@ function setIsPreV1(set: string): boolean {
         // `0.9.4`, `=0.9.4`, `^0.9`, `~0.7.5`, `0.x`: caret and tilde never
         // cross a major, so major 0 stays below 1. An exact `1.0.0-rc.1` pins
         // a prerelease and admits no stable v1 either; `^1.0.0-rc.1` does.
-        if (major === 0) cappedBelowOne = true;
-        else if (!/^[~^]/.test(version) && isPrereleaseOfOne(version)) {
+        if (major === 0) {
           cappedBelowOne = true;
-        } else return false;
+        } else if (
+          !/^[~^]/.test(version) &&
+          isPrereleaseOfOne(version.replace(/^=/, ''))
+        ) {
+          cappedBelowOne = true;
+        } else {
+          return false;
+        }
     }
   }
   return cappedBelowOne;
@@ -97,10 +119,9 @@ function setIsPreV1(set: string): boolean {
  * Three numeric parts only, matching semver; `1.0-beta` is not a token this
  * parser reads and is left alone. A caret or tilde on one is different
  * (`^1.0.0-rc.1` admits 1.0.4), which is why the callers check the operator.
+ * Accepts the same optional `v` that the version grammar does.
  */
 function isPrereleaseOfOne(version: string): boolean {
-  // `majorOf` accepts a leading `v`, so this must too, or `v1.0.0-rc.1` is
-  // read as a v1 pin and left alone while `1.0.0-rc.1` is bumped.
   return /^v?1\.0\.0-/.test(version);
 }
 
@@ -122,29 +143,36 @@ export function isRecognisedRange(range: string): boolean {
       if (/^(\*|x|X)$/.test(text)) return true;
       const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
       if (hyphen) {
-        return majorOf(hyphen[1]) !== null && majorOf(hyphen[2]) !== null;
+        return (
+          versionMajor(hyphen[1]) !== null && versionMajor(hyphen[2]) !== null
+        );
       }
-      return text
-        .split(/\s+/)
-        .every(tok => majorOf(tok.replace(/^(>=|<=|>|<|=)/, '')) !== null);
+      return text.split(/\s+/).every(tok => {
+        const m = tok.match(/^(>=|<=|>|<|=)?(.*)$/);
+        if (!m) return false;
+        const [, op = '', v] = m;
+        return (op ? versionMajor(v) : majorOf(v)) !== null;
+      });
     });
 }
 
 /**
- * The major of a COMPLETE semver token, or null. Reading only the numeric
- * prefix accepted a dist-tag like `0.next` as major 0, and the manifest was
- * then overwritten with `^1.0.4`, which is the one thing this parser must
- * never do to a value it does not understand. A prerelease or build suffix is
- * accepted only after three numeric parts, matching semver itself; x-ranges
- * (`0.x`, `0.7.*`) are accepted in the minor and patch positions.
+ * The major of a COMPLETE plain version or x-range, or null. npm's optional
+ * leading `v` is the only prefix allowed here. Reading a numeric prefix alone
+ * accepted a dist-tag like `0.next` as major 0, and the manifest was then
+ * overwritten with `^1.0.4`, which is the one thing this parser must never do
+ * to a value it does not understand.
  */
-function majorOf(version: string): number | null {
-  // At most one of `^`, `~`, `=` and at most one `v`: stripping any run of
-  // them accepted `^^0.9.4` and `vv0.9.4` as major 0 and overwrote them.
-  const m = version.replace(/^(?:[~^=]v?|v)?/, '').match(
-    // Numeric parts are `0|[1-9]\d*`: SemVer forbids leading zeros, and
-    // `00.9.4` / `0.07.0` were being read as major 0 and overwritten.
-    /^(0|[1-9]\d*)(?:\.(?:0|[1-9]\d*|x|X|\*)(?:\.(?:x|X|\*|(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?))?)?$/
-  );
+function versionMajor(version: string): number | null {
+  const m = version.replace(/^v/, '').match(VERSION);
   return m ? Number(m[1]) : null;
+}
+
+/**
+ * The major of a BARE token, which may carry exactly one range prefix (`^`,
+ * `~`, `=`) before the version. Stripping any run of prefix characters
+ * accepted `^^0.9.4` and `vv0.9.4` as major 0 and overwrote them.
+ */
+function majorOf(token: string): number | null {
+  return versionMajor(token.replace(/^[~^=]/, ''));
 }

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -48,8 +48,12 @@ function setIsPreV1(set: string): boolean {
         if (major >= 1) return false;
         break;
       case '<':
-        // `<1`, `<1.0`, `<1.0.0` exclude every v1; `<0.9` does too.
-        if (major === 0 || (major === 1 && /^1(\.0)*$/.test(version))) {
+        // `<1`, `<1.0`, `<1.0.0` exclude every v1, and so does npm's canonical
+        // `<1.0.0-0` (below the lowest 1.0.0 prerelease); `<0.9` does too.
+        if (
+          major === 0 ||
+          (major === 1 && /^1(\.0){0,2}(-0)?$/.test(version))
+        ) {
           cappedBelowOne = true;
         } else {
           return false;

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -75,23 +75,23 @@ function setIsPreV1(set: string): boolean {
         // `<1`, `<1.0`, `<1.0.0` (build metadata carries no precedence, so
         // `<1.0.0+build.1` is the same) exclude every stable v1, as does a
         // prerelease of 1.0.0 (`<1.0.0-0`, `<1.0.0-rc.1`); `<0.9` does too.
+        // A higher upper bound (`<2` in `<1 <2`) never widens the set, so it
+        // is neutral rather than disqualifying; the result still needs some
+        // other comparator to cap it. Alone, `<2` therefore stays unbumped.
         if (
           major === 0 ||
           (major === 1 && /^1(\.0){0,2}(\+[0-9A-Za-z.-]+)?$/.test(plain)) ||
           isPrereleaseOfOne(version)
         ) {
           cappedBelowOne = true;
-        } else {
-          return false;
         }
         break;
       case '<=':
         // `<=1.0.0-0` caps at the lowest 1.0.0 prerelease, so it excludes
-        // every stable v1 just as `<1.0.0-0` does.
+        // every stable v1 just as `<1.0.0-0` does. A higher inclusive bound
+        // is neutral for the same reason as above.
         if (major === 0 || isPrereleaseOfOne(version)) {
           cappedBelowOne = true;
-        } else {
-          return false;
         }
         break;
       default:

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -17,6 +17,15 @@ const PRE_ID = String.raw`(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)`;
 const PRERELEASE = String.raw`-${PRE_ID}(?:\.${PRE_ID})*`;
 const BUILD = String.raw`\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*`;
 /**
+ * An exclusive upper bound that sits exactly at 1.0.0: `1`, `1.0`, `1.0.0`,
+ * and the x-ranges that desugar to it (`1.x`, `1.0.x`, `1.*`), optionally with
+ * build metadata, which carries no precedence. `1.1.x` desugars to 1.1.0 and
+ * still admits 1.0.x, so it is deliberately not here.
+ */
+const STABLE_ONE_BOUND = new RegExp(
+  `^1(?:\\.(?:0|${WILD}))?(?:\\.(?:0|${WILD}))?(?:${BUILD})?$`
+);
+/**
  * A plain version or x-range: `N`, `N.N`, `N.N.N[-pre][+build]`, `N.x`,
  * `N.x.x`, `N.N.x`. SemVer forbids leading zeros in numeric parts, and once a
  * component is a wildcard everything after it must be a wildcard or omitted.
@@ -86,8 +95,7 @@ function setIsPreV1(set: string): boolean {
         // other comparator to cap it. Alone, `<2` therefore stays unbumped.
         if (
           major === 0 ||
-          (major === 1 &&
-            new RegExp(`^1(\\.0){0,2}(?:${BUILD})?$`).test(plain)) ||
+          (major === 1 && STABLE_ONE_BOUND.test(plain)) ||
           isPrereleaseOfOne(version)
         ) {
           cappedBelowOne = true;
@@ -133,7 +141,9 @@ function isPrereleaseOfOne(version: string): boolean {
 }
 
 function glueOperators(set: string): string {
-  return set.trim().replace(/(>=|<=|>|<|=)\s+/g, '$1');
+  // Only when what follows starts a plain version. Gluing unconditionally
+  // turned the invalid `> =0.7` into a valid `>=0.7`, which was then bumped.
+  return set.trim().replace(/(>=|<=|>|<|=)\s+(?=[0-9vxX*])/g, '$1');
 }
 
 /**

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -60,8 +60,13 @@ function setIsPreV1(set: string): boolean {
         }
         break;
       case '<=':
-        if (major === 0) cappedBelowOne = true;
-        else return false;
+        // `<=1.0.0-0` caps at the lowest 1.0.0 prerelease, so it excludes every
+        // stable v1 just as `<1.0.0-0` does.
+        if (major === 0 || (major === 1 && /^1(\.0){0,2}-0$/.test(version))) {
+          cappedBelowOne = true;
+        } else {
+          return false;
+        }
         break;
       default:
         // `0.9.4`, `=0.9.4`, `^0.9`, `~0.7.5`, `0.x`: caret and tilde never

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -10,13 +10,19 @@
 
 const NUMERIC = String.raw`(?:0|[1-9]\d*)`;
 const WILD = String.raw`(?:x|X|\*)`;
+// SemVer's own identifier grammar: dot-separated, non-empty, no leading zero on
+// a numeric prerelease identifier. Looser fragments accepted `0.9.0-alpha..1`,
+// `0.9.0-01` and `0.9.0+foo..bar` as complete versions and overwrote them.
+const PRE_ID = String.raw`(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const PRERELEASE = String.raw`-${PRE_ID}(?:\.${PRE_ID})*`;
+const BUILD = String.raw`\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*`;
 /**
  * A plain version or x-range: `N`, `N.N`, `N.N.N[-pre][+build]`, `N.x`,
  * `N.x.x`, `N.N.x`. SemVer forbids leading zeros in numeric parts, and once a
  * component is a wildcard everything after it must be a wildcard or omitted.
  */
 const VERSION = new RegExp(
-  `^(${NUMERIC})(?:\\.(?:${NUMERIC}(?:\\.(?:${WILD}|${NUMERIC}(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?))?|${WILD}(?:\\.${WILD})?))?$`
+  `^(${NUMERIC})(?:\\.(?:${NUMERIC}(?:\\.(?:${WILD}|${NUMERIC}(?:${PRERELEASE})?(?:${BUILD})?))?|${WILD}(?:\\.${WILD})?))?$`
 );
 
 /**
@@ -80,7 +86,8 @@ function setIsPreV1(set: string): boolean {
         // other comparator to cap it. Alone, `<2` therefore stays unbumped.
         if (
           major === 0 ||
-          (major === 1 && /^1(\.0){0,2}(\+[0-9A-Za-z.-]+)?$/.test(plain)) ||
+          (major === 1 &&
+            new RegExp(`^1(\\.0){0,2}(?:${BUILD})?$`).test(plain)) ||
           isPrereleaseOfOne(version)
         ) {
           cappedBelowOne = true;

--- a/bestax-migrate/src/sources/_shared/semver-range.ts
+++ b/bestax-migrate/src/sources/_shared/semver-range.ts
@@ -33,7 +33,9 @@ function setIsPreV1(set: string): boolean {
   const text = glueOperators(set);
   if (text === '' || /^(\*|x|X|latest)$/.test(text)) return false;
   const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
-  if (hyphen) return majorOf(hyphen[2]) === 0;
+  if (hyphen) {
+    return majorOf(hyphen[2]) === 0 || isPrereleaseOfOne(hyphen[2]);
+  }
 
   let cappedBelowOne = false;
   for (const token of text.split(/\s+/)) {
@@ -52,7 +54,8 @@ function setIsPreV1(set: string): boolean {
         // `<1.0.0-0` (below the lowest 1.0.0 prerelease); `<0.9` does too.
         if (
           major === 0 ||
-          (major === 1 && /^1(\.0){0,2}(-0)?$/.test(version))
+          (major === 1 && /^1(\.0){0,2}$/.test(version)) ||
+          isPrereleaseOfOne(version)
         ) {
           cappedBelowOne = true;
         } else {
@@ -62,7 +65,7 @@ function setIsPreV1(set: string): boolean {
       case '<=':
         // `<=1.0.0-0` caps at the lowest 1.0.0 prerelease, so it excludes every
         // stable v1 just as `<1.0.0-0` does.
-        if (major === 0 || (major === 1 && /^1(\.0){0,2}-0$/.test(version))) {
+        if (major === 0 || isPrereleaseOfOne(version)) {
           cappedBelowOne = true;
         } else {
           return false;
@@ -70,12 +73,25 @@ function setIsPreV1(set: string): boolean {
         break;
       default:
         // `0.9.4`, `=0.9.4`, `^0.9`, `~0.7.5`, `0.x`: caret and tilde never
-        // cross a major, so major 0 stays below 1.
+        // cross a major, so major 0 stays below 1. An exact `1.0.0-rc.1` pins
+        // a prerelease and admits no stable v1 either; `^1.0.0-rc.1` does.
         if (major === 0) cappedBelowOne = true;
-        else return false;
+        else if (!/^[~^]/.test(version) && isPrereleaseOfOne(version)) {
+          cappedBelowOne = true;
+        } else return false;
     }
   }
   return cappedBelowOne;
+}
+
+/**
+ * `1.0.0-0`, `1.0.0-rc.1`, `1.0-beta`: a prerelease of exactly 1.0.0 orders
+ * below every stable 1.x, so as an upper bound or an exact pin it admits no
+ * usable v1. A caret or tilde on one is different (`^1.0.0-rc.1` admits
+ * 1.0.4), which is why the callers check the operator first.
+ */
+function isPrereleaseOfOne(version: string): boolean {
+  return /^1(\.0){0,2}-/.test(version);
 }
 
 function glueOperators(set: string): string {

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -188,6 +188,9 @@ describe('pre-1.0 bulma range detection', () => {
     '>=0.9',
     '<=1.0.0',
     '^1.0.0-rc.1',
+    '0.next',
+    '1.0-beta',
+    '0.7.x-foo',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe(range);

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -1,8 +1,8 @@
 /**
- * package.json updater. The behaviour worth pinning down is the guard on the
- * four Bulma extensions: they are only removed *alongside* rbx, because an
- * app that added `bulma-tooltip` on its own may still be using it outside rbx
- * components.
+ * package.json updater. The behaviour worth pinning down is the four Bulma
+ * extensions: they are reported for the user to remove, never deleted, because
+ * an app that added `bulma-tooltip` on its own may still be using it outside
+ * rbx components.
  */
 
 import { updateDependencies } from '../deps.js';

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -175,9 +175,24 @@ describe('pre-1.0 bulma range detection', () => {
     '1.0.0-rc.1',
     '<1.0.0-rc.1',
     '0.9.0 - 1.0.0-0',
+    '<1.0.0+build.1',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');
+  });
+
+  it.each([
+    '0.next',
+    '1.0-beta',
+    '0.7.x-foo',
+    '^^0.9.4',
+    'vv0.9.4',
+    'not-a-range - 0.9.4',
+  ])('leaves %s alone because it is not a range this parser reads', range => {
+    // Not "admits a v1": these are left untouched because the parser cannot
+    // read them, which the rbx report words differently from an actual v1.
+    const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
+    expect(next?.dependencies.bulma).toBe(range);
   });
 
   it.each([
@@ -188,9 +203,6 @@ describe('pre-1.0 bulma range detection', () => {
     '>=0.9',
     '<=1.0.0',
     '^1.0.0-rc.1',
-    '0.next',
-    '1.0-beta',
-    '0.7.x-foo',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe(range);

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -179,6 +179,9 @@ describe('pre-1.0 bulma range detection', () => {
     'v1.0.0-rc.1',
     '<v1.0.0',
     '>=1.0.0-rc.1 <1.0.0',
+    '<1 <2',
+    '<1 <=2',
+    '>=0.7 <1 <3',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');
@@ -211,6 +214,8 @@ describe('pre-1.0 bulma range detection', () => {
     '>=0.9',
     '<=1.0.0',
     '^1.0.0-rc.1',
+    '<2',
+    '<=2',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe(range);

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -176,6 +176,8 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.0.0-rc.1',
     '0.9.0 - 1.0.0-0',
     '<1.0.0+build.1',
+    '0.9.0-alpha.1',
+    '0.9.0+build.7',
     'v1.0.0-rc.1',
     '<v1.0.0',
     '>=1.0.0-rc.1 <1.0.0',
@@ -199,6 +201,9 @@ describe('pre-1.0 bulma range detection', () => {
     '==0.9.4',
     '<^0.9',
     '0.x.1',
+    '0.9.0-alpha..1',
+    '0.9.0-01',
+    '0.9.0+foo..bar',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -187,6 +187,8 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.x',
     '<1.0.x',
     '<1.*',
+    '~ 0.7.5',
+    '^ 0.9.4',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -169,6 +169,8 @@ describe('pre-1.0 bulma range detection', () => {
     '<1',
     '0.7.0 - 0.9.4',
     '^0.9 || ^0.8',
+    '<1.0.0-0',
+    '>=0.9.0 <1.0.0-0',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -176,6 +176,7 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.0.0-rc.1',
     '0.9.0 - 1.0.0-0',
     '<1.0.0+build.1',
+    'v1.0.0-rc.1',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');
@@ -188,6 +189,8 @@ describe('pre-1.0 bulma range detection', () => {
     '^^0.9.4',
     'vv0.9.4',
     'not-a-range - 0.9.4',
+    '00.9.4',
+    '0.07.0',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -171,6 +171,7 @@ describe('pre-1.0 bulma range detection', () => {
     '^0.9 || ^0.8',
     '<1.0.0-0',
     '>=0.9.0 <1.0.0-0',
+    '<=1.0.0-0',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -172,18 +172,26 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.0.0-0',
     '>=0.9.0 <1.0.0-0',
     '<=1.0.0-0',
+    '1.0.0-rc.1',
+    '<1.0.0-rc.1',
+    '0.9.0 - 1.0.0-0',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');
   });
 
-  it.each(['^1.0.2', '>=0.9 <2', '^0.9 || ^1.0', '*', '>=0.9', '<=1.0.0'])(
-    'leaves %s alone because it admits a v1',
-    range => {
-      const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
-      expect(next?.dependencies.bulma).toBe(range);
-    }
-  );
+  it.each([
+    '^1.0.2',
+    '>=0.9 <2',
+    '^0.9 || ^1.0',
+    '*',
+    '>=0.9',
+    '<=1.0.0',
+    '^1.0.0-rc.1',
+  ])('leaves %s alone because it admits a v1', range => {
+    const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
+    expect(next?.dependencies.bulma).toBe(range);
+  });
 });
 
 describe('range edge cases the deep review found', () => {

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -184,6 +184,9 @@ describe('pre-1.0 bulma range detection', () => {
     '<1 <2',
     '<1 <=2',
     '>=0.7 <1 <3',
+    '<1.x',
+    '<1.0.x',
+    '<1.*',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');
@@ -204,6 +207,7 @@ describe('pre-1.0 bulma range detection', () => {
     '0.9.0-alpha..1',
     '0.9.0-01',
     '0.9.0+foo..bar',
+    '> =0.7 <1',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.
@@ -221,6 +225,8 @@ describe('pre-1.0 bulma range detection', () => {
     '^1.0.0-rc.1',
     '<2',
     '<=2',
+    '<1.1.x',
+    '<=1.x',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe(range);

--- a/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/rbx/__tests__/deps.test.ts
@@ -177,6 +177,8 @@ describe('pre-1.0 bulma range detection', () => {
     '0.9.0 - 1.0.0-0',
     '<1.0.0+build.1',
     'v1.0.0-rc.1',
+    '<v1.0.0',
+    '>=1.0.0-rc.1 <1.0.0',
   ])('bumps %s', range => {
     const { next } = run({ dependencies: { rbx: '^2.2.0', bulma: range } });
     expect(next?.dependencies.bulma).toBe('^1.0.4');
@@ -191,6 +193,9 @@ describe('pre-1.0 bulma range detection', () => {
     'not-a-range - 0.9.4',
     '00.9.4',
     '0.07.0',
+    '==0.9.4',
+    '<^0.9',
+    '0.x.1',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.

--- a/bestax-migrate/src/sources/rbx/deps.ts
+++ b/bestax-migrate/src/sources/rbx/deps.ts
@@ -15,6 +15,7 @@
  */
 
 import type { DependenciesUpdate } from '../../types.js';
+import { isPreV1, isRecognisedRange } from '../_shared/semver-range.js';
 
 const BESTAX_RANGE = '^5';
 const BULMA_RANGE = '^1.0.4';
@@ -34,97 +35,6 @@ const RBX_STYLE_DEPS = [
 ] as const;
 
 const DEP_SECTIONS = ['dependencies', 'devDependencies'] as const;
-
-/**
- * True only when `range` PROVABLY admits no version >= 1.0.0.
- *
- * The first version matched a leading `0` and nothing else, so a range written
- * as comparators (`>=0.7 <1`) was left on 0.x and then reported as already v1.
- * This walks each `||` alternative and its comparators: a set is pre-v1 when
- * some comparator caps it below 1.0.0 and none of them opens it at 1 or above.
- *
- * Conservative by design: an unrecognised shape returns false and the range is
- * left alone (and reported as such). Bumping a range that might already admit
- * v1 would be the best-guess rewrite this package refuses to make.
- */
-function isPreV1(range: string): boolean {
-  const alternatives = range.trim().split(/\s*\|\|\s*/);
-  return alternatives.length > 0 && alternatives.every(setIsPreV1);
-}
-
-function setIsPreV1(set: string): boolean {
-  // npm accepts whitespace between an operator and its version
-  // (`>= 0.7.0 < 1.0.0`); splitting on whitespace first made the operator a
-  // token of its own, so the range parsed as unrecognised and was left alone.
-  const text = glueOperators(set);
-  if (text === '' || /^(\*|x|X|latest)$/.test(text)) return false;
-  const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
-  if (hyphen) return majorOf(hyphen[2]) === 0;
-
-  let cappedBelowOne = false;
-  for (const token of text.split(/\s+/)) {
-    const match = token.match(/^(>=|<=|>|<|=)?\s*v?(.*)$/);
-    if (!match) return false;
-    const [, op = '', version] = match;
-    const major = majorOf(version);
-    if (major === null) return false;
-    switch (op) {
-      case '>':
-      case '>=':
-        if (major >= 1) return false;
-        break;
-      case '<':
-        // `<1`, `<1.0`, `<1.0.0` exclude every v1; `<0.9` does too.
-        if (major === 0 || (major === 1 && /^1(\.0)*$/.test(version))) {
-          cappedBelowOne = true;
-        } else {
-          return false;
-        }
-        break;
-      case '<=':
-        if (major === 0) cappedBelowOne = true;
-        else return false;
-        break;
-      default:
-        // `0.9.4`, `=0.9.4`, `^0.9`, `~0.7.5`, `0.x`: caret and tilde never
-        // cross a major, so major 0 stays below 1.
-        if (major === 0) cappedBelowOne = true;
-        else return false;
-    }
-  }
-  return cappedBelowOne;
-}
-
-function glueOperators(set: string): string {
-  return set.trim().replace(/(>=|<=|>|<|=)\s+/g, '$1');
-}
-
-/**
- * True when every comparator in every alternative parses to a semver major,
- * so the headline can tell "already v1" apart from "not a version range at
- * all" (`latest`, a git URL) rather than calling both v1.
- */
-function isRecognisedRange(range: string): boolean {
-  return range
-    .trim()
-    .split(/\s*\|\|\s*/)
-    .every(alt => {
-      const text = glueOperators(alt);
-      if (/^(\*|x|X)$/.test(text)) return true;
-      const hyphen = text.match(/^(\S+)\s+-\s+(\S+)$/);
-      if (hyphen) {
-        return majorOf(hyphen[1]) !== null && majorOf(hyphen[2]) !== null;
-      }
-      return text
-        .split(/\s+/)
-        .every(tok => majorOf(tok.replace(/^(>=|<=|>|<|=)/, '')) !== null);
-    });
-}
-
-function majorOf(version: string): number | null {
-  const m = version.replace(/^[~^=v]+/, '').match(/^(\d+)(?:\.|$)/);
-  return m ? Number(m[1]) : null;
-}
 
 export const updateDependencies: DependenciesUpdate = (
   filePath,

--- a/bestax-migrate/src/sources/rbx/styles.ts
+++ b/bestax-migrate/src/sources/rbx/styles.ts
@@ -5,11 +5,11 @@
  * identical.
  *
  * Note what it does NOT do: a `bulma-*` extension import in Sass is left in
- * place with a TODO, not removed. Only the JS/CSS-import side of rbx's
- * extension cleanup is automatic (transform.ts prunes
- * `bulma-badge`/`bulma-divider`/`bulma-pageloader`/`bulma-tooltip` CSS
- * imports outright, since bestax ships all four as components). A Sass
- * `@import` of one may be pulling in customisation the codemod cannot see,
+ * place with a TODO, not removed. The JS/CSS-import side in transform.ts does
+ * the same for `bulma-badge`/`bulma-divider`/`bulma-pageloader`/`bulma-tooltip`
+ * (kept, with a TODO), and the manifest pass reports rather than removes the
+ * packages, since markup outside rbx may still use the extension's classes. A
+ * Sass `@import` of one may be pulling in customisation the codemod cannot see,
  * so it is flagged for a human instead.
  *
  * rbx's own stylesheet is `rbx/rbx` (its Sass entry, usually imported as

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -162,6 +162,7 @@ describe('pre-1.0 bulma range detection', () => {
     '^0.9 || ^0.8',
     '<1.0.0-0',
     '>=0.9.0 <1.0.0-0',
+    '<=1.0.0-0',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -166,11 +166,28 @@ describe('pre-1.0 bulma range detection', () => {
     '1.0.0-rc.1',
     '<1.0.0-rc.1',
     '0.9.0 - 1.0.0-0',
+    '<1.0.0+build.1',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
     });
     expect((next?.dependencies as Record<string, string>).bulma).toBe('^1.0.4');
+  });
+
+  it.each([
+    '0.next',
+    '1.0-beta',
+    '0.7.x-foo',
+    '^^0.9.4',
+    'vv0.9.4',
+    'not-a-range - 0.9.4',
+  ])('leaves %s alone because it is not a range this parser reads', range => {
+    // Not "admits a v1": these are left untouched because the parser cannot
+    // read them, which the rbx report words differently from an actual v1.
+    const { next } = run({
+      dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
+    });
+    expect((next?.dependencies as Record<string, string>).bulma).toBe(range);
   });
 
   it.each([
@@ -181,9 +198,6 @@ describe('pre-1.0 bulma range detection', () => {
     '>=0.9',
     '<=1.0.0',
     '^1.0.0-rc.1',
-    '0.next',
-    '1.0-beta',
-    '0.7.x-foo',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -160,6 +160,8 @@ describe('pre-1.0 bulma range detection', () => {
     '<1',
     '0.7.0 - 0.9.4',
     '^0.9 || ^0.8',
+    '<1.0.0-0',
+    '>=0.9.0 <1.0.0-0',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -181,6 +181,9 @@ describe('pre-1.0 bulma range detection', () => {
     '>=0.9',
     '<=1.0.0',
     '^1.0.0-rc.1',
+    '0.next',
+    '1.0-beta',
+    '0.7.x-foo',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -170,6 +170,9 @@ describe('pre-1.0 bulma range detection', () => {
     'v1.0.0-rc.1',
     '<v1.0.0',
     '>=1.0.0-rc.1 <1.0.0',
+    '<1 <2',
+    '<1 <=2',
+    '>=0.7 <1 <3',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
@@ -206,6 +209,8 @@ describe('pre-1.0 bulma range detection', () => {
     '>=0.9',
     '<=1.0.0',
     '^1.0.0-rc.1',
+    '<2',
+    '<=2',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -167,6 +167,8 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.0.0-rc.1',
     '0.9.0 - 1.0.0-0',
     '<1.0.0+build.1',
+    '0.9.0-alpha.1',
+    '0.9.0+build.7',
     'v1.0.0-rc.1',
     '<v1.0.0',
     '>=1.0.0-rc.1 <1.0.0',
@@ -192,6 +194,9 @@ describe('pre-1.0 bulma range detection', () => {
     '==0.9.4',
     '<^0.9',
     '0.x.1',
+    '0.9.0-alpha..1',
+    '0.9.0-01',
+    '0.9.0+foo..bar',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -175,6 +175,9 @@ describe('pre-1.0 bulma range detection', () => {
     '<1 <2',
     '<1 <=2',
     '>=0.7 <1 <3',
+    '<1.x',
+    '<1.0.x',
+    '<1.*',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
@@ -197,6 +200,7 @@ describe('pre-1.0 bulma range detection', () => {
     '0.9.0-alpha..1',
     '0.9.0-01',
     '0.9.0+foo..bar',
+    '> =0.7 <1',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.
@@ -216,6 +220,8 @@ describe('pre-1.0 bulma range detection', () => {
     '^1.0.0-rc.1',
     '<2',
     '<=2',
+    '<1.1.x',
+    '<=1.x',
   ])('leaves %s alone because it admits a v1', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -163,6 +163,9 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.0.0-0',
     '>=0.9.0 <1.0.0-0',
     '<=1.0.0-0',
+    '1.0.0-rc.1',
+    '<1.0.0-rc.1',
+    '0.9.0 - 1.0.0-0',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
@@ -170,13 +173,18 @@ describe('pre-1.0 bulma range detection', () => {
     expect((next?.dependencies as Record<string, string>).bulma).toBe('^1.0.4');
   });
 
-  it.each(['^1.0.2', '>=0.9 <2', '^0.9 || ^1.0', '*', '>=0.9', '<=1.0.0'])(
-    'leaves %s alone because it admits a v1',
-    range => {
-      const { next } = run({
-        dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
-      });
-      expect((next?.dependencies as Record<string, string>).bulma).toBe(range);
-    }
-  );
+  it.each([
+    '^1.0.2',
+    '>=0.9 <2',
+    '^0.9 || ^1.0',
+    '*',
+    '>=0.9',
+    '<=1.0.0',
+    '^1.0.0-rc.1',
+  ])('leaves %s alone because it admits a v1', range => {
+    const { next } = run({
+      dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
+    });
+    expect((next?.dependencies as Record<string, string>).bulma).toBe(range);
+  });
 });

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -178,6 +178,8 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.x',
     '<1.0.x',
     '<1.*',
+    '~ 0.7.5',
+    '^ 0.9.4',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -145,3 +145,35 @@ describe('retained-import warning', () => {
     expect(todos.map(t => t.message).join('\n')).not.toMatch(/still import it/);
   });
 });
+
+describe('pre-1.0 bulma range detection', () => {
+  // The regex this pass used matched a leading `0` and nothing else, so a
+  // range written as comparators (`>=0.9.0 <1`) was neither bumped nor
+  // reported. The parser is now shared with the rbx source, which had already
+  // been fixed; this pins the port.
+  it.each([
+    '^0.9.4',
+    '~0.7.5',
+    '0.7.x',
+    '>=0.7 <1',
+    '>= 0.7.0 < 1.0.0',
+    '<1',
+    '0.7.0 - 0.9.4',
+    '^0.9 || ^0.8',
+  ])('bumps %s', range => {
+    const { next } = run({
+      dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
+    });
+    expect((next?.dependencies as Record<string, string>).bulma).toBe('^1.0.4');
+  });
+
+  it.each(['^1.0.2', '>=0.9 <2', '^0.9 || ^1.0', '*', '>=0.9', '<=1.0.0'])(
+    'leaves %s alone because it admits a v1',
+    range => {
+      const { next } = run({
+        dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
+      });
+      expect((next?.dependencies as Record<string, string>).bulma).toBe(range);
+    }
+  );
+});

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -168,6 +168,8 @@ describe('pre-1.0 bulma range detection', () => {
     '0.9.0 - 1.0.0-0',
     '<1.0.0+build.1',
     'v1.0.0-rc.1',
+    '<v1.0.0',
+    '>=1.0.0-rc.1 <1.0.0',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
@@ -184,6 +186,9 @@ describe('pre-1.0 bulma range detection', () => {
     'not-a-range - 0.9.4',
     '00.9.4',
     '0.07.0',
+    '==0.9.4',
+    '<^0.9',
+    '0.x.1',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.

--- a/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/__tests__/deps.test.ts
@@ -167,6 +167,7 @@ describe('pre-1.0 bulma range detection', () => {
     '<1.0.0-rc.1',
     '0.9.0 - 1.0.0-0',
     '<1.0.0+build.1',
+    'v1.0.0-rc.1',
   ])('bumps %s', range => {
     const { next } = run({
       dependencies: { 'react-bulma-components': '^4.1.0', bulma: range },
@@ -181,6 +182,8 @@ describe('pre-1.0 bulma range detection', () => {
     '^^0.9.4',
     'vv0.9.4',
     'not-a-range - 0.9.4',
+    '00.9.4',
+    '0.07.0',
   ])('leaves %s alone because it is not a range this parser reads', range => {
     // Not "admits a v1": these are left untouched because the parser cannot
     // read them, which the rbx report words differently from an actual v1.

--- a/bestax-migrate/src/sources/react-bulma-components/deps.ts
+++ b/bestax-migrate/src/sources/react-bulma-components/deps.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DependenciesUpdate } from '../../types.js';
+import { isPreV1 } from '../_shared/semver-range.js';
 
 const BESTAX_RANGE = '^5';
 const BULMA_RANGE = '^1.0.4';
@@ -13,10 +14,6 @@ const BULMA_RANGE = '^1.0.4';
 const SASS_RANGE = '^1.79.0';
 
 const DEP_SECTIONS = ['dependencies', 'devDependencies'] as const;
-
-function isPreV1(range: string): boolean {
-  return /^[~^]?0[.x]/.test(range.trim());
-}
 
 export const updateDependencies: DependenciesUpdate = (
   filePath,


### PR DESCRIPTION
## What

The react-bulma-components manifest pass still used the original pre-1.0 check, a regex that matches a leading `0` and nothing else (`react-bulma-components/deps.ts:17` before this PR). An app declaring `"bulma": ">=0.9.0 <1"` was neither bumped nor reported. The rbx source replaced that check with a comparator-aware parser on #613; this is the unported sibling that the new `CLAUDE.md` rule in #626 warns about.

## Change

- The parser is hoisted to `bestax-migrate/src/sources/_shared/semver-range.ts` and both sources import it, so there is one copy to fix next time.
- The fourteen range shapes pinned in `rbx/__tests__/deps.test.ts` are now pinned for react-bulma-components too (eight that must bump, six that must be left alone because they admit a v1).
- Two comments that still described the CSS-import pass as pruning extension stylesheets (`rbx/styles.ts`, `rbx/__tests__/deps.test.ts` header) now match the behaviour shipped in #613: kept with a TODO, and the manifest pass reports rather than removes.

**rbx behaviour change, added in the later commits on this PR:** the shared parser now also treats npm's prerelease bounds as pre-1.0. `<1.0.0-0`, `<=1.0.0-0`, an exact `1.0.0-rc.1`, `<1.0.0-rc.1`, and a hyphen range ending in `1.0.0-0` are bumped to `^1.0.4`, where the original rbx parser left them untouched and reported them as already v1. A caret or tilde on a 1.0.0 prerelease (`^1.0.0-rc.1`) is still left alone because it admits stable 1.x. Both suites pin all of these.

**Conservative hardening, both sources:** the shared parser bumps only a value it can read as a complete SemVer version or range. Malformed or non-version specifiers that the original regexes bumped on a numeric prefix are now left untouched (and, in rbx's manifest report, called out as a specifier the tool cannot read; react-bulma-components has no such headline, so there they are simply left alone): dist-tags like `0.next`, wildcards followed by a component (`0.x.1`, `0.7.x-foo`), doubled prefixes (`^^0.9.4`, `vv0.9.4`), leading zeros (`00.9.4`), malformed identifiers (`0.9.0-01`, `0.9.0-alpha..1`), split operators (`> =0.7`), and hyphen ranges with an unreadable endpoint. For rbx this narrows what was previously bumped; for react-bulma-components, whose regex also matched on a leading `0`, the same narrowing applies. Both suites pin every one of these as left alone. Everything else the two passes did is unchanged.

## Verification

`pnpm exec turbo run test typecheck lint --filter=bestax-migrate`: 4/4, 873 tests green including every range shape above. `pnpm check:conformance` green.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Bulma dependency ranges that cannot use stable version 1.0.0 or later, including prerelease, comparator, caret, tilde, and wildcard ranges.
  * Preserved ranges that already allow version 1.0.0 or later.
  * Migration guidance now reports certain Bulma extensions and imports for manual review instead of removing them automatically.
* **Tests**
  * Expanded coverage for pre-1.0 and v1-compatible dependency ranges across supported migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

