### PR TITLE
ci: raise the implement turn budget and stop denials burning it

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -259,13 +259,18 @@ jobs:
           # 250 turns is ~27m at the observed 6.4s/turn, still well inside
           # timeout-minutes: 60.
           #
-          # Four allowlist entries were added for those denials. Each either
-          # cannot write or is a different spelling of something already
-          # allowed: `git fetch` is a read-only transfer (and `git push` is
-          # already allowed, which is strictly stronger); `git stash` is local
-          # working-tree state only; `pnpm gen` is the alias form of the
-          # already-allowed `pnpm run gen`; `pnpm -w run` is the root-scoped
-          # form of the already-allowed `pnpm run`.
+          # Four allowlist entries were added for those denials. None of them
+          # can reach the remote or a credential, and two are only different
+          # spellings of something already allowed:
+          #   - `git fetch` DOES write, but only locally: FETCH_HEAD and
+          #     remote-tracking refs in this ephemeral checkout. It cannot
+          #     mutate the remote, and `git push` — which can, and is already
+          #     allowed — is strictly stronger.
+          #   - `git stash` writes local working-tree state only; no network.
+          #   - `pnpm gen` is the alias form of the already-allowed
+          #     `pnpm run gen`, so the capability is identical.
+          #   - `pnpm -w run` is the root-scoped form of the already-allowed
+          #     `pnpm run`.
           #
           # Considered and REFUSED, because this job holds AI_LOOP_PAT
           # (repository write) beside the model token: `Bash(gh api:*)`, a

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -252,11 +252,32 @@ jobs:
           # The prompt's protected-path exclusions are enforced here, not just
           # stated: --disallowedTools deny rules take precedence over the
           # Edit/MultiEdit/Write allows in --allowedTools.
+          #
+          # --max-turns was 150. Issue #622 stopped at `error_max_turns` with
+          # 151 turns, 16m of model time, and no commit — while burning turns
+          # on denial-and-retry loops for commands the prompt itself asks for.
+          # 250 turns is ~27m at the observed 6.4s/turn, still well inside
+          # timeout-minutes: 60.
+          #
+          # Four allowlist entries were added for those denials. Each either
+          # cannot write or is a different spelling of something already
+          # allowed: `git fetch` is a read-only transfer (and `git push` is
+          # already allowed, which is strictly stronger); `git stash` is local
+          # working-tree state only; `pnpm gen` is the alias form of the
+          # already-allowed `pnpm run gen`; `pnpm -w run` is the root-scoped
+          # form of the already-allowed `pnpm run`.
+          #
+          # Considered and REFUSED, because this job holds AI_LOOP_PAT
+          # (repository write) beside the model token: `Bash(gh api:*)`, a
+          # general-purpose write primitive that would bypass the narrow
+          # gh issue/gh pr verbs entirely, and `Bash(git -C:*)`, which would
+          # permit any git subcommand at any path and defeat the per-subcommand
+          # structure of this list. The prompt tells the session to avoid both.
           claude_args: |
-            --max-turns 150
+            --max-turns 250
             --model claude-sonnet-5
             --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*),Edit(scripts/check-conformance.mjs),MultiEdit(scripts/check-conformance.mjs),Write(scripts/check-conformance.mjs),Edit(scripts/conformance-baseline.json),MultiEdit(scripts/conformance-baseline.json),Write(scripts/conformance-baseline.json)"
-            --allowedTools "Edit,MultiEdit,Write,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
+            --allowedTools "Edit,MultiEdit,Write,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm gen:*),Bash(pnpm -w run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(pnpm ls:*),Bash(pnpm why:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git fetch:*),Bash(git stash:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(mkdir:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh pr checks:*)"
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}
@@ -303,7 +324,15 @@ jobs:
                  comment on the issue explaining what you found, and stop.
                  (For feature/enhancement issues, add tests that exercise the
                  new behavior; a pre-fix failing test is not required.)
