### PR TITLE
ci: move the opus workflows to opus 5

### DIFF
--- a/.github/workflows/bestaxbot-reply.yml
+++ b/.github/workflows/bestaxbot-reply.yml
@@ -308,7 +308,7 @@ jobs:
           # Edit/MultiEdit/Write allows in --allowedTools.
           claude_args: |
             --max-turns 120
-            --model claude-opus-4-8
+            --model claude-opus-5
             --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*),Edit(scripts/check-conformance.mjs),MultiEdit(scripts/check-conformance.mjs),Write(scripts/check-conformance.mjs),Edit(scripts/conformance-baseline.json),MultiEdit(scripts/conformance-baseline.json),Write(scripts/conformance-baseline.json)"
             --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh-thread:*)"
           prompt: |

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -526,7 +526,7 @@ jobs:
           # thread ops go through the pinned gh-thread helper instead.
           claude_args: |
             --max-turns 120
-            --model claude-opus-4-8[1m]
+            --model claude-opus-5[1m]
             --disallowedTools "Edit(.github/**),MultiEdit(.github/**),Write(.github/**),Edit(pnpm-workspace.yaml),MultiEdit(pnpm-workspace.yaml),Write(pnpm-workspace.yaml),Edit(.npmrc),MultiEdit(.npmrc),Write(.npmrc),Edit(.coderabbit.yaml),MultiEdit(.coderabbit.yaml),Write(.coderabbit.yaml),Edit(turbo.json),MultiEdit(turbo.json),Write(turbo.json),Edit(**/jest.config.*),MultiEdit(**/jest.config.*),Write(**/jest.config.*),Edit(commitlint.config.js),MultiEdit(commitlint.config.js),Write(commitlint.config.js),Edit(**/release.config.*),MultiEdit(**/release.config.*),Write(**/release.config.*),Edit(scripts/check-conformance.mjs),MultiEdit(scripts/check-conformance.mjs),Write(scripts/check-conformance.mjs),Edit(scripts/conformance-baseline.json),MultiEdit(scripts/conformance-baseline.json),Write(scripts/conformance-baseline.json)"
             --allowedTools "Edit,MultiEdit,Write,mcp__github_inline_comment__create_inline_comment,Bash(pnpm install:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(node:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(awk:*),Bash(echo:*),Bash(printf:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git config:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh-thread:*)"
           prompt: |
@@ -892,7 +892,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --max-turns 25
-            --model claude-opus-4-8
+            --model claude-opus-5
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh-thread:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*),Bash(rg:*),Bash(grep:*),Bash(cat:*),Bash(sed:*),Bash(ls:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -393,7 +393,7 @@ jobs:
           show_full_output: ${{ runner.debug == '1' }}
           claude_args: |
             --max-turns 120
-            --model claude-opus-4-8
+            --model claude-opus-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(pnpm run:*),Bash(pnpm test:*),Bash(pnpm exec:*),Bash(pnpm --filter:*)"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Moves every opus-pinned session from `claude-opus-4-8` to `claude-opus-5`.

## What changes

| Workflow | Job | Line |
|---|---|---|
| `claude-pr-loop.yml` | `fix` | 529 — keeps its `[1m]` context suffix: `claude-opus-5[1m]` |
| `claude-pr-loop.yml` | `verify` | 895 |
| `claude-review.yml` | deep review | 396 |
| `bestaxbot-reply.yml` | `respond` | 311 |

No `opus-4-8` reference remains anywhere under `.github/`.

**Deliberately untouched:** the five sonnet sessions — `ai-scan`, `ai-triage`, `claude-repro`, `claude-implement` and `claude` — stay on `claude-sonnet-5`. Those carry different budgets and cost profiles, and picking a model for them is its own decision rather than a side effect of this bump.

No allowlist change, no `permissions:` change, no trigger change, no action-SHA change.

## Note on the claude-fix failures

This PR will **not** fix `claude-fix` dying on issues #617, #619 and #622, and should not be expected to. `claude-implement` runs on sonnet, so this change does not touch that workflow at all. More to the point, the evidence says the model is not the cause. Across six runs:

| Outcome | Count |
|---|---|
| `error_max_turns` | 1 (#622, before #634 raised the cap) |
| Killed externally — exit 143 / "the operation was canceled" | **5** |

The two runs that started at 02:32, immediately after #634 merged, both died the same way and neither reached the turn cap, so #634 worked as intended and simply addressed a different failure. A job being SIGTERM'd at 10–20 minutes is being killed by the runner host.

Every eviction so far has happened with multiple `claude-implement` jobs running concurrently, including those two, which started 16 seconds apart. The most informative next step remains re-applying `claude-fix` to **one** issue alone and seeing whether a lone run survives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated response, pull request, and review workflows to use the latest Claude Opus model.
  - Improved the model configuration used for automated fixes, verification, and deep reviews.
  - No changes to end-user application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->