### PR TITLE
chore(deps): raise the fast-uri floor to 3.1.6 for four new advisories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,22 +74,22 @@ red**, including yours, over a transitive dependency you never touched (#391). T
 is not your PR's fault, and this is the way out:
 
 1. Force the patched version in `overrides`, scoped to the affected range rather than unscoped.
-   When each major ships its own backport, scope per major (`'thing@3': '>=3.1.5 <4'`) so the
+   When each major ships its own backport, scope per major (`'thing@3': '>=3.1.6 <4'`) so the
    other majors are untouched. When the advisory has a single patched floor across majors, use
-   an unbounded-lower selector instead (`'thing@<3.1.5': '>=3.1.5'`), as the committed
+   an unbounded-lower selector instead (`'thing@<3.1.6': '>=3.1.6'`), as the committed
    `postcss` and `sharp` entries do — scoping that case to whichever major the lockfile happens
    to hold today leaves older majors unguarded if a future dependency edge pulls one in.
 2. If the patch is still inside the cooldown, add it to `minimumReleaseAgeExclude` too — without
    this the resolver refuses the version step 1 demands. **Qualify it with the exact version**
-   (`- 'fast-uri@3.1.5'`, not `- fast-uri`): a bare package name waives the cooldown for every
+   (`- 'fast-uri@3.1.6'`, not `- fast-uri`): a bare package name waives the cooldown for every
    future release of that package, so a later lockfile refresh could pull in a different
    just-published version that nobody reviewed. That is the whole defence you are stepping
    around, so step around it as narrowly as possible.
 3. Annotate both entries with a review date — this is required, not a nicety:
 
    ```yaml
-   # bestax:review 2026-11-13 — drop once the ajv chain resolves to >=3.1.5 itself
-   'fast-uri@3': '>=3.1.5 <4'
+   # bestax:review 2026-11-13 — drop once the ajv chain resolves to >=3.1.6 itself
+   'fast-uri@3': '>=3.1.6 <4'
    ```
 
 4. Run `pnpm install`, confirm `pnpm audit --audit-level=high` is clean, and commit the lockfile

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   brace-expansion@2: '>=2.1.4 <3'
   brace-expansion@3: '>=3.0.6 <4'
   brace-expansion@5: '>=5.0.9 <6'
-  fast-uri@3: '>=3.1.5 <4'
+  fast-uri@3: '>=3.1.6 <4'
   undici@7: '>=7.29.0 <8'
   undici@6: '>=6.28.0 <7'
   minimatch@9: '>=9.0.7 <10'
@@ -6004,8 +6004,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -15761,7 +15761,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -17447,7 +17447,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -155,11 +155,15 @@ overrides:
   'brace-expansion@5': '>=5.0.9 <6'
   # bestax:review 2026-11-13 — quarterly sweep
   # Force patched fast-uri under ajv@8 (transitive via commitlint, webpack's
-  # schema-utils, and the eslint toolchain) — high advisory
-  # GHSA-7p8r-x3mc-p8w7: host confusion via a backslash authority introducer.
-  # Scoped to the affected 3.x major. Prune once the ajv chain resolves to
-  # >=3.1.5 on its own.
-  'fast-uri@3': '>=3.1.5 <4'
+  # schema-utils, the eslint toolchain and the MCP SDK) — five high advisories
+  # now: GHSA-7p8r-x3mc-p8w7 (host confusion via a backslash authority
+  # introducer) plus GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc,
+  # GHSA-fph4-wmhf-6fwf and GHSA-jqff-g426-hqxp (host confusion via skipped
+  # IDN and percent-encoded scheme normalization, and SSRF). The floor was
+  # >=3.1.5 for the first advisory; the four new ones are only patched in
+  # 3.1.6. Scoped to the affected 3.x major. Prune once the ajv chain resolves
+  # to >=3.1.6 on its own.
+  'fast-uri@3': '>=3.1.6 <4'
   # bestax:review 2026-11-13 — quarterly sweep
   # Force patched undici 7.x (transitive via semantic-release/github and
   # wrangler>miniflare — release and CI-deploy tooling, never published


### PR DESCRIPTION
## What

Four new high advisories against `fast-uri`, all patched only in **3.1.6**:

- [GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8) — host confusion via skipped IDN
- [GHSA-f65p-4m7j-42xc](https://github.com/advisories/GHSA-f65p-4m7j-42xc) — server-side request forgery
- [GHSA-fph4-wmhf-6fwf](https://github.com/advisories/GHSA-fph4-wmhf-6fwf) — server-side request forgery
- [GHSA-jqff-g426-hqxp](https://github.com/advisories/GHSA-jqff-g426-hqxp) — host confusion via percent-encoded scheme normalization

Nothing here declares `fast-uri`; it arrives transitively through `ajv`, under commitlint, webpack's schema-utils, the eslint toolchain and `@modelcontextprotocol/sdk`.

## Why now

`pnpm audit --audit-level=high` is a blocking gate, so **every open PR is red** over a dependency none of them touched. This is the situation CONTRIBUTING calls out.

## The fix

The override already exists; only its floor was stale. It was `>=3.1.5` for the earlier GHSA-7p8r-x3mc-p8w7, and the four new advisories are patched only in 3.1.6.

- `'fast-uri@3': '>=3.1.5 <4'` → `'>=3.1.6 <4'`, still scoped to the affected 3.x major.
- **No `minimumReleaseAgeExclude` needed:** 3.1.6 was published 2026-08-23, eleven days ago, well clear of the 72h cooldown.
- The comment above the entry now names all five advisories and why the floor moved, and the existing `# bestax:review 2026-11-13` annotation is unchanged.

This raises a dependency to a patched version; it is not an `ignoreGhsas` suppression, and no advisory is waived.

## Verification

```
pnpm install
pnpm audit --audit-level=high     # exits 0
pnpm check:conformance            # clean, bypass-expiry annotation intact
grep -o 'fast-uri@[0-9.]*' pnpm-lock.yaml | sort -u   # fast-uri@3.1.6
```

Remaining audit findings are moderate (`qs`, `uuid`) and below the gate.

Unblocks #630 and every other open PR.