-            3. Before opening the PR, run the gates for what you touched:
+            3. Command forms matter: the tool allowlist matches on a command
+               prefix, so a spelling it does not recognise is denied and each
+               denial costs you two turns. Write `pnpm run gen:catalog`, never
+               `pnpm gen` with a colon-suffixed script and never `pnpm -w run
+               <script>`. Run ONE command per Bash call: a compound
+               `cd X && Y` is denied as a whole even when both halves would be
+               allowed on their own. Do not use `git -C <path>`; `cd` is not
+               allowed either, so work from the default directory.
+            4. Before opening the PR, run the gates for what you touched:
                `pnpm --filter <pkg> run lint`, `... typecheck`,
                `... test:coverage`, `pnpm run format:check`,
                `pnpm run gen:catalog:check`, `pnpm run check:conformance`;
@@ -313,7 +342,7 @@ jobs:
                bundle:stats, a high-severity audit, and a React 18/19
                compatibility matrix — write code that works on both React
                majors.
-            4. COMMIT + PUSH with the git CLI — create the branch and push it
+            5. COMMIT + PUSH with the git CLI — create the branch and push it
                yourself with plain git:
                  git checkout -b claude/issue-${{ github.event.issue.number }}-<short-timestamp>
                  git add -A
@@ -331,7 +360,7 @@ jobs:
                self-review checklist at the end of
                /CONTRIBUTING-COMPONENTS.md and fix every miss — each miss a
                reviewer catches costs one of the loop's 4 iterations.
-            5. Open the PR yourself. This is REQUIRED and is the definition
+            6. Open the PR yourself. This is REQUIRED and is the definition
                of "done" — the task is NOT complete until a real PR exists.
                Do NOT merely post a "Create a PR" / compare link; a link does
                not count and is an explicit failure of this step. You MUST
@@ -345,7 +374,7 @@ jobs:
                put that PR URL in your final comment. If `gh pr create` errors,
                report the exact error in your comment and STOP — never fall
                back to a compare link and never claim the PR step is done.
-            6. Never merge or close PRs, never enable auto-merge, never push
+            7. Never merge or close PRs, never enable auto-merge, never push
                to main, and never write "@claude" or "@coderabbitai" in any
                comment, commit message, or PR text.
 

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -259,9 +259,11 @@ jobs:
           # 250 turns is ~27m at the observed 6.4s/turn, still well inside
           # timeout-minutes: 60.
           #
-          # Four allowlist entries were added for those denials. None of them
-          # can reach the remote or a credential, and two are only different
-          # spellings of something already allowed:
+          # Four allowlist entries were added for those denials. The property
+          # each one is claimed on is narrow and stated per entry below; the
+          # only thing true of all four is that none can MUTATE the remote.
+          # `git fetch` does reach it, read-only and authenticated with the
+          # ambient git credential, exactly as the checkout already is.
           #   - `git fetch` DOES write, but only locally: FETCH_HEAD and
           #     remote-tracking refs in this ephemeral checkout. It cannot
           #     mutate the remote, and `git push` — which can, and is already


### PR DESCRIPTION
## Diagnosis

`claude-fix` on issues #617, #619 and #622 produced no branch, no PR and no comment, repeatedly. Four runs examined:

| Run | Issue | Real failure | Duration (of 60m) |
|---|---|---|---|
| 33691402266 | #622 | `error_max_turns` — **151 turns vs the 150 cap**, $10.60, stopped mid-tool-use before the commit step | 17m09s |
| 33691371110 | #619 | Killed: exit 143 (SIGTERM) 0.9s after a passing test, then "the runner has received a shutdown signal" | 19m35s |
| 33691275319 | #617 | Killed: same signal, 24s into `test:coverage` | 18m38s |
| 33697120818 | #617 | Killed likewise | ~20m |

So **"ran out of turns" was true for one of the four.** Ruled out by evidence for the rest: concurrency (group is per-issue with `cancel-in-progress: false`, no overlapping runs), the 60-minute timeout (nothing ran past 20m), billing (`billable.UBUNTU` is 0), and the egress and labeler gates (steps 1-9 succeeded every time). Three separate VMs; the maintainer cancelled none of them. Those shutdowns are GitHub-side and outside this workflow's control.

