### PR TITLE
fix(create-bestax): declare @allxsmith/bestax-bulma as a dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,12 @@ Full versioning details (breaking-change footers, tag formats): `VERSIONING.md`.
   not stop every consumer being made to install the dependency. Which packages publish with pnpm
   is **declared** in `check:conformance` rather than inferred from their release config —
   inferring it meant parsing semantic-release's config format, which was wrong four times,
-  and every miss granted the exemption.
+  and every miss granted the exemption. A workspace **sibling** in `dependencies` or
+  `optionalDependencies` is separately a violation however the specifier is spelled (#537), and
+  the only way through is a line in `SIBLING_RUNTIME_DEPS` — same declared shape — for a
+  package that depends on a sibling at runtime on purpose (#644: the CLIs on
+  `@allxsmith/bestax-bulma`, the way bulma-ui declares `bulma`); the test holds that declaration
+  to the real manifests, so a removed dependency cannot leave a standing exemption.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,10 @@ Full versioning details (breaking-change footers, tag formats): `VERSIONING.md`.
   and every miss granted the exemption. A workspace **sibling** in `dependencies` or
   `optionalDependencies` is separately a violation however the specifier is spelled (#537), and
   the only way through is a line in `SIBLING_RUNTIME_DEPS` — same declared shape — for a
-  package that depends on a sibling at runtime on purpose (#644: the CLIs on
-  `@allxsmith/bestax-bulma`, the way bulma-ui declares `bulma`); the test holds that declaration
-  to the real manifests, so a removed dependency cannot leave a standing exemption.
+  package that depends on a sibling at runtime on purpose (#644: create-bestax on
+  `@allxsmith/bestax-bulma`, the way bulma-ui declares `bulma`; bestax-mcp and bestax-migrate
+  follow in their own PRs); the test holds that declaration to the real manifests, so a removed
+  dependency cannot leave a standing exemption.
 
 ## Workflow
 

--- a/create-bestax/CLAUDE.md
+++ b/create-bestax/CLAUDE.md
@@ -15,6 +15,18 @@ path (`-y` + flags, no TTY) must never hang or regress (#192).
 - `src/validators.ts`, `src/display.ts`, `src/file-system.ts` — support modules
 - `templates/vite`, `templates/vite-ts` — the app templates
 
+## Dependencies
+
+`@allxsmith/bestax-bulma` is a declared runtime dependency (#644). The scaffolder is built for
+the library and its manifest says so, the way bulma-ui declares `bulma` without importing it:
+nothing in `src/` imports the library, the templates pin the published package themselves
+(`^5.0.0` in `templates/*/package.json`), and the e2e installs from the registry with
+`--ignore-workspace`. It is spelled `workspace:^`, which `pnpm publish` rewrites to the release
+current at pack time (bulma-ui releases first in the same job), and the sibling rule in
+`check:conformance` allows it only because `SIBLING_RUNTIME_DEPS` declares this exact pair.
+What a consumer sees: `npm create bestax` installs the library, `bulma`, and — npm's automatic
+peer install — `react`/`react-dom` alongside the CLI.
+
 ## Sync rules (this package re-ships other parts of the repo)
 
 - `pnpm build` and `prepack` run `scripts/sync-skills.mjs`, which copies **every directory

--- a/create-bestax/package.json
+++ b/create-bestax/package.json
@@ -54,6 +54,7 @@
     "url": "https://github.com/allxsmith/bestax/issues"
   },
   "dependencies": {
+    "@allxsmith/bestax-bulma": "workspace:^",
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "figures": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
 
   create-bestax:
     dependencies:
+      '@allxsmith/bestax-bulma':
+        specifier: workspace:^
+        version: link:../bulma-ui
       chalk:
         specifier: ^6.0.0
         version: 6.0.0

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2068,8 +2068,9 @@ const PNPM_PUBLISHED = new Set([
 
 /**
  * Workspace siblings a published package depends on AT RUNTIME, on purpose
- * (#644): the CLIs are built for `@allxsmith/bestax-bulma` and their manifests
- * say so, the way bulma-ui declares `bulma` without ever importing it. This is
+ * (#644): create-bestax is built for `@allxsmith/bestax-bulma` and its
+ * manifest says so, the way bulma-ui declares `bulma` without ever importing
+ * it; bestax-mcp and bestax-migrate join this map in their own PRs. This is
  * the exemption the sibling rule below reserved for "the PR that needs one",
  * and it takes the PNPM_PUBLISHED shape for the same reason: a declaration
  * cannot be misparsed, and scripts/publishable-manifests.test.mjs checks it
@@ -2269,8 +2270,9 @@ export function manifestViolations(dir, pkg, siblings = new Map()) {
  * The rule is blanket over published packages rather than an opt-in set, so
  * nothing is grandfathered by accident: the ONLY way through it is a line in
  * SIBLING_RUNTIME_DEPS above, added by the PR that wants the dependency, at
- * the moment the decision is cheap. #644 is that PR for the CLIs, which
- * depend on `@allxsmith/bestax-bulma` by declaration and never import it. The
+ * the moment the decision is cheap. #644 is that decision for the CLIs, one
+ * PR per package, each depending on `@allxsmith/bestax-bulma` by declaration
+ * and never importing it. The
  * exemption is per directory and per target, never per section: a declared
  * sibling in `optionalDependencies`, or a different sibling in the same
  * manifest, is still the case this rule exists for. A private sibling is never

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2067,11 +2067,28 @@ const PNPM_PUBLISHED = new Set([
 ]);
 
 /**
+ * Workspace siblings a published package depends on AT RUNTIME, on purpose
+ * (#644): the CLIs are built for `@allxsmith/bestax-bulma` and their manifests
+ * say so, the way bulma-ui declares `bulma` without ever importing it. This is
+ * the exemption the sibling rule below reserved for "the PR that needs one",
+ * and it takes the PNPM_PUBLISHED shape for the same reason: a declaration
+ * cannot be misparsed, and scripts/publishable-manifests.test.mjs checks it
+ * against the real manifests, so a dependency that is later removed fails a
+ * test instead of leaving a silent standing exemption.
+ *
+ * Keyed by directory, valued by the sibling's PACKAGE NAME (the alias target,
+ * so `"ui": "npm:@allxsmith/bestax-bulma@^5"` is the same declaration). It
+ * covers `dependencies` only: an optional sibling is not what anyone declared.
+ */
+export const SIBLING_RUNTIME_DEPS = new Map([
+  ['create-bestax', new Set(['@allxsmith/bestax-bulma'])],
+]);
+
+/**
  * The per-package rule, split out from the filesystem walk so it can be driven
  * with fixtures. Without this seam the violation branches never execute during
- * a real run — bestax-migrate is the only package carrying a pack-time
- * specifier and it is exempt for it — so inverting the rule would leave CI
- * green.
+ * a real run — every package carrying a pack-time specifier is declared exempt
+ * for it — so inverting the rule would leave CI green.
  *
  * Each offender carries the reason it survived the filter, so the message does
  * not re-derive the predicate that produced it. Two copies of one rule inside
@@ -2249,12 +2266,16 @@ export function manifestViolations(dir, pkg, siblings = new Map()) {
  * four-file codemod CLI install the component library. bestax-migrate's
  * CLAUDE.md carried "that one is on review" as the only enforcement.
  *
- * The rule is blanket over published packages rather than an opt-in set: no
- * package has a sibling dep in a consumer section today, so nothing is
- * grandfathered, and a scaffolder or an MCP server has no more business
- * pulling in the component library than the codemod does. If a package ever
- * legitimately needs one, that PR adds the exemption — a decision at the
- * moment it is cheap, the PNPM_PUBLISHED shape.
+ * The rule is blanket over published packages rather than an opt-in set, so
+ * nothing is grandfathered by accident: the ONLY way through it is a line in
+ * SIBLING_RUNTIME_DEPS above, added by the PR that wants the dependency, at
+ * the moment the decision is cheap. #644 is that PR for the CLIs, which
+ * depend on `@allxsmith/bestax-bulma` by declaration and never import it. The
+ * exemption is per directory and per target, never per section: a declared
+ * sibling in `optionalDependencies`, or a different sibling in the same
+ * manifest, is still the case this rule exists for. A private sibling is never
+ * exempt, declared or not — no consumer could install it, so the declaration
+ * would be excusing a manifest that cannot ship.
  *
  * peerDependencies are deliberately OUTSIDE the rule, and this departs from
  * the protocol rule above, which does fire on a `workspace:` peer (with
@@ -2288,6 +2309,13 @@ export function siblingViolations(dir, pkg, siblings) {
       }
       const sibling = siblings.get(target);
       if (!sibling || target === pkg?.name) continue;
+      if (
+        section === 'dependencies' &&
+        !sibling.private &&
+        SIBLING_RUNTIME_DEPS.get(dir)?.has(target)
+      ) {
+        continue;
+      }
       // A PRIVATE sibling gets different advice: it does not exist on the
       // registry, so "make it a peerDependency" would leave every consumer
       // unable to install — the dependency cannot ship in any section

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2293,28 +2293,51 @@ export function manifestViolations(dir, pkg, siblings = new Map()) {
  * private sibling cannot become a peerDependency, since no consumer could
  * resolve it.
  */
-export function siblingViolations(dir, pkg, siblings) {
+/**
+ * The package a dependency entry actually installs. An npm alias installs its
+ * TARGET, so `"ui": "npm:@allxsmith/…@^5"` pulls in the sibling under another
+ * key — and `"@allxsmith/…": "npm:other@^1"` pulls in something else under
+ * the sibling's key. Every comparison against a sibling name goes through this,
+ * in the rule and in the test that holds SIBLING_RUNTIME_DEPS to the manifests,
+ * or either is bypassable by renaming (review on #537 caught exactly that hole
+ * in the rule; review on #645 caught it again in the test). The last `@`
+ * splits off the range; a scoped name's leading `@` survives because the slice
+ * starts past `npm:`.
+ */
+export function dependencyTarget(name, spec) {
+  if (typeof spec === 'string' && spec.startsWith('npm:')) {
+    const aliased = spec.slice(4);
+    const at = aliased.lastIndexOf('@');
+    return at > 0 ? aliased.slice(0, at) : aliased;
+  }
+  return name;
+}
+
+/**
+ * `runtimeDeps` defaults to the real declaration and the walk never passes
+ * one, so a test that omits it exercises the wiring — the same reason
+ * manifestViolations reads PNPM_PUBLISHED itself. It is a parameter at all
+ * because the private-sibling guard below is unreachable through the real
+ * map: the reality test forbids declaring a private target, so the only way
+ * to prove the guard exists is a fixture declaration that does.
+ */
+export function siblingViolations(
+  dir,
+  pkg,
+  siblings,
+  runtimeDeps = SIBLING_RUNTIME_DEPS
+) {
   if (pkg?.private) return [];
   const violations = [];
   for (const section of ['dependencies', 'optionalDependencies']) {
     for (const [name, spec] of Object.entries(pkg?.[section] ?? {})) {
-      // An npm alias installs its TARGET, so `"ui": "npm:@allxsmith/…@^5"`
-      // pulls in the sibling under another key. Compared on the target, or
-      // the rule is bypassable by renaming — review on the PR caught exactly
-      // that hole. The last `@` splits off the range; a scoped name's leading
-      // `@` survives because the slice starts past `npm:`.
-      let target = name;
-      if (typeof spec === 'string' && spec.startsWith('npm:')) {
-        const aliased = spec.slice(4);
-        const at = aliased.lastIndexOf('@');
-        target = at > 0 ? aliased.slice(0, at) : aliased;
-      }
+      const target = dependencyTarget(name, spec);
       const sibling = siblings.get(target);
       if (!sibling || target === pkg?.name) continue;
       if (
         section === 'dependencies' &&
         !sibling.private &&
-        SIBLING_RUNTIME_DEPS.get(dir)?.has(target)
+        runtimeDeps.get(dir)?.has(target)
       ) {
         continue;
       }

--- a/scripts/publishable-manifests.test.mjs
+++ b/scripts/publishable-manifests.test.mjs
@@ -21,6 +21,7 @@ import assert from 'node:assert/strict';
 
 import {
   SIBLING_RUNTIME_DEPS,
+  dependencyTarget,
   hookScripts,
   manifestViolations,
   parseWorkspacePackages,
@@ -934,15 +935,62 @@ test('an undeclared directory depending on a declared target is still flagged', 
   assert.equal(v.length, 1, v.join('\n'));
 });
 
-test('a private sibling is never exempt, declared or not', () => {
-  // The map cannot be edited from here, so this pins the guard the only way
-  // it can be reached: a declared directory naming a private target. Nothing
-  // declares one today; if a declaration ever does, this is what fails.
-  for (const [dir, targets] of SIBLING_RUNTIME_DEPS) {
-    for (const target of targets) {
-      assert.equal(SIBLINGS.get(target)?.private, false, `${dir} -> ${target}`);
-    }
-  }
+test('a private sibling is never exempt, even when declared', () => {
+  // The real map cannot declare a private target without failing the reality
+  // test below, so the guard is reached the only other way: a fixture
+  // declaration that does. The same fixture shape with a public target IS
+  // exempt, so the guard is what makes the difference, not the fixture.
+  const privateDecl = new Map([
+    ['bestax-migrate', new Set(['@allxsmith/bestax-docs'])],
+  ]);
+  const v = siblingViolations(
+    'bestax-migrate',
+    {
+      name: 'bestax-migrate',
+      dependencies: { '@allxsmith/bestax-docs': 'workspace:*' },
+    },
+    SIBLINGS,
+    privateDecl
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /private and unpublishable/);
+
+  const publicDecl = new Map([
+    ['bestax-migrate', new Set(['@allxsmith/bestax-bulma'])],
+  ]);
+  assert.deepEqual(
+    siblingViolations(
+      'bestax-migrate',
+      {
+        name: 'bestax-migrate',
+        dependencies: { '@allxsmith/bestax-bulma': 'workspace:^' },
+      },
+      SIBLINGS,
+      publicDecl
+    ),
+    []
+  );
+});
+
+test('dependencyTarget follows an npm alias in either direction', () => {
+  assert.equal(
+    dependencyTarget('ui', 'npm:@allxsmith/bestax-bulma@^5'),
+    '@allxsmith/bestax-bulma'
+  );
+  assert.equal(
+    dependencyTarget('ui', 'npm:@allxsmith/bestax-bulma'),
+    '@allxsmith/bestax-bulma'
+  );
+  // The sibling's own key pointing somewhere else is NOT a dependency on it.
+  assert.equal(
+    dependencyTarget('@allxsmith/bestax-bulma', 'npm:other@^1'),
+    'other'
+  );
+  assert.equal(
+    dependencyTarget('@allxsmith/bestax-bulma', 'workspace:^'),
+    '@allxsmith/bestax-bulma'
+  );
+  assert.equal(dependencyTarget('bulma', '^1.0.4'), 'bulma');
 });
 
 test('every declared runtime sibling matches the real manifests', () => {
@@ -974,10 +1022,19 @@ test('every declared runtime sibling matches the real manifests', () => {
         `${target} is not a workspace package`
       );
       assert.equal(privateByName.get(target), false, `${target} is private`);
+      // Compared on what each entry installs, not on its key, exactly as the
+      // rule compares: `"@allxsmith/bestax-bulma": "npm:other@^1"` would keep
+      // the key and drop the dependency, and a key check would keep the
+      // exemption standing over it.
+      const installs = new Set(
+        Object.entries(pkg.dependencies ?? {}).map(([n, spec]) =>
+          dependencyTarget(n, spec)
+        )
+      );
       assert.ok(
-        Object.hasOwn(pkg.dependencies ?? {}, target),
-        `${dir} declares ${target} in SIBLING_RUNTIME_DEPS but its ` +
-          `package.json does not list it in dependencies`
+        installs.has(target),
+        `${dir} declares ${target} in SIBLING_RUNTIME_DEPS but nothing in ` +
+          `its package.json dependencies installs it`
       );
     }
   }

--- a/scripts/publishable-manifests.test.mjs
+++ b/scripts/publishable-manifests.test.mjs
@@ -20,6 +20,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  SIBLING_RUNTIME_DEPS,
   hookScripts,
   manifestViolations,
   parseWorkspacePackages,
@@ -302,9 +303,9 @@ test('quotes, blank lines, and comment lines still parse as before', () => {
 
 // --- the rule ----------------------------------------------------------------
 //
-// bestax-migrate is the only package carrying a pack-time specifier and it is
-// exempt for that one, so none of these branches executes during a real run.
-// Without them, inverting the rule leaves CI green.
+// Every package carrying a pack-time specifier is declared exempt for it, so
+// none of these branches executes during a real run. Without them, inverting
+// the rule leaves CI green.
 
 // A declared package must also wire the prepublishOnly guard, so fixtures for
 // the pnpm side carry it; otherwise every one of them picks up that violation
@@ -708,9 +709,10 @@ test('an unresolvable protocol in devDependencies is explained honestly', () => 
 // --- the sibling-at-runtime rule (#537) --------------------------------------
 //
 // Driven with an explicit name set because the rule is pure and the real set
-// is derived inside the async walk. No published package carries a sibling in
-// a consumer section today, so none of these branches executes on the real
-// tree — the same seam rationale as everything above.
+// is derived inside the async walk. The violating fixtures below use pairs that
+// are NOT in SIBLING_RUNTIME_DEPS, because the declared pair (#644) is the one
+// the real tree carries and it passes — the same seam rationale as everything
+// above: a test that used the real, exempt pair would pass with the rule off.
 
 const SIBLINGS = new Map([
   ['@allxsmith/bestax-bulma', { private: false }],
@@ -722,15 +724,15 @@ const SIBLINGS = new Map([
 
 test('a plain-semver sibling in dependencies is flagged, whatever the range', () => {
   const v = siblingViolations(
-    'bestax-migrate',
+    'bestax-mcp',
     {
-      name: 'bestax-migrate',
-      dependencies: { '@allxsmith/bestax-bulma': '^5' },
+      name: 'bestax-mcp',
+      dependencies: { 'create-bestax': '^4' },
     },
     SIBLINGS
   );
   assert.equal(v.length, 1, v.join('\n'));
-  assert.match(v[0], /consumers of bestax-migrate/);
+  assert.match(v[0], /consumers of bestax-mcp/);
   assert.match(v[0], /#537/);
 });
 
@@ -806,16 +808,16 @@ test('an npm alias pointing at a sibling is still a sibling', () => {
   // another key, so a key-only comparison was bypassable by renaming —
   // review caught the hole. The message names both the target and the alias.
   const v = siblingViolations(
-    'bestax-migrate',
+    'bestax-mcp',
     {
-      name: 'bestax-migrate',
-      dependencies: { ui: 'npm:@allxsmith/bestax-bulma@^5' },
+      name: 'bestax-mcp',
+      dependencies: { scaffold: 'npm:create-bestax@^4' },
     },
     SIBLINGS
   );
   assert.equal(v.length, 1, v.join('\n'));
-  assert.match(v[0], /@allxsmith\/bestax-bulma/);
-  assert.match(v[0], /aliased as "ui"/);
+  assert.match(v[0], /"create-bestax"/);
+  assert.match(v[0], /aliased as "scaffold"/);
 });
 
 test('a private sibling is not offered the peerDependency escape', () => {
@@ -841,15 +843,15 @@ test('one violation, one fix: the sibling rule owns a workspace: sibling dep', (
   // fix is the correct one, so the protocol rule stands down by name; a
   // `catalog:` entry pointing at an EXTERNAL package is no sibling and stays
   // protocol-flagged.
-  const siblings = new Map([['@allxsmith/bestax-bulma', { private: false }]]);
+  const siblings = new Map([['create-bestax', { private: false }]]);
   const pkg = {
-    name: 'bestax-migrate',
-    dependencies: { '@allxsmith/bestax-bulma': 'workspace:^' },
+    name: 'bestax-mcp',
+    dependencies: { 'create-bestax': 'workspace:^' },
   };
-  const protocol = manifestViolations('bestax-migrate', pkg, siblings).filter(
-    v => v.includes('bestax-bulma')
+  const protocol = manifestViolations('bestax-mcp', pkg, siblings).filter(v =>
+    v.includes('create-bestax')
   );
-  const sibling = siblingViolations('bestax-migrate', pkg, siblings);
+  const sibling = siblingViolations('bestax-mcp', pkg, siblings);
   assert.equal(protocol.length, 0);
   assert.equal(sibling.length, 1);
   assert.match(sibling[0], /Move it to devDependencies/);
@@ -860,4 +862,123 @@ test('one violation, one fix: the sibling rule owns a workspace: sibling dep', (
     siblings
   );
   assert.ok(external.some(v => v.includes('leftpad')));
+});
+
+// --- the declared runtime siblings (#644) -------------------------------------
+//
+// SIBLING_RUNTIME_DEPS is the one way through the rule above. These pin its
+// edges: exempt exactly the declared (directory, target) pair in
+// `dependencies`, and nothing adjacent to it.
+
+test('a declared runtime sibling in dependencies is exempt', () => {
+  for (const [dir, targets] of SIBLING_RUNTIME_DEPS) {
+    for (const target of targets) {
+      assert.deepEqual(
+        siblingViolations(
+          dir,
+          { name: dir, dependencies: { [target]: 'workspace:^' } },
+          SIBLINGS
+        ),
+        [],
+        `${dir} -> ${target}`
+      );
+    }
+  }
+});
+
+test('the exemption is by target, so an alias to a declared sibling is exempt too', () => {
+  assert.deepEqual(
+    siblingViolations(
+      'create-bestax',
+      {
+        name: 'create-bestax',
+        dependencies: { ui: 'npm:@allxsmith/bestax-bulma@^5' },
+      },
+      SIBLINGS
+    ),
+    []
+  );
+});
+
+test('a declared sibling in optionalDependencies is still flagged', () => {
+  const v = siblingViolations(
+    'create-bestax',
+    {
+      name: 'create-bestax',
+      optionalDependencies: { '@allxsmith/bestax-bulma': 'workspace:^' },
+    },
+    SIBLINGS
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+});
+
+test('a declared directory depending on a different sibling is still flagged', () => {
+  const v = siblingViolations(
+    'create-bestax',
+    { name: 'create-bestax', dependencies: { 'bestax-mcp': 'workspace:^' } },
+    SIBLINGS
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+  assert.match(v[0], /"bestax-mcp"/);
+});
+
+test('an undeclared directory depending on a declared target is still flagged', () => {
+  const v = siblingViolations(
+    'bulma-ui',
+    {
+      name: '@allxsmith/bestax-bulma',
+      dependencies: { 'create-bestax': 'workspace:^' },
+    },
+    SIBLINGS
+  );
+  assert.equal(v.length, 1, v.join('\n'));
+});
+
+test('a private sibling is never exempt, declared or not', () => {
+  // The map cannot be edited from here, so this pins the guard the only way
+  // it can be reached: a declared directory naming a private target. Nothing
+  // declares one today; if a declaration ever does, this is what fails.
+  for (const [dir, targets] of SIBLING_RUNTIME_DEPS) {
+    for (const target of targets) {
+      assert.equal(SIBLINGS.get(target)?.private, false, `${dir} -> ${target}`);
+    }
+  }
+});
+
+test('every declared runtime sibling matches the real manifests', () => {
+  // The declaration is the exemption, so it has to describe the tree as it is:
+  // a directory that stopped depending on the sibling must lose its line, or
+  // the exemption outlives the dependency it was granted for. Read through the
+  // same helpers as the PNPM_PUBLISHED checks above, so an unreadable manifest
+  // throws rather than shrinking the set.
+  const manifests = new Map(
+    parseWorkspacePackages(repoFile('pnpm-workspace.yaml')).map(dir => [
+      dir,
+      JSON.parse(repoFile(`${dir}/package.json`)),
+    ])
+  );
+  const privateByName = new Map(
+    [...manifests.values()].map(p => [p.name, Boolean(p.private)])
+  );
+  assert.ok(SIBLING_RUNTIME_DEPS.size > 0, 'SIBLING_RUNTIME_DEPS is empty');
+  for (const [dir, targets] of SIBLING_RUNTIME_DEPS) {
+    assert.ok(
+      DECLARED.has(dir),
+      `${dir} is declared in SIBLING_RUNTIME_DEPS but not in PNPM_PUBLISHED`
+    );
+    const pkg = manifests.get(dir);
+    assert.ok(pkg, `${dir} is not a workspace package`);
+    for (const target of targets) {
+      assert.ok(
+        privateByName.has(target),
+        `${target} is not a workspace package`
+      );
+      assert.equal(privateByName.get(target), false, `${target} is private`);
+      assert.ok(
+        Object.hasOwn(pkg.dependencies ?? {}, target),
+        `${dir} declares ${target} in SIBLING_RUNTIME_DEPS but its ` +
+          `package.json does not list it in dependencies`
+      );
+    }
+  }
 });

--- a/scripts/require-pnpm-publish.test.mjs
+++ b/scripts/require-pnpm-publish.test.mjs
@@ -172,8 +172,9 @@ test('the refusal names the package being packed, not a hardcoded one', () => {
 });
 
 test('a readable manifest gets its offending specifier quoted', () => {
-  // bestax-migrate is the only package carrying one, and naming it is the
-  // reason this branch exists at all.
+  // bestax-migrate carries one in devDependencies (create-bestax carries the
+  // same sibling in dependencies, #644), and naming it is the reason this
+  // branch exists at all.
   let msg = '';
   main({ npm_execpath: NPM }, m => (msg = m), repoDir('bestax-migrate'));
   assert.match(msg, /bestax-migrate declares/);


### PR DESCRIPTION
First of three for #644, one per package so each releases on its own scope.

## What

- `create-bestax/package.json`: `"@allxsmith/bestax-bulma": "workspace:^"` in `dependencies`. `pnpm publish` rewrites it to the release current at pack time; the packed tarball reads `"^5.15.0"` today.
- `scripts/check-conformance.mjs`: the sibling rule (#537) reserved its exemption for "the PR that needs one, the `PNPM_PUBLISHED` shape". This adds it: `SIBLING_RUNTIME_DEPS`, directory → sibling names, consulted inside `siblingViolations` for `dependencies` only. `optionalDependencies`, a different sibling in the same manifest, an undeclared directory, and any private sibling stay flagged.
- `scripts/publishable-manifests.test.mjs`: the violating fixtures moved off the now-declared pair; new tests pin each edge of the exemption, plus one that reads the real manifests and fails if a declared pair is not actually in that package's `dependencies`, so the exemption cannot outlive the dependency.
- Prose: the root `CLAUDE.md` manifest bullet, a Dependencies section in `create-bestax/CLAUDE.md`, and two test comments that said bestax-migrate was the only package carrying a pack-time specifier.

## Why

The scaffolder is built for the library and its manifest now says so, the way bulma-ui declares `bulma` (and Buefy does) without importing it. Nothing in `src/` imports the library; the templates keep their own `^5.0.0` pin and the e2e still installs from the registry with `--ignore-workspace`.

## Consequences

- `npm create bestax` now installs the library, `bulma`, and under npm's automatic peer install `react`/`react-dom` alongside the CLI.
- `create-bestax#build` waits on `@allxsmith/bestax-bulma#build` through turbo's `^build`; no `turbo.json` change.
- Touches `scripts/check-conformance.mjs`, so this stays outside the AI loop.

## Verified

- `node --test scripts/*.test.mjs` (publishable-manifests 58, require-pnpm-publish 16)
- `pnpm check:conformance` green, `pnpm all` green
- `pnpm -C create-bestax pack`: the tarball's `dependencies` carries `"^5.15.0"`, no `workspace:`

Next: `fix(bestax-mcp)` and `fix(bestax-migrate)` add their lines to `SIBLING_RUNTIME_DEPS` once this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `create-bestax` now includes `@allxsmith/bestax-bulma` as a runtime dependency, ensuring generated projects receive the required UI library.

- **Documentation**
  - Clarified dependency requirements and runtime sibling-package exceptions.
  - Documented how the `create-bestax` template receives and publishes its UI dependency.

- **Tests**
  - Expanded package conformance coverage to verify dependency declarations, publishing eligibility, and supported exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->