### PR TITLE
ci: wake the loop for Copilot reviews, not just CodeRabbit

### DIFF
--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -92,7 +92,8 @@ jobs:
       vars.AI_LOOP_ENABLED == 'true' && (
         (github.event_name == 'pull_request_review' &&
           (github.event.review.user.login == 'coderabbitai[bot]' ||
-            github.event.review.user.login == 'copilot-pull-request-reviewer[bot]') &&
+            github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' ||
+            github.event.review.user.login == 'Copilot') &&
           github.event.review.user.type == 'Bot' &&
           github.event.pull_request.state == 'open' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
@@ -509,15 +510,22 @@ jobs:
           bot_name: bestaxbot
           bot_id: '300268469'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Trigger actors are bots by design: coderabbitai[bot] and
-          # copilot-pull-request-reviewer[bot] (reviews), claude[bot] (CI
-          # workflow_run after its own pushes), and github-actions[bot] (the
-          # loop's self-dispatch continuation). The action matches this list
-          # against the RUN's actor by exact normalised login, and fix/verify
-          # run in the gate's own run — so a login the gate triggers on but
-          # this list omits fails the session's actor check instead of
-          # waiting (#612).
-          allowed_bots: 'coderabbitai,claude,github-actions,copilot-pull-request-reviewer'
+          # Trigger actors are bots by design: coderabbitai[bot] and Copilot
+          # (reviews), claude[bot] (CI workflow_run after its own pushes), and
+          # github-actions[bot] (the loop's self-dispatch continuation). The
+          # action matches this list against the RUN's actor by exact
+          # normalised login, and fix/verify run in the gate's own run — so a
+          # login the gate triggers on but this list omits fails the session's
+          # actor check instead of waiting (#612).
+          #
+          # Copilot needs BOTH spellings, and they are not interchangeable:
+          # one account (id 175728472) renders as `Copilot` to Actions (the
+          # run's actor, which is what this list is matched against — verified
+          # against seven pull_request_review runs on this repo) and as
+          # `copilot-pull-request-reviewer[bot]` through the reviews API (what
+          # the gate's event payload is expected to carry). CodeRabbit needs
+          # only one because both surfaces agree on it.
+          allowed_bots: 'coderabbitai,claude,github-actions,copilot,copilot-pull-request-reviewer'
           use_commit_signing: true
           # Stream the full turn-by-turn (tool calls + permission denials) into
           # the job log. The proxy blocks the execution-output artifact's blob
@@ -893,7 +901,7 @@ jobs:
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'coderabbitai,claude,github-actions,copilot-pull-request-reviewer'
+          allowed_bots: 'coderabbitai,claude,github-actions,copilot,copilot-pull-request-reviewer'
           # Stream tool calls + denials to the log (blob-hosted artifact is
           # blocked by the proxy) so a rebuttal pass is diagnosable.
           show_full_output: true

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -2,10 +2,11 @@ name: Claude PR Loop
 
 # Review → fix → verify → converge loop for AI-authored PRs (label: ai-loop)
 # ONLY. Triggered by CodeRabbit reviews, CI completions on claude/* branches,
-# or manual dispatch; Copilot reviews are eligible too, but GitHub has so far
-# created a run with jobs only for human-requested ones (the ai-development
-# guide has the data). The `gate` job is cheap shell that re-derives the PR's
-# live state and picks a mode — Claude usage is spent only in fix/verify.
+# or manual dispatch; Copilot reviews are eligible too, but every run one has
+# started so far died before creating a job, and jobs have appeared only when
+# a maintainer re-ran it (the ai-development guide has the data). The `gate`
+# job is cheap shell that re-derives the PR's live state and picks a mode —
+# Claude usage is spent only in fix/verify.
 #
 # Modes:
 #   fix-ci      CI is red on the head → Claude fixes the root cause, pushes.

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -519,15 +519,20 @@ jobs:
           # login the gate triggers on but this list omits fails the session's
           # actor check instead of waiting (#612).
           #
-          # `copilot` is the entry that does the work: one account
+          # `copilot` is the entry that does the work: the reviewer app
           # (id 175728472) renders as `Copilot` to Actions, and the run's
           # actor is the only string this list is ever compared against
           # (verified across every pull_request_review run this repo has had
-          # from it). The same account is `copilot-pull-request-reviewer[bot]`
-          # in the event payload, which is what the gate's trigger matches.
-          # That spelling is listed here only as a hedge against GitHub
-          # changing which name it reports as the actor; it matches nothing
-          # today. CodeRabbit needs one entry because both surfaces agree.
+          # from it). Matching is by normalised login, not by id: GitHub's
+          # other Copilot app, copilot-swe-agent[bot] (id 198982749), also
+          # renders as `Copilot`, so this entry admits either. What confines
+          # it is the gate's `if:` (same-repo, claude/* head, ai-loop label,
+          # PR open), not the precision of this string. The reviewer is
+          # `copilot-pull-request-reviewer[bot]` in the event payload, which
+          # is what the gate's `if:` matches. That spelling is listed here
+          # only as a hedge against GitHub changing which name it reports as
+          # the actor; it matches nothing today. CodeRabbit needs one entry
+          # because both surfaces agree.
           allowed_bots: 'coderabbitai,claude,github-actions,copilot,copilot-pull-request-reviewer'
           use_commit_signing: true
           # Stream the full turn-by-turn (tool calls + permission denials) into

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -987,14 +987,22 @@ jobs:
       # Thread replies/resolutions fire no workflow events — continue the
       # loop explicitly, but only if this pass made progress (otherwise a
       # broken verifier would self-dispatch forever).
-      # An empty execution_file means the session never ran: verify supplies
-      # no github_token, so the action's OIDC exchange can hit workflow
-      # validation when the PR head's copy of this file differs from main's,
-      # and it returns green having done nothing. Counting that as zero
-      # progress would pause the loop for the wrong reason; skipping this
-      # step leaves the PR for the next event instead.
+      # A green step with an empty execution_file means the session never
+      # ran: verify supplies no github_token, so the action's OIDC exchange
+      # can hit workflow validation when the PR head's copy of this file
+      # differs from main's, and it returns green having done nothing.
+      # Counting that as zero progress would pause the loop for the wrong
+      # reason; skipping this step leaves the PR for the next event instead.
+      # A red step can also have an empty execution_file (a failure before
+      # the session wrote its output), and that must still reach this step,
+      # which is verify's only terminal state: the iteration cap never
+      # counts verify, so a skipped handler here would let the sweep re-run
+      # a dying verify forever.
       - name: Continue loop
-        if: always() && steps.claude.conclusion != 'skipped' && steps.claude.outputs.execution_file != ''
+        if: |
+          always() && steps.claude.conclusion != 'skipped' &&
+            (steps.claude.outputs.execution_file != '' ||
+              steps.claude.conclusion == 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_TOKEN: ${{ secrets.AI_LOOP_PAT }}

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -517,11 +517,15 @@ jobs:
           # (reviews), claude[bot] (CI workflow_run after its own pushes), and
           # github-actions[bot] (the loop's self-dispatch continuation). The
           # action matches this list against the RUN's actor by exact
-          # normalised login, and fix/verify run in the gate's own run — so a
+          # normalised login, and fix/verify run in the gate's own run, so a
           # login the gate triggers on but this list omits fails the session's
-          # WRITE-PERMISSION check (a non-user actor is credited with write
-          # access only when this list names it) and then its human-actor
-          # check, so a red run rather than a wait (#612).
+          # human-actor check: a red run rather than a wait (#612). The
+          # action's write-permission check is a second, narrower consumer:
+          # it runs only in PR and issue contexts (here, the review arm) and
+          # returns true for any `[bot]`-suffixed actor before reading this
+          # list, so it reaches the list only for `Copilot`, which has no
+          # suffix. On workflow_run, dispatch and schedule only the
+          # human-actor check consults it.
           #
           # `copilot` is the entry that does the work: the reviewer app
           # (id 175728472) renders as `Copilot` to Actions, and the run's
@@ -530,17 +534,20 @@ jobs:
           # from it). Matching is by normalised login, not by id: GitHub's
           # other Copilot app, copilot-swe-agent[bot] (id 198982749), also
           # renders as `Copilot`, so this entry admits either. What confines
-          # it is the gate, not the precision of this string: its `if:` holds
-          # the same-repo and claude/* head tests on every arm, and the
-          # ai-loop label, PR-open and protected-path tests live in the gate
-          # job's shell (the review arm repeats the first two in its `if:`),
-          # so a Copilot-actored CI completion on a claude/* head still has to
-          # pass all of them before fix runs. The reviewer is
-          # `copilot-pull-request-reviewer[bot]` in the event payload, which
-          # is what the gate's `if:` matches. That spelling is listed here
-          # only as a hedge against GitHub changing which name it reports as
-          # the actor; it matches nothing today. CodeRabbit needs one entry
-          # because both surfaces agree.
+          # it is the gate, not the precision of this string, and each arm
+          # holds different parts of it: the review and workflow_run arms of
+          # the `if:` carry the same-repo and claude/* head tests, the
+          # workflow_dispatch arm carries neither and relies on GitHub only
+          # letting write-access actors dispatch (see the note under the
+          # `if:`), and the ai-loop label, PR-open and protected-path tests
+          # are re-derived in the gate job's shell on every arm while the two
+          # head tests are not. A Copilot-actored CI completion on a claude/*
+          # head therefore still passes all of them before fix runs. The
+          # reviewer is `copilot-pull-request-reviewer[bot]` in the event
+          # payload, which is what the gate's `if:` matches. That spelling is
+          # listed here only as a hedge against GitHub changing which name it
+          # reports as the actor; it matches nothing today. CodeRabbit needs
+          # one entry because both surfaces agree.
           allowed_bots: 'coderabbitai,claude,github-actions,copilot,copilot-pull-request-reviewer'
           use_commit_signing: true
           # Stream the full turn-by-turn (tool calls + permission denials) into

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -1,10 +1,11 @@
 name: Claude PR Loop
 
 # Review → fix → verify → converge loop for AI-authored PRs (label: ai-loop)
-# ONLY. Triggered by CodeRabbit or Copilot reviews, CI completions on
-# claude/* branches, or manual dispatch. The `gate` job is cheap shell that
-# re-derives the PR's live state and picks a mode — Claude usage is spent
-# only in fix/verify.
+# ONLY. Triggered by CodeRabbit reviews, CI completions on claude/* branches,
+# or manual dispatch; Copilot reviews are eligible too, but GitHub has so far
+# created a run with jobs only for human-requested ones (the ai-development
+# guide has the data). The `gate` job is cheap shell that re-derives the PR's
+# live state and picks a mode — Claude usage is spent only in fix/verify.
 #
 # Modes:
 #   fix-ci      CI is red on the head → Claude fixes the root cause, pushes.

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -3,10 +3,11 @@ name: Claude PR Loop
 # Review → fix → verify → converge loop for AI-authored PRs (label: ai-loop)
 # ONLY. Triggered by CodeRabbit reviews, CI completions on claude/* branches,
 # or manual dispatch; Copilot reviews are eligible too, but every run one has
-# started so far died before creating a job, and jobs have appeared only when
-# a maintainer re-ran it (the ai-development guide has the data). The `gate`
-# job is cheap shell that re-derives the PR's live state and picks a mode —
-# Claude usage is spent only in fix/verify.
+# started so far died before creating a job, jobs have appeared only when a
+# maintainer re-ran it, and since 2026-09-06 its reviews have created no run
+# at all (the ai-development guide has the data). The `gate` job is cheap
+# shell that re-derives the PR's live state and picks a mode — Claude usage
+# is spent only in fix/verify.
 #
 # Modes:
 #   fix-ci      CI is red on the head → Claude fixes the root cause, pushes.
@@ -527,8 +528,12 @@ jobs:
           # from it). Matching is by normalised login, not by id: GitHub's
           # other Copilot app, copilot-swe-agent[bot] (id 198982749), also
           # renders as `Copilot`, so this entry admits either. What confines
-          # it is the gate's `if:` (same-repo, claude/* head, ai-loop label,
-          # PR open), not the precision of this string. The reviewer is
+          # it is the gate, not the precision of this string: its `if:` holds
+          # the same-repo and claude/* head tests on every arm, and the
+          # ai-loop label, PR-open and protected-path tests live in the gate
+          # job's shell (the review arm repeats the first two in its `if:`),
+          # so a Copilot-actored CI completion on a claude/* head still has to
+          # pass all of them before fix runs. The reviewer is
           # `copilot-pull-request-reviewer[bot]` in the event payload, which
           # is what the gate's `if:` matches. That spelling is listed here
           # only as a hedge against GitHub changing which name it reports as

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -518,13 +518,15 @@ jobs:
           # login the gate triggers on but this list omits fails the session's
           # actor check instead of waiting (#612).
           #
-          # Copilot needs BOTH spellings, and they are not interchangeable:
-          # one account (id 175728472) renders as `Copilot` to Actions (the
-          # run's actor, which is what this list is matched against — verified
-          # against seven pull_request_review runs on this repo) and as
-          # `copilot-pull-request-reviewer[bot]` through the reviews API (what
-          # the gate's event payload is expected to carry). CodeRabbit needs
-          # only one because both surfaces agree on it.
+          # `copilot` is the entry that does the work: one account
+          # (id 175728472) renders as `Copilot` to Actions, and the run's
+          # actor is the only string this list is ever compared against
+          # (verified across every pull_request_review run this repo has had
+          # from it). The same account is `copilot-pull-request-reviewer[bot]`
+          # in the event payload, which is what the gate's trigger matches.
+          # That spelling is listed here only as a hedge against GitHub
+          # changing which name it reports as the actor; it matches nothing
+          # today. CodeRabbit needs one entry because both surfaces agree.
           allowed_bots: 'coderabbitai,claude,github-actions,copilot,copilot-pull-request-reviewer'
           use_commit_signing: true
           # Stream the full turn-by-turn (tool calls + permission denials) into

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -519,7 +519,9 @@ jobs:
           # action matches this list against the RUN's actor by exact
           # normalised login, and fix/verify run in the gate's own run — so a
           # login the gate triggers on but this list omits fails the session's
-          # actor check instead of waiting (#612).
+          # WRITE-PERMISSION check (a non-user actor is credited with write
+          # access only when this list names it) and then its human-actor
+          # check, so a red run rather than a wait (#612).
           #
           # `copilot` is the entry that does the work: the reviewer app
           # (id 175728472) renders as `Copilot` to Actions, and the run's

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -1,9 +1,10 @@
 name: Claude PR Loop
 
 # Review → fix → verify → converge loop for AI-authored PRs (label: ai-loop)
-# ONLY. Triggered by CodeRabbit reviews, CI completions on claude/* branches,
-# or manual dispatch. The `gate` job is cheap shell that re-derives the PR's
-# live state and picks a mode — Claude usage is spent only in fix/verify.
+# ONLY. Triggered by CodeRabbit or Copilot reviews, CI completions on
+# claude/* branches, or manual dispatch. The `gate` job is cheap shell that
+# re-derives the PR's live state and picks a mode — Claude usage is spent
+# only in fix/verify.
 #
 # Modes:
 #   fix-ci      CI is red on the head → Claude fixes the root cause, pushes.
@@ -90,7 +91,8 @@ jobs:
     if: |
       vars.AI_LOOP_ENABLED == 'true' && (
         (github.event_name == 'pull_request_review' &&
-          github.event.review.user.login == 'coderabbitai[bot]' &&
+          (github.event.review.user.login == 'coderabbitai[bot]' ||
+            github.event.review.user.login == 'copilot-pull-request-reviewer[bot]') &&
           github.event.review.user.type == 'Bot' &&
           github.event.pull_request.state == 'open' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
@@ -507,10 +509,15 @@ jobs:
           bot_name: bestaxbot
           bot_id: '300268469'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Trigger actors are bots by design: coderabbitai[bot] (reviews),
-          # claude[bot] (CI workflow_run after its own pushes), and
-          # github-actions[bot] (the loop's self-dispatch continuation).
-          allowed_bots: 'coderabbitai,claude,github-actions'
+          # Trigger actors are bots by design: coderabbitai[bot] and
+          # copilot-pull-request-reviewer[bot] (reviews), claude[bot] (CI
+          # workflow_run after its own pushes), and github-actions[bot] (the
+          # loop's self-dispatch continuation). The action matches this list
+          # against the RUN's actor by exact normalised login, and fix/verify
+          # run in the gate's own run — so a login the gate triggers on but
+          # this list omits fails the session's actor check instead of
+          # waiting (#612).
+          allowed_bots: 'coderabbitai,claude,github-actions,copilot-pull-request-reviewer'
           use_commit_signing: true
           # Stream the full turn-by-turn (tool calls + permission denials) into
           # the job log. The proxy blocks the execution-output artifact's blob
@@ -886,7 +893,7 @@ jobs:
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'coderabbitai,claude,github-actions'
+          allowed_bots: 'coderabbitai,claude,github-actions,copilot-pull-request-reviewer'
           # Stream tool calls + denials to the log (blob-hosted artifact is
           # blocked by the proxy) so a rebuttal pass is diagnosable.
           show_full_output: true

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -95,8 +95,7 @@ jobs:
       vars.AI_LOOP_ENABLED == 'true' && (
         (github.event_name == 'pull_request_review' &&
           (github.event.review.user.login == 'coderabbitai[bot]' ||
-            github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' ||
-            github.event.review.user.login == 'Copilot') &&
+            github.event.review.user.login == 'copilot-pull-request-reviewer[bot]') &&
           github.event.review.user.type == 'Bot' &&
           github.event.pull_request.state == 'open' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
@@ -527,28 +526,25 @@ jobs:
           # suffix. On workflow_run, dispatch and schedule only the
           # human-actor check consults it.
           #
-          # `copilot` is the entry that does the work: the reviewer app
-          # (id 175728472) renders as `Copilot` to Actions, and the run's
-          # actor is the only string this list is ever compared against
-          # (verified across every pull_request_review run this repo has had
-          # from it). Matching is by normalised login, not by id: GitHub's
-          # other Copilot app, copilot-swe-agent[bot] (id 198982749), also
-          # renders as `Copilot`, so this entry admits either. What confines
-          # it is the gate, not the precision of this string, and each arm
-          # holds different parts of it: the review and workflow_run arms of
-          # the `if:` carry the same-repo and claude/* head tests, the
-          # workflow_dispatch arm carries neither and relies on GitHub only
-          # letting write-access actors dispatch (see the note under the
-          # `if:`), and the ai-loop label, PR-open and protected-path tests
-          # are re-derived in the gate job's shell on every arm while the two
-          # head tests are not. A Copilot-actored CI completion on a claude/*
-          # head therefore still passes all of them before fix runs. The
-          # reviewer is `copilot-pull-request-reviewer[bot]` in the event
-          # payload, which is what the gate's `if:` matches. That spelling is
-          # listed here only as a hedge against GitHub changing which name it
-          # reports as the actor; it matches nothing today. CodeRabbit needs
-          # one entry because both surfaces agree.
-          allowed_bots: 'coderabbitai,claude,github-actions,copilot,copilot-pull-request-reviewer'
+          # `copilot` is the Copilot reviewer app (id 175728472), which
+          # renders as `Copilot` to Actions (the run actor, verified across
+          # every pull_request_review run this repo has had from it) and as
+          # `copilot-pull-request-reviewer[bot]` in the event payload, which
+          # is what the gate's `if:` matches; each list carries only the
+          # spelling it is compared against. Matching here is by normalised
+          # login, not by id: GitHub's other Copilot app,
+          # copilot-swe-agent[bot] (id 198982749), also renders as `Copilot`,
+          # so this entry admits either. What confines it is the gate, not
+          # the precision of this string, and each arm holds different parts
+          # of it: the review and workflow_run arms of the `if:` carry the
+          # same-repo and claude/* head tests, the workflow_dispatch arm
+          # carries neither and relies on GitHub only letting write-access
+          # actors dispatch (see the note under the `if:`), and the ai-loop
+          # label, PR-open and protected-path tests are re-derived in the
+          # gate job's shell on every arm while the two head tests are not.
+          # A CI completion with Copilot as the actor, on a claude/* head,
+          # therefore still passes all of them before fix runs.
+          allowed_bots: 'coderabbitai,claude,github-actions,copilot'
           use_commit_signing: true
           # Stream the full turn-by-turn (tool calls + permission denials) into
           # the job log. The proxy blocks the execution-output artifact's blob
@@ -924,7 +920,7 @@ jobs:
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'coderabbitai,claude,github-actions,copilot,copilot-pull-request-reviewer'
+          allowed_bots: 'coderabbitai,claude,github-actions,copilot'
           # Stream tool calls + denials to the log (blob-hosted artifact is
           # blocked by the proxy) so a rebuttal pass is diagnosable.
           show_full_output: true
@@ -991,8 +987,14 @@ jobs:
       # Thread replies/resolutions fire no workflow events — continue the
       # loop explicitly, but only if this pass made progress (otherwise a
       # broken verifier would self-dispatch forever).
+      # An empty execution_file means the session never ran: verify supplies
+      # no github_token, so the action's OIDC exchange can hit workflow
+      # validation when the PR head's copy of this file differs from main's,
+      # and it returns green having done nothing. Counting that as zero
+      # progress would pause the loop for the wrong reason; skipping this
+      # step leaves the PR for the next event instead.
       - name: Continue loop
-        if: always() && steps.claude.conclusion != 'skipped'
+        if: always() && steps.claude.conclusion != 'skipped' && steps.claude.outputs.execution_file != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_TOKEN: ${{ secrets.AI_LOOP_PAT }}

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -993,8 +993,9 @@ jobs:
       # differs from main's, and it returns green having done nothing.
       # Counting that as zero progress would pause the loop for the wrong
       # reason; skipping this step leaves the PR for the next event instead.
-      # A red step can also have an empty execution_file (a failure before
-      # the session wrote its output), and that must still reach this step,
+      # A red or cancelled step can also have an empty execution_file (a
+      # failure or kill before the session wrote its output), and that must
+      # still reach this step,
       # which is verify's only terminal state: the iteration cap never
       # counts verify, so a skipped handler here would let the sweep re-run
       # a dying verify forever.
@@ -1002,7 +1003,7 @@ jobs:
         if: |
           always() && steps.claude.conclusion != 'skipped' &&
             (steps.claude.outputs.execution_file != '' ||
-              steps.claude.conclusion == 'failure')
+              steps.claude.conclusion != 'success')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_TOKEN: ${{ secrets.AI_LOOP_PAT }}

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -227,10 +227,16 @@ which before this change matched only `coderabbitai[bot]`; run `33041194214` was
 none. Runs `33586960606`, `33232938014` and `33035152465` are three of the twenty, on `claude/*`
 heads, and `33586960606` is the worked example: attempt 1 was `action_required` with zero jobs,
 attempt 2 produced the six. So there is no observed case of a Copilot review starting a loop run
-unaided. The `AI_LOOP_COPILOT=true` path adds nothing to that picture yet: `claude-implement.yml`
-requests the review under the workflow's `GITHUB_TOKEN`, and events attributed to that token start
-no workflows at all. Either way a Copilot-only finding still waits for the next natural event: a
-CI or deep-review completion, a CodeRabbit review, or the 2-hourly watchdog sweep. The widened
+unaided. Since 2026-09-06 the shape has changed again: Copilot's reviews on PR #643 that day (all
+of them its "encountered an error" submissions) created no `Claude PR Loop` run at all, so the
+query below can come back with nothing new rather than a fresh startup failure, and absence of a
+run is the expected reading, not a broken query. Whether `AI_LOOP_COPILOT=true` changes any of
+this is untested: the variable has never been on, so no review requested by `claude-implement.yml`
+has been observed. The request itself starts nothing (it is made under the workflow's
+`GITHUB_TOKEN`, and nothing here listens for `review_requested`), but the review Copilot then
+submits is its own event under its own credentials, so treat that path as unknown rather than
+ruled out. Either way a Copilot-only finding still waits for the next natural event: a CI or
+deep-review completion, a CodeRabbit review, or the 2-hourly watchdog sweep. The widened
 condition removes our side of the obstacle; it is not a latency guarantee. Treat a `Claude PR
 Loop` run **with jobs** as the proof. Keep the `--paginate` and the `run_attempt` column: the most
 recent page alone is all startup failures, which is how the absolute version of this claim was
@@ -255,8 +261,11 @@ Those two strings are not always the same. The Copilot reviewer app renders as
 spelling is what makes the gate condition match and the actor spelling is what makes
 `allowed_bots` match. `allowed_bots` compares normalised logins, not account ids, and GitHub's
 other Copilot app (`copilot-swe-agent[bot]`) also renders as `Copilot`, so that entry admits
-either; the confinement is the gate's `if:` (same-repo `claude/*` head, `ai-loop` label, PR
-open), not the precision of the string. Each place also lists the other spelling, but only as a
+either; the confinement is the gate, not the precision of the string. Its `if:` tests same-repo
+and `claude/*` head on every arm, and the `ai-loop` label, PR-open and protected-path tests are
+re-derived in the gate job's shell (the review arm repeats the first two in its `if:`), so a
+`Copilot`-actored CI completion still passes all of them before `fix` runs. Each place also lists
+the other spelling, but only as a
 hedge against GitHub changing which name it reports where; those extra entries match nothing
 today. CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer,
 read its login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`, since

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -213,33 +213,38 @@ separate store and none are documented here.
 | `AI_SCAN_DAILY_LIMIT`   | `20`                  | integer                | Auto scans per UTC day                                                                                                                     |
 | `AI_LOOP_COPILOT`       | `false`               | must be exactly `true` | Requests a Copilot review on loop PRs (Copilot's own automatic review skips bot-authored PRs on personal repos, so it has to be asked for) |
 
-Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the gate job's `if:` names it
-alongside CodeRabbit: a submitted review from either is **eligible** to fire the gate on an
-`ai-loop` PR. Eligible is the honest word, and the split between runs that start and runs that do
-not is not random. Whether a `Claude PR Loop` run for a Copilot review ever creates a job is
-decided by whether a maintainer re-ran it. Every run Copilot has triggered arrived as
-`run_attempt: 1` with `triggering_actor: Copilot` and died before a job existed (100 `failure`
-with zero jobs and 21 `action_required`, 121 so far), so no job `if:` was evaluated. The only ones that reached a job are among the 21 a maintainer re-ran by hand: on a re-run `triggering_actor`
-becomes the re-runner, which is what the `allxsmith` rows in that query are, and not a record of
-who requested the review. Twenty of those created all six jobs and evaluated the gate's `if:`,
-which before this change matched only `coderabbitai[bot]`; run `33041194214` was cancelled with
-none. Runs `33586960606`, `33232938014` and `33035152465` are three of the twenty, on `claude/*`
-heads, and `33586960606` is the worked example: attempt 1 was `action_required` with zero jobs,
-attempt 2 produced the six. So there is no observed case of a Copilot review starting a loop run
-unaided. Since 2026-09-06 the shape has changed again: Copilot's reviews on PR #643 that day (all
-of them its "encountered an error" submissions) created no `Claude PR Loop` run at all, so the
-query below can come back with nothing new rather than a fresh startup failure, and absence of a
-run is the expected reading, not a broken query. Whether `AI_LOOP_COPILOT=true` changes any of
-this is untested: the variable has never been on, so no review requested by `claude-implement.yml`
-has been observed. The request itself starts nothing (it is made under the workflow's
-`GITHUB_TOKEN`, and nothing here listens for `review_requested`), but the review Copilot then
-submits is its own event under its own credentials, so treat that path as unknown rather than
-ruled out. Either way a Copilot-only finding still waits for the next natural event: a CI or
-deep-review completion, a CodeRabbit review, or the 2-hourly watchdog sweep. The widened
-condition removes our side of the obstacle; it is not a latency guarantee. Treat a `Claude PR
-Loop` run **with jobs** as the proof. Keep the `--paginate` and the `run_attempt` column: the most
-recent page alone is all startup failures, which is how the absolute version of this claim was
-first written, and without the attempt number the re-runs look like a second kind of trigger.
+The gate job's `if:` names Copilot alongside CodeRabbit: a submitted review from either is
+**eligible** to fire the gate on an `ai-loop` PR. That condition reads no `AI_LOOP_COPILOT`, only
+`AI_LOOP_ENABLED`, so it is live for any Copilot review, including one a maintainer requests by
+hand, which is how every Copilot review on a loop PR has arrived so far (#573, #624).
+`AI_LOOP_COPILOT` decides only whether `claude-implement.yml` asks for the review; unsetting it is
+not a kill switch for this trigger. `AI_LOOP_ENABLED=false` and removing `ai-loop` are. Eligible is
+the honest word, and the split between runs that start and runs that do not is not random. Whether a
+`Claude PR Loop` run for a Copilot review ever creates a job is decided by whether a maintainer
+re-ran it. Every run Copilot has triggered arrived as `run_attempt: 1` with `triggering_actor:
+Copilot` and died before a job existed (100 `failure` with zero jobs and 21 `action_required`, 121
+so far), so no job `if:` was evaluated. The only ones that reached a job are among the 21 a
+maintainer re-ran by hand: on a re-run `triggering_actor` becomes the re-runner, which is what the
+`allxsmith` rows in that query are, and not a record of who requested the review. Twenty of those
+created all six jobs and evaluated the gate's `if:`, which before this change matched only
+`coderabbitai[bot]`; run `33041194214` was cancelled with none. Runs `33586960606`, `33232938014`
+and `33035152465` are three of the twenty, on `claude/*` heads, and `33586960606` is the worked
+example: attempt 1 was `action_required` with zero jobs, attempt 2 produced the six. So there is no
+observed case of a Copilot review starting a loop run unaided. Since 2026-09-06 the shape has
+changed again: Copilot's reviews on PR #643 that day (all of them its "encountered an error"
+submissions) created no `Claude PR Loop` run at all, so the query below can come back with nothing
+new rather than a fresh startup failure, and absence of a run is the expected reading, not a broken
+query. Whether `AI_LOOP_COPILOT=true` changes any of this is untested: the variable has never been
+on, so no review requested by `claude-implement.yml` has been observed. The request itself starts
+nothing (it is made under the workflow's `GITHUB_TOKEN`, and nothing here listens for
+`review_requested`), but the review Copilot then submits is its own event under its own credentials,
+so treat that path as unknown rather than ruled out. Either way a Copilot-only finding still waits
+for the next natural event: a CI or deep-review completion, a CodeRabbit review, or the 2-hourly
+watchdog sweep. The widened condition removes our side of the obstacle; it is not a latency
+guarantee. Treat a `Claude PR Loop` run **with jobs** as the proof. Keep the `--paginate` and the
+`run_attempt` column: the most recent page alone is all startup failures, which is how the absolute
+version of this claim was first written, and without the attempt number the re-runs look like a
+second kind of trigger.
 
 ```bash
 gh api --paginate \
@@ -253,24 +258,27 @@ different strings. The `pull_request_review` branch of the gate job's `if:` is m
 event payload (`review.user.login`); the `allowed_bots` list on the fix and verify sessions is
 matched against the **run's actor**, and nothing else. A reviewer in one but not the other either
 waits for an unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly
-watchdog sweep) or fails the session's write-permission check outright, since the action credits a
-non-user actor with write access only when `allowed_bots` names it, and then its human-actor check.
+watchdog sweep) or fails the session's human-actor check outright. The action's write-permission
+check also reads `allowed_bots`, but only in PR and issue contexts and only for an actor without a
+`[bot]` suffix, which here means `Copilot` on the review arm; every other entry and every other arm
+is decided by the human-actor check alone.
 
 Those two strings are not always the same. The Copilot reviewer app renders as
 `copilot-pull-request-reviewer[bot]` in the payload and as `Copilot` to Actions, so the payload
-spelling is what makes the gate condition match and the actor spelling is what makes
-`allowed_bots` match. `allowed_bots` compares normalised logins, not account ids, and GitHub's
-other Copilot app (`copilot-swe-agent[bot]`) also renders as `Copilot`, so that entry admits
-either; the confinement is the gate, not the precision of the string. Its `if:` tests same-repo
-and `claude/*` head on every arm, and the `ai-loop` label, PR-open and protected-path tests are
-re-derived in the gate job's shell (the review arm repeats the first two in its `if:`), so a
-`Copilot`-actored CI completion still passes all of them before `fix` runs. Each place also lists
-the other spelling, but only as a
-hedge against GitHub changing which name it reports where; those extra entries match nothing
-today. CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer,
-read its login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`, since
-`gh run list` exposes no actor field) as well as off the API, and put each spelling where it is
-actually compared (#612).
+spelling is what makes the gate condition match and the actor spelling is what makes `allowed_bots`
+match. `allowed_bots` compares normalised logins, not account ids, and GitHub's other Copilot app
+(`copilot-swe-agent[bot]`) also renders as `Copilot`, so that entry admits either; the confinement
+is the gate, not the precision of the string, and each arm holds different parts of it. The review
+and CI-completion arms of the `if:` carry the same-repo and `claude/*` head tests; the
+manual-dispatch arm carries neither and relies on GitHub only letting write-access users dispatch.
+The `ai-loop` label, PR-open and protected-path tests are re-derived in the gate job's shell on
+every arm, and the two head tests are not. So a `Copilot`-actored CI completion on a `claude/*` head
+still passes all of them before `fix` runs. Each place also lists the other spelling, but only as a
+hedge against GitHub changing which name it reports where; those extra entries match nothing today.
+CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer, read its
+login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`, since `gh run list`
+exposes no actor field) as well as off the API, and put each spelling where it is actually compared
+(#612).
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -280,6 +280,15 @@ login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`,
 exposes no actor field) as well as off the API, and put each spelling where it is actually compared
 (#612).
 
+One divergence deliberately remains. The gate's `if:` names exact logins, while the `ACTIONABLE`
+counter, and the fix job's terminal check that repeats it, match the case-insensitive prefix
+`^(coderabbitai|copilot)`. A thread opened by any other `copilot-*` app, `copilot-swe-agent[bot]`
+today or a future reviewer app, is therefore still counted as work the loop owes while its review
+fires no gate run, which is the same wait of up to two hours that #612 describes. That is the safe
+direction: a new `copilot-*` app cannot admit itself to a session holding `AI_LOOP_PAT` just by
+existing. But it means the two agree only for the logins named above, so adding a reviewer means
+adding it to the `if:` and to `allowed_bots`, not only to the counter's regex.
+
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:
 

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -213,9 +213,22 @@ separate store and none are documented here.
 | `AI_SCAN_DAILY_LIMIT`   | `20`                  | integer                | Auto scans per UTC day                                                                                                                     |
 | `AI_LOOP_COPILOT`       | `false`               | must be exactly `true` | Requests a Copilot review on loop PRs (Copilot's own automatic review skips bot-authored PRs on personal repos, so it has to be asked for) |
 
-Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the loop wakes for it the
-same way it wakes for CodeRabbit: a submitted review from either reviewer fires the gate on an
-`ai-loop` PR. Two lists have to name the reviewer for that to work end to end — the gate's
+Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the gate's trigger names it
+alongside CodeRabbit: a submitted review from either is **eligible** to fire the gate on an
+`ai-loop` PR. Eligible is the honest word. Every `pull_request_review` run this repository has
+had with actor `Copilot` either failed at startup — zero jobs, so no job `if:` is ever
+evaluated — or was never created at all, which is what a Copilot review on this repo does today.
+So a Copilot-only finding still waits for the next natural event: a CI or deep-review completion,
+a CodeRabbit review, or the 2-hourly watchdog sweep. The trigger removes our side of the
+obstacle; it is not yet a latency guarantee. Re-check before relying on it, and treat a
+`Claude PR Loop` run with jobs as the proof:
+
+```bash
+gh api "repos/allxsmith/bestax/actions/workflows/claude-pr-loop.yml/runs?event=pull_request_review" \
+  --jq '.workflow_runs[] | select(.actor.login=="Copilot") | [.id, .conclusion] | @tsv'
+```
+
+Two lists have to name the reviewer for that to work end to end — the gate's
 `pull_request_review` trigger, matched against the event payload, and the `allowed_bots` list on
 the fix and verify sessions, matched against the **run's actor**. A reviewer in one but not the
 other either waits for an unrelated event (a CI or deep-review completion, the other reviewer, or

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -217,28 +217,30 @@ Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the gate job'
 alongside CodeRabbit: a submitted review from either is **eligible** to fire the gate on an
 `ai-loop` PR. Eligible is the honest word, and the split between runs that start and runs that do
 not is not random. Whether a `Claude PR Loop` run for a Copilot review ever creates a job is
-decided by its `triggering_actor`. Every run Copilot triggered under its own actor (121 so far,
-100 `failure` with zero jobs and 21 `action_required`) died before a job existed, so no job `if:`
-was evaluated. Every run where a human had requested the review (`triggering_actor: allxsmith`,
-21 runs) created all six jobs and evaluated the gate's `if:`, which before this change matched
-only `coderabbitai[bot]`; runs `33586960606`, `33232938014` and `33035152465` are three of those,
-on `claude/*` heads. The two buckets interleave across August 2026, so this is a partition and
-not a change over time. The `AI_LOOP_COPILOT=true` path is a third case with no observations
-yet: `claude-implement.yml` requests the review under the workflow's `GITHUB_TOKEN`, and if
-attribution follows the requester the way it does for a human, GitHub's rule against
-`GITHUB_TOKEN`-attributed events starting workflows suppresses the run entirely. Verify that
-before relying on it. Either way a Copilot-only finding may still wait for the next natural
-event: a CI or deep-review completion, a CodeRabbit review, or the 2-hourly watchdog sweep. The
-widened condition removes our side of the obstacle; it is not yet a latency guarantee. Treat a
-`Claude PR Loop` run **with jobs** as the proof. Keep the `--paginate` and the `triggering_actor`
-column: the most recent page alone is all startup failures, which is how the absolute version of
-this claim was first written, and without the actor the partition looks like flakiness.
+decided by whether a maintainer re-ran it. Every run Copilot has triggered arrived as
+`run_attempt: 1` with `triggering_actor: Copilot` and died before a job existed (100 `failure`
+with zero jobs and 21 `action_required`, 121 so far), so no job `if:` was evaluated. The only 21
+that reached a job are the ones a maintainer re-ran by hand: on a re-run `triggering_actor`
+becomes the re-runner, which is what the `allxsmith` rows in that query are, and not a record of
+who requested the review. Twenty of those created all six jobs and evaluated the gate's `if:`,
+which before this change matched only `coderabbitai[bot]`; run `33041194214` was cancelled with
+none. Runs `33586960606`, `33232938014` and `33035152465` are three of the twenty, on `claude/*`
+heads, and `33586960606` is the worked example: attempt 1 was `action_required` with zero jobs,
+attempt 2 produced the six. So there is no observed case of a Copilot review starting a loop run
+unaided. The `AI_LOOP_COPILOT=true` path adds nothing to that picture yet: `claude-implement.yml`
+requests the review under the workflow's `GITHUB_TOKEN`, and events attributed to that token start
+no workflows at all. Either way a Copilot-only finding still waits for the next natural event: a
+CI or deep-review completion, a CodeRabbit review, or the 2-hourly watchdog sweep. The widened
+condition removes our side of the obstacle; it is not a latency guarantee. Treat a `Claude PR
+Loop` run **with jobs** as the proof. Keep the `--paginate` and the `run_attempt` column: the most
+recent page alone is all startup failures, which is how the absolute version of this claim was
+first written, and without the attempt number the re-runs look like a second kind of trigger.
 
 ```bash
 gh api --paginate \
   "repos/allxsmith/bestax/actions/workflows/claude-pr-loop.yml/runs?event=pull_request_review" \
   --jq '.workflow_runs[] | select(.actor.login=="Copilot")
-        | [.id, .triggering_actor.login, .conclusion, .head_branch] | @tsv'
+        | [.id, .run_attempt, .triggering_actor.login, .conclusion, .head_branch] | @tsv'
 ```
 
 Two lists have to name the reviewer for that to work end to end, and they are matched against
@@ -257,8 +259,9 @@ either; the confinement is the gate's `if:` (same-repo `claude/*` head, `ai-loop
 open), not the precision of the string. Each place also lists the other spelling, but only as a
 hedge against GitHub changing which name it reports where; those extra entries match nothing
 today. CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer,
-read its login off a real run (`gh run list --json actor`) as well as off the API, and put each
-spelling where it is actually compared (#612).
+read its login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`, since
+`gh run list` exposes no actor field) as well as off the API, and put each spelling where it is
+actually compared (#612).
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -238,13 +238,13 @@ query. Whether `AI_LOOP_COPILOT=true` changes any of this is untested: the varia
 on, so no review requested by `claude-implement.yml` has been observed. The request itself starts
 nothing (it is made under the workflow's `GITHUB_TOKEN`, and nothing here listens for
 `review_requested`), but the review Copilot then submits is its own event under its own credentials,
-so treat that path as unknown rather than ruled out. Either way a Copilot-only finding still waits
-for the next natural event: a CI or deep-review completion, a CodeRabbit review, or the 2-hourly
-watchdog sweep. The widened condition removes our side of the obstacle; it is not a latency
-guarantee. Treat a `Claude PR Loop` run **with jobs** as the proof. Keep the `--paginate` and the
-`run_attempt` column: the most recent page alone is all startup failures, which is how the absolute
-version of this claim was first written, and without the attempt number the re-runs look like a
-second kind of trigger.
+so treat that path as unknown rather than ruled out. In every case observed so far, a Copilot-only
+finding has still waited for the next natural event: a CI or deep-review completion, a CodeRabbit
+review, or the 2-hourly watchdog sweep. The widened condition removes our side of the obstacle; it
+is not a latency guarantee. Treat a `Claude PR Loop` run **with jobs** as the proof. Keep the
+`--paginate` and the `run_attempt` column: the most recent page alone is all startup failures, which
+is how the absolute version of this claim was first written, and without the attempt number the
+re-runs look like a second kind of trigger.
 
 ```bash
 gh api --paginate \
@@ -272,13 +272,13 @@ is the gate, not the precision of the string, and each arm holds different parts
 and CI-completion arms of the `if:` carry the same-repo and `claude/*` head tests; the
 manual-dispatch arm carries neither and relies on GitHub only letting write-access users dispatch.
 The `ai-loop` label, PR-open and protected-path tests are re-derived in the gate job's shell on
-every arm, and the two head tests are not. So a `Copilot`-actored CI completion on a `claude/*` head
-still passes all of them before `fix` runs. Each place also lists the other spelling, but only as a
-hedge against GitHub changing which name it reports where; those extra entries match nothing today.
-CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer, read its
-login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`, since `gh run list`
-exposes no actor field) as well as off the API, and put each spelling where it is actually compared
-(#612).
+every arm, and the two head tests are not. So a CI completion with `Copilot` as the actor, on a
+`claude/*` head, still passes all of them before `fix` runs. Each place also lists the other
+spelling, but only as a hedge against GitHub changing which name it reports where; those extra
+entries match nothing today. CodeRabbit needs one spelling because both surfaces agree on it. When
+adding a reviewer, read its login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq
+.actor.login`, since `gh run list` exposes no actor field) as well as off the API, and put each
+spelling where it is actually compared (#612).
 
 One divergence deliberately remains. The gate's `if:` names exact logins, while the `ACTIONABLE`
 counter, and the fix job's terminal check that repeats it, match the case-insensitive prefix

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -213,6 +213,14 @@ separate store and none are documented here.
 | `AI_SCAN_DAILY_LIMIT`   | `20`                  | integer                | Auto scans per UTC day                                                                                                                     |
 | `AI_LOOP_COPILOT`       | `false`               | must be exactly `true` | Requests a Copilot review on loop PRs (Copilot's own automatic review skips bot-authored PRs on personal repos, so it has to be asked for) |
 
+Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the loop wakes for it the
+same way it wakes for CodeRabbit: a submitted review from either reviewer fires the gate on an
+`ai-loop` PR. Both logins are named in two places that have to agree — the gate's
+`pull_request_review` trigger and the `allowed_bots` list on the fix and verify sessions, which
+the action matches against the run's own actor. A reviewer named in one but not the other either
+waits for an unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly
+watchdog sweep) or fails the session's actor check outright, so add a new reviewer to both (#612).
+
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:
 

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -215,11 +215,17 @@ separate store and none are documented here.
 
 Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the loop wakes for it the
 same way it wakes for CodeRabbit: a submitted review from either reviewer fires the gate on an
-`ai-loop` PR. Both logins are named in two places that have to agree — the gate's
-`pull_request_review` trigger and the `allowed_bots` list on the fix and verify sessions, which
-the action matches against the run's own actor. A reviewer named in one but not the other either
-waits for an unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly
-watchdog sweep) or fails the session's actor check outright, so add a new reviewer to both (#612).
+`ai-loop` PR. Two lists have to name the reviewer for that to work end to end — the gate's
+`pull_request_review` trigger, matched against the event payload, and the `allowed_bots` list on
+the fix and verify sessions, matched against the **run's actor**. A reviewer in one but not the
+other either waits for an unrelated event (a CI or deep-review completion, the other reviewer, or
+the 2-hourly watchdog sweep) or fails the session's actor check outright.
+
+They are not always the same string. Copilot is one account that renders as
+`copilot-pull-request-reviewer[bot]` through the reviews API and as `Copilot` to Actions, so both
+spellings are listed; CodeRabbit needs one because both surfaces agree on it. When adding a
+reviewer, read its login off a real run (`gh run list --json actor`) as well as off the API, and
+put whichever spellings you find in both places (#612).
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -248,14 +248,17 @@ matched against the **run's actor**, and nothing else. A reviewer in one but not
 waits for an unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly
 watchdog sweep) or fails the session's actor check outright.
 
-Those two strings are not always the same. Copilot is one account that renders as
+Those two strings are not always the same. The Copilot reviewer app renders as
 `copilot-pull-request-reviewer[bot]` in the payload and as `Copilot` to Actions, so the payload
 spelling is what makes the gate condition match and the actor spelling is what makes
-`allowed_bots` match. Each place also lists the other spelling, but only as a hedge against GitHub
-changing which name it reports where; those extra entries match nothing today. CodeRabbit needs
-one spelling because both surfaces agree on it. When adding a reviewer, read its login off a real
-run (`gh run list --json actor`) as well as off the API, and put each spelling where it is
-actually compared (#612).
+`allowed_bots` match. `allowed_bots` compares normalised logins, not account ids, and GitHub's
+other Copilot app (`copilot-swe-agent[bot]`) also renders as `Copilot`, so that entry admits
+either; the confinement is the gate's `if:` (same-repo `claude/*` head, `ai-loop` label, PR
+open), not the precision of the string. Each place also lists the other spelling, but only as a
+hedge against GitHub changing which name it reports where; those extra entries match nothing
+today. CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer,
+read its login off a real run (`gh run list --json actor`) as well as off the API, and put each
+spelling where it is actually compared (#612).
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -219,8 +219,7 @@ alongside CodeRabbit: a submitted review from either is **eligible** to fire the
 not is not random. Whether a `Claude PR Loop` run for a Copilot review ever creates a job is
 decided by whether a maintainer re-ran it. Every run Copilot has triggered arrived as
 `run_attempt: 1` with `triggering_actor: Copilot` and died before a job existed (100 `failure`
-with zero jobs and 21 `action_required`, 121 so far), so no job `if:` was evaluated. The only 21
-that reached a job are the ones a maintainer re-ran by hand: on a re-run `triggering_actor`
+with zero jobs and 21 `action_required`, 121 so far), so no job `if:` was evaluated. The only ones that reached a job are among the 21 a maintainer re-ran by hand: on a re-run `triggering_actor`
 becomes the re-runner, which is what the `allxsmith` rows in that query are, and not a record of
 who requested the review. Twenty of those created all six jobs and evaluated the gate's `if:`,
 which before this change matched only `coderabbitai[bot]`; run `33041194214` was cancelled with
@@ -254,7 +253,8 @@ different strings. The `pull_request_review` branch of the gate job's `if:` is m
 event payload (`review.user.login`); the `allowed_bots` list on the fix and verify sessions is
 matched against the **run's actor**, and nothing else. A reviewer in one but not the other either
 waits for an unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly
-watchdog sweep) or fails the session's actor check outright.
+watchdog sweep) or fails the session's write-permission check outright, since the action credits a
+non-user actor with write access only when `allowed_bots` names it, and then its human-actor check.
 
 Those two strings are not always the same. The Copilot reviewer app renders as
 `copilot-pull-request-reviewer[bot]` in the payload and as `Copilot` to Actions, so the payload

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -213,41 +213,49 @@ separate store and none are documented here.
 | `AI_SCAN_DAILY_LIMIT`   | `20`                  | integer                | Auto scans per UTC day                                                                                                                     |
 | `AI_LOOP_COPILOT`       | `false`               | must be exactly `true` | Requests a Copilot review on loop PRs (Copilot's own automatic review skips bot-authored PRs on personal repos, so it has to be asked for) |
 
-Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the gate's trigger names it
+Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the gate job's `if:` names it
 alongside CodeRabbit: a submitted review from either is **eligible** to fire the gate on an
-`ai-loop` PR. Eligible is the honest word. Most `pull_request_review` runs this repository has had
-with actor `Copilot` never reached a job: they failed at startup with zero jobs, so no job `if:`
-was evaluated, or sat at `action_required`, or were never created at all. A minority start
-normally and reach the gate (runs `33586960606`, `33232938014` and `33035152465` each created all
-six jobs on a `claude/*` head and evaluated the gate's `if:`, which before this change matched
-only `coderabbitai[bot]`). So the widened trigger is reachable, but a Copilot-only finding may
-still wait for the next natural event: a CI or deep-review completion, a CodeRabbit review, or the
-2-hourly watchdog sweep. The trigger removes our side of the obstacle; it is not yet a latency
-guarantee. Re-check before relying on it, and treat a `Claude PR Loop` run with jobs as the proof.
-Keep the `--paginate`: the most recent page alone can be all startup failures, which is how the
-absolute version of this claim was first written.
+`ai-loop` PR. Eligible is the honest word, and the split between runs that start and runs that do
+not is not random. Whether a `Claude PR Loop` run for a Copilot review ever creates a job is
+decided by its `triggering_actor`. Every run Copilot triggered under its own actor (121 so far,
+100 `failure` with zero jobs and 21 `action_required`) died before a job existed, so no job `if:`
+was evaluated. Every run where a human had requested the review (`triggering_actor: allxsmith`,
+21 runs) created all six jobs and evaluated the gate's `if:`, which before this change matched
+only `coderabbitai[bot]`; runs `33586960606`, `33232938014` and `33035152465` are three of those,
+on `claude/*` heads. The two buckets interleave across August 2026, so this is a partition and
+not a change over time. The `AI_LOOP_COPILOT=true` path is a third case with no observations
+yet: `claude-implement.yml` requests the review under the workflow's `GITHUB_TOKEN`, and if
+attribution follows the requester the way it does for a human, GitHub's rule against
+`GITHUB_TOKEN`-attributed events starting workflows suppresses the run entirely. Verify that
+before relying on it. Either way a Copilot-only finding may still wait for the next natural
+event: a CI or deep-review completion, a CodeRabbit review, or the 2-hourly watchdog sweep. The
+widened condition removes our side of the obstacle; it is not yet a latency guarantee. Treat a
+`Claude PR Loop` run **with jobs** as the proof. Keep the `--paginate` and the `triggering_actor`
+column: the most recent page alone is all startup failures, which is how the absolute version of
+this claim was first written, and without the actor the partition looks like flakiness.
 
 ```bash
 gh api --paginate \
   "repos/allxsmith/bestax/actions/workflows/claude-pr-loop.yml/runs?event=pull_request_review" \
-  --jq '.workflow_runs[] | select(.actor.login=="Copilot") | [.id, .conclusion, .head_branch] | @tsv'
+  --jq '.workflow_runs[] | select(.actor.login=="Copilot")
+        | [.id, .triggering_actor.login, .conclusion, .head_branch] | @tsv'
 ```
 
 Two lists have to name the reviewer for that to work end to end, and they are matched against
-different strings. The gate's `pull_request_review` trigger is matched against the event payload
-(`review.user.login`); the `allowed_bots` list on the fix and verify sessions is matched against
-the **run's actor**, and nothing else. A reviewer in one but not the other either waits for an
-unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly watchdog
-sweep) or fails the session's actor check outright.
+different strings. The `pull_request_review` branch of the gate job's `if:` is matched against the
+event payload (`review.user.login`); the `allowed_bots` list on the fix and verify sessions is
+matched against the **run's actor**, and nothing else. A reviewer in one but not the other either
+waits for an unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly
+watchdog sweep) or fails the session's actor check outright.
 
 Those two strings are not always the same. Copilot is one account that renders as
 `copilot-pull-request-reviewer[bot]` in the payload and as `Copilot` to Actions, so the payload
-spelling is what makes the trigger match and the actor spelling is what makes `allowed_bots`
-match. Each place also lists the other spelling, but only as a hedge against GitHub changing
-which name it reports where; those extra entries match nothing today. CodeRabbit needs one
-spelling because both surfaces agree on it. When adding a reviewer, read its login off a real run
-(`gh run list --json actor`) as well as off the API, and put each spelling where it is actually
-compared (#612).
+spelling is what makes the gate condition match and the actor spelling is what makes
+`allowed_bots` match. Each place also lists the other spelling, but only as a hedge against GitHub
+changing which name it reports where; those extra entries match nothing today. CodeRabbit needs
+one spelling because both surfaces agree on it. When adding a reviewer, read its login off a real
+run (`gh run list --json actor`) as well as off the API, and put each spelling where it is
+actually compared (#612).
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -215,30 +215,39 @@ separate store and none are documented here.
 
 Turning `AI_LOOP_COPILOT` on gives the loop a second reviewer, and the gate's trigger names it
 alongside CodeRabbit: a submitted review from either is **eligible** to fire the gate on an
-`ai-loop` PR. Eligible is the honest word. Every `pull_request_review` run this repository has
-had with actor `Copilot` either failed at startup — zero jobs, so no job `if:` is ever
-evaluated — or was never created at all, which is what a Copilot review on this repo does today.
-So a Copilot-only finding still waits for the next natural event: a CI or deep-review completion,
-a CodeRabbit review, or the 2-hourly watchdog sweep. The trigger removes our side of the
-obstacle; it is not yet a latency guarantee. Re-check before relying on it, and treat a
-`Claude PR Loop` run with jobs as the proof:
+`ai-loop` PR. Eligible is the honest word. Most `pull_request_review` runs this repository has had
+with actor `Copilot` never reached a job: they failed at startup with zero jobs, so no job `if:`
+was evaluated, or sat at `action_required`, or were never created at all. A minority start
+normally and reach the gate (runs `33586960606`, `33232938014` and `33035152465` each created all
+six jobs on a `claude/*` head and evaluated the gate's `if:`, which before this change matched
+only `coderabbitai[bot]`). So the widened trigger is reachable, but a Copilot-only finding may
+still wait for the next natural event: a CI or deep-review completion, a CodeRabbit review, or the
+2-hourly watchdog sweep. The trigger removes our side of the obstacle; it is not yet a latency
+guarantee. Re-check before relying on it, and treat a `Claude PR Loop` run with jobs as the proof.
+Keep the `--paginate`: the most recent page alone can be all startup failures, which is how the
+absolute version of this claim was first written.
 
 ```bash
-gh api "repos/allxsmith/bestax/actions/workflows/claude-pr-loop.yml/runs?event=pull_request_review" \
-  --jq '.workflow_runs[] | select(.actor.login=="Copilot") | [.id, .conclusion] | @tsv'
+gh api --paginate \
+  "repos/allxsmith/bestax/actions/workflows/claude-pr-loop.yml/runs?event=pull_request_review" \
+  --jq '.workflow_runs[] | select(.actor.login=="Copilot") | [.id, .conclusion, .head_branch] | @tsv'
 ```
 
-Two lists have to name the reviewer for that to work end to end — the gate's
-`pull_request_review` trigger, matched against the event payload, and the `allowed_bots` list on
-the fix and verify sessions, matched against the **run's actor**. A reviewer in one but not the
-other either waits for an unrelated event (a CI or deep-review completion, the other reviewer, or
-the 2-hourly watchdog sweep) or fails the session's actor check outright.
+Two lists have to name the reviewer for that to work end to end, and they are matched against
+different strings. The gate's `pull_request_review` trigger is matched against the event payload
+(`review.user.login`); the `allowed_bots` list on the fix and verify sessions is matched against
+the **run's actor**, and nothing else. A reviewer in one but not the other either waits for an
+unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly watchdog
+sweep) or fails the session's actor check outright.
 
-They are not always the same string. Copilot is one account that renders as
-`copilot-pull-request-reviewer[bot]` through the reviews API and as `Copilot` to Actions, so both
-spellings are listed; CodeRabbit needs one because both surfaces agree on it. When adding a
-reviewer, read its login off a real run (`gh run list --json actor`) as well as off the API, and
-put whichever spellings you find in both places (#612).
+Those two strings are not always the same. Copilot is one account that renders as
+`copilot-pull-request-reviewer[bot]` in the payload and as `Copilot` to Actions, so the payload
+spelling is what makes the trigger match and the actor spelling is what makes `allowed_bots`
+match. Each place also lists the other spelling, but only as a hedge against GitHub changing
+which name it reports where; those extra entries match nothing today. CodeRabbit needs one
+spelling because both surfaces agree on it. When adding a reviewer, read its login off a real run
+(`gh run list --json actor`) as well as off the API, and put each spelling where it is actually
+compared (#612).
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -223,12 +223,12 @@ the honest word, and the split between runs that start and runs that do not is n
 `Claude PR Loop` run for a Copilot review ever creates a job is decided by whether a maintainer
 re-ran it. Every run Copilot has triggered arrived as `run_attempt: 1` with `triggering_actor:
 Copilot` and died before a job existed (100 `failure` with zero jobs and 21 `action_required`, 121
-so far), so no job `if:` was evaluated. The only ones that reached a job are among the 21 a
+so far), so no job `if:` was evaluated. The only ones that reached a job are among the 19 a
 maintainer re-ran by hand: on a re-run `triggering_actor` becomes the re-runner, which is what the
-`allxsmith` rows in that query are, and not a record of who requested the review. Twenty of those
+`allxsmith` rows in that query are, and not a record of who requested the review. Eighteen of those
 created all six jobs and evaluated the gate's `if:`, which before this change matched only
 `coderabbitai[bot]`; run `33041194214` was cancelled with none. Runs `33586960606`, `33232938014`
-and `33035152465` are three of the twenty, on `claude/*` heads, and `33586960606` is the worked
+and `33035152465` are three of the eighteen, on `claude/*` heads, and `33586960606` is the worked
 example: attempt 1 was `action_required` with zero jobs, attempt 2 produced the six. So there is no
 observed case of a Copilot review starting a loop run unaided. Since 2026-09-06 the shape has
 changed again: Copilot's reviews on PR #643 that day (all of them its "encountered an error"

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -273,21 +273,24 @@ and CI-completion arms of the `if:` carry the same-repo and `claude/*` head test
 manual-dispatch arm carries neither and relies on GitHub only letting write-access users dispatch.
 The `ai-loop` label, PR-open and protected-path tests are re-derived in the gate job's shell on
 every arm, and the two head tests are not. So a CI completion with `Copilot` as the actor, on a
-`claude/*` head, still passes all of them before `fix` runs. Each place also lists the other
-spelling, but only as a hedge against GitHub changing which name it reports where; those extra
-entries match nothing today. CodeRabbit needs one spelling because both surfaces agree on it. When
-adding a reviewer, read its login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq
-.actor.login`, since `gh run list` exposes no actor field) as well as off the API, and put each
-spelling where it is actually compared (#612).
+`claude/*` head, still passes all of them before `fix` runs. Each list carries only the spelling it
+is compared against; a hedge entry in the other place would match nothing today and, in
+`allowed_bots`, would widen an allowlist on the job holding `AI_LOOP_PAT` for no observed reason.
+CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer, read its
+login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`, since `gh run list`
+exposes no actor field) as well as off the API, and put each spelling where it is actually compared
+(#612).
 
 One divergence deliberately remains. The gate's `if:` names exact logins, while the `ACTIONABLE`
 counter, and the fix job's terminal check that repeats it, match the case-insensitive prefix
 `^(coderabbitai|copilot)`. A thread opened by any other `copilot-*` app, `copilot-swe-agent[bot]`
 today or a future reviewer app, is therefore still counted as work the loop owes while its review
-fires no gate run, which is the same wait of up to two hours that #612 describes. That is the safe
-direction: a new `copilot-*` app cannot admit itself to a session holding `AI_LOOP_PAT` just by
-existing. But it means the two agree only for the logins named above, so adding a reviewer means
-adding it to the `if:` and to `allowed_bots`, not only to the counter's regex.
+fires no gate run (its run actor can still reach `fix` through the CI-completion arm described
+above, where the gate confines it), which is the same wait of up to two hours that #612 describes.
+That is the safe direction: a new `copilot-*` app cannot admit itself to a session holding
+`AI_LOOP_PAT` just by existing. But it means the two agree only for the logins named above, so
+adding a reviewer means adding it to the `if:` and to `allowed_bots`, not only to the counter's
+regex.
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:


### PR DESCRIPTION
Closes #612.

The gate **counted** Copilot threads as actionable work while its `pull_request_review` arm hard-coded `coderabbitai[bot]`, so a Copilot-only finding sat until an unrelated event fired the gate — a CI or deep-review completion, a CodeRabbit review, or the 2-hourly watchdog. Up to ~2 hours of silence on a loop whose point is prompt convergence.

## What changed

- **The gate's trigger names both review logins**, so a Copilot review submission wakes the loop the way a CodeRabbit one does.
- **`allowed_bots` on the fix and verify sessions names Copilot's run-actor login too.** Each list carries only the spelling it is compared against: `copilot-pull-request-reviewer[bot]` in the gate's `if:` (the payload spelling, verified from real reviews on #642) and `copilot` in `allowed_bots` (the run actor, verified across every Copilot-actored run here). Earlier revisions carried the other spelling in each place as a hedge; three reviews called those entries inert, and one sat on the job holding `AI_LOOP_PAT`, so they are gone.
- **`verify`'s Continue loop step now requires the session to have run.** `verify` supplies no `github_token`, so on a review-triggered run whose head copy of the workflow differs from `main` the action's OIDC exchange hits workflow validation and returns green without running; the step then read that as zero progress and paused the loop. It now also requires a non-empty `execution_file` output, which the action sets only after a session ran.

## The second half is not optional, and the issue said otherwise

#612 concluded no `allowed_bots` change was needed, reasoning that the input governs trigger actors while the sessions read threads through `gh-thread`, which is author-agnostic. The first half of that is exactly why it matters: `fix` and `verify` are `needs: gate`, so they run **inside the gate's own run**, whose actor is the review submitter. The pinned action resolves the actor's type and, for a non-User, requires an exact normalised login match:

```ts
// anthropics/claude-code-action@51c4762 src/github/validation/actor.ts
const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
return allowedList.includes(normalizedActor);
```

With `'coderabbitai,claude,github-actions'`, a Copilot-triggered run reaches `fix` and fails the actor check. Widening the trigger alone would have converted a latency bug into a red run — strictly worse. The thread-reading half of the issue's reasoning stands: `gh-thread.sh`'s GraphQL query is author-agnostic and needed nothing.

## What the widened trigger admits

Exactly one new event shape: a submitted review from `copilot-pull-request-reviewer[bot]` (verified `user.type == Bot`, same as `coderabbitai[bot]`) on a PR that is open, on a `claude/*` head in this repository, labelled `ai-loop`, with `AI_LOOP_ENABLED == 'true'`. Exact logins rather than the counter's `^(coderabbitai|copilot)` prefix, so a future `copilot-*` app is not admitted by accident; the guide records the residue that leaves.

Every other guard is unchanged, and the gate re-derives all live state, so a spurious trigger is a cheap `skip` that spends no model usage. The trigger set and the `ACTIONABLE` test now agree for the reviewer logins named in the gate; the counter's `^(coderabbitai|copilot)` prefix stays broader on purpose, so any other `copilot-*` app is still counted but wakes nothing, and the guide documents that residue with the latency it implies, which is the issue's other acceptance path.

Live on merge, not gated on `AI_LOOP_COPILOT`: the gate reads only `AI_LOOP_ENABLED`, and a maintainer already requests Copilot reviews on loop PRs by hand (#573, #624), so those fire it. `AI_LOOP_COPILOT` decides only whether `claude-implement.yml` asks for the review, which it has to because Copilot's automatic review skips bot-authored PRs on personal repos. The kill switches for this path are `AI_LOOP_ENABLED=false` and removing `ai-loop`.

## Invariants

Neither I1 nor I2 is touched: no job composition changes, no identity changes, no new credential adjacency, no `--allowedTools` change, and the `anthropics/claude-code-action` SHA stays on the repo-wide pin (9 occurrences, one SHA).

The one allowlist that grows is `allowed_bots` on `fix`, the job holding `AI_LOOP_PAT` and `AI_LOOP_SSH_SIGNING_KEY` (and on `verify`, which holds neither). The entry admits GitHub's `Copilot` actor login, which two Copilot apps share, on every arm the gate can fire on, not only the review arm; before `fix` runs, the gate still re-derives same-repo `claude/*` head, `ai-loop` label, PR open and the protected-path halt from live data, and that is the confinement rather than the precision of the login.

## Docs

The ai-development guide now says, next to `AI_LOOP_COPILOT`, that the two lists have to agree and what happens when they do not — a reviewer in one but not the other either waits for an unrelated event or fails the actor check.

## Verification

- `pnpm check:conformance` — 19/19.
- `pnpm format:check` — clean.
- Copilot's review identity checked against a real review on #642: `login=copilot-pull-request-reviewer[bot] type=Bot`.
- The action's matching semantics read from the pinned SHA rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated review workflow handling for bot identity variations, failed or cancelled runs, and verification sessions without execution output.
  - Refined continuation logic so successful sessions are skipped only when appropriate.

- **Documentation**
  - Updated guidance on workflow failures, maintainer reruns, job creation, triggering actors, and verification.
  - Clarified bot naming, actor normalization, permission checks, allowlist behavior, gate conditions, and security boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