## What this PR fixes

The waste that fed the one real turn-limit failure. Every session hit permission denials, several for commands **this prompt itself instructs**. The allowlist matches on a command prefix, so `Bash(pnpm run:*)` does not cover `pnpm gen` (no `run`) or `pnpm -w run gen:catalog` (flag before `run`). Also denied: `git fetch`, `git stash`, `git -C <path> diff`, and any compound `cd X && Y`. #622 logged 7 denials; the killed runs logged 22 and 20. Each denial costs a turn plus a retry.

1. **`--max-turns 150` → `250`.** Sized from the data: 151 turns took 974s, about 6.4s/turn, so 250 turns is ~27 minutes and still sits well inside the unchanged `timeout-minutes: 60`. Cost scales from the observed $10.60 to roughly $17.50 worst case per attempt.
2. **Four allowlist entries** — `Bash(git fetch:*)`, `Bash(git stash:*)`, `Bash(pnpm gen:*)`, `Bash(pnpm -w run:*)`.
3. **The prompt now states the spellings the allowlist accepts** (new step 3), since a session cannot infer them from a denial: use `pnpm run gen:catalog`, one command per Bash call, no `git -C`.

## Security argument (`.github/CLAUDE.md` rule 2)

This is a top-row change: `--allowedTools` on a session holding credentials. Naming them, as the rule requires — the `implement` job carries **`AI_LOOP_PAT`** (bestaxbot's PAT, repository write, passed as `github_token`), **`CLAUDE_CODE_OAUTH_TOKEN`** and **`AI_LOOP_SSH_SIGNING_KEY`**. The allowlist is one of the controls between an issue-text-ingesting session and those credentials.

Each entry, and why it cannot write or grants nothing new:

| Entry | Argument |
|---|---|
| `Bash(git fetch:*)` | Read-only transfer from origin; cannot mutate the remote. `Bash(git push:*)` is already allowed and is strictly stronger. |
| `Bash(git stash:*)` | Local working-tree state only. No network, touches no credential. |
| `Bash(pnpm gen:*)` | The alias spelling of `pnpm run gen`, already allowed. Identical capability. The generators only rewrite in-repo generated files, which `Edit`/`Write` already permit. |
| `Bash(pnpm -w run:*)` | The root-scoped spelling of `pnpm run`, already allowed. `-w` selects the workspace root, the same as running from the root directory. |

**Considered and refused, recorded in the file as refused:**

- **`Bash(gh api:*)`** — `.github/CLAUDE.md` forbids it by name, "a general-purpose write primitive wearing a read-shaped name". With `AI_LOOP_PAT` in the environment it would grant everything that PAT can do, bypassing the narrow `gh issue`/`gh pr` verbs.
- **`Bash(git -C:*)`** — would permit any git subcommand at any path including `push`, defeating the per-subcommand structure of the list. The prompt tells the session to avoid it instead.
- **`Bash(gh auth status:*)`** — not needed; no surface added for convenience.

No `permissions:` change, no trigger change, no action SHA change, no new `vars.*` gate. `--model` and `timeout-minutes` are untouched.

## Verification

```
grep -c 'max-turns 250'                      # 1
Bash(gh api / Bash(git -C in --allowedTools  # 0 and 0
duplicate action SHAs across .github/        # none
pnpm exec prettier --check                   # clean
```

Prompt steps renumbered after the insertion (old 4→5, 5→6, 6→7); there are no cross-references to step numbers.

## After merge

Three of four runs died to GitHub-side eviction while three implement jobs ran concurrently, so re-apply `claude-fix` to **one** issue first (#619 is the smallest), confirm it completes, then the next. If a lone run is still evicted, the eviction is independent of load and worth raising with GitHub rather than worked around here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflows to support longer implementation runs and additional approved command formats.
  * Clarified automation command requirements and maintained protections around sensitive paths and broad repository API operations.
  * Preserved safeguards preventing approved commands from modifying remote repositories.
  * No changes to product functionality or the end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->