### PR TITLE
ci: make prose findings advisory and scope the residual-risk hunt

### DIFF
--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -607,17 +607,18 @@ jobs:
               before refuting one; refute only if the file contradicts
               the reviewer. This does not extend to workflow comments,
               guide prose, or the PR body.
-            - Findings about workflow COMMENTS, guide prose under
-              docs/docs/guides, or a CLAUDE.md (component API pages stay
-              under the house-style rule above): act only if the text is
-              FALSE about something a reader will act on: who can trigger
-              a job or what a credentialed job can do, what a public
-              component, prop, or command does, or an example that does
-              not work as written. Fix by deleting or correcting the false
-              clause — never by adding qualifiers, counts, run ids, or
-              dates. Otherwise refute in one line ("Imprecise, not false;
-              leaving it.") and push nothing. You cannot edit the PR
-              body; a finding about it is the human's.
+            - Findings about guide prose under docs/docs/guides or a
+              CLAUDE.md outside .github (component API pages stay under
+              the house-style rule above): act only if the text is FALSE
+              about something a reader will act on: who can trigger a job
+              or what a credentialed job can do, what a public component,
+              prop, or command does, or an example that does not work as
+              written. Fix by deleting or correcting the false clause —
+              never by adding qualifiers, counts, run ids, or dates.
+              Otherwise refute in one line ("Imprecise, not false; leaving
+              it.") and push nothing. You cannot edit the PR body or
+              anything under .github; a finding about either is the
+              human's, so say so in one line and leave it.
             Only implement findings that are genuine, in-scope defects or
             small, clearly-correct improvements.
 

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -608,11 +608,13 @@ jobs:
               the reviewer. This does not extend to workflow comments,
               guide prose, or the PR body.
             - Findings about COMMENTS, docs prose, or the PR body: act only
-              if the text is FALSE about who can trigger a job or what a
-              credentialed job can do. Fix by deleting the overstated
-              clause — never by adding sentences, qualifiers, counts, run
-              ids, or dates. Otherwise refute in one line ("Imprecise,
-              not false; leaving it.") and push nothing for it.
+              if the text is FALSE about something a reader will act on:
+              who can trigger a job or what a credentialed job can do,
+              what a public component, prop, or command does, or an
+              example that does not work as written. Fix by deleting or
+              correcting the false clause — never by adding qualifiers,
+              counts, run ids, or dates. Otherwise refute in one line
+              ("Imprecise, not false; leaving it.") and push nothing.
             Only implement findings that are genuine, in-scope defects or
             small, clearly-correct improvements.
 

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -600,12 +600,19 @@ jobs:
               a fine end state: the loop escalates contested findings to a
               human (needs-human-review). Do NOT thrash trying to satisfy an
               out-of-scope or over-large ask — that wastes the whole budget.
-            - House-style findings (docs page sections, story argType
-              descriptions, inline styles, SCSS variable registration,
-              missing listing surfaces) are usually valid — check
-              /CONTRIBUTING-COMPONENTS.md and the folder CLAUDE.md before
-              refuting one; refute only if the file contradicts the
-              reviewer.
+            - House-style findings on COMPONENT files (docs page sections,
+              story argType descriptions, inline styles, SCSS variable
+              registration, missing listing surfaces) are usually valid —
+              check /CONTRIBUTING-COMPONENTS.md and the folder CLAUDE.md
+              before refuting one; refute only if the file contradicts
+              the reviewer. This does not extend to workflow comments,
+              guide prose, or the PR body.
+            - Findings about COMMENTS, docs prose, or the PR body: act only
+              if the text is FALSE about who can trigger a job or what a
+              credentialed job can do. Fix by deleting the overstated
+              clause — never by adding sentences, qualifiers, counts, run
+              ids, or dates. Otherwise refute in one line ("Imprecise,
+              not false; leaving it.") and push nothing for it.
             Only implement findings that are genuine, in-scope defects or
             small, clearly-correct improvements.
 
@@ -657,7 +664,8 @@ jobs:
                WHY, or why you disagree, and cite the specific file/code. No
                bare markers, no terse one-liners — be concrete and
                conversational (e.g. "I reordered the spread so the observer ref
-               can't be clobbered — `...rest` now comes before `ref`.").
+               can't be clobbered — `...rest` now comes before `ref`."). The
+               one-line prose refutation above is the deliberate exception.
             3. Thread bookkeeping — keep these EXACT rules even while writing
                conversationally; they drive the loop's state machine:
                - Claude-review threads (first author claude): when you fix one,

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -607,14 +607,17 @@ jobs:
               before refuting one; refute only if the file contradicts
               the reviewer. This does not extend to workflow comments,
               guide prose, or the PR body.
-            - Findings about COMMENTS, docs prose, or the PR body: act only
-              if the text is FALSE about something a reader will act on:
-              who can trigger a job or what a credentialed job can do,
-              what a public component, prop, or command does, or an
-              example that does not work as written. Fix by deleting or
-              correcting the false clause — never by adding qualifiers,
-              counts, run ids, or dates. Otherwise refute in one line
-              ("Imprecise, not false; leaving it.") and push nothing.
+            - Findings about workflow COMMENTS, guide prose under
+              docs/docs/guides, or a CLAUDE.md (component API pages stay
+              under the house-style rule above): act only if the text is
+              FALSE about something a reader will act on: who can trigger
+              a job or what a credentialed job can do, what a public
+              component, prop, or command does, or an example that does
+              not work as written. Fix by deleting or correcting the false
+              clause — never by adding qualifiers, counts, run ids, or
+              dates. Otherwise refute in one line ("Imprecise, not false;
+              leaving it.") and push nothing. You cannot edit the PR
+              body; a finding about it is the human's.
             Only implement findings that are genuine, in-scope defects or
             small, clearly-correct improvements.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -483,9 +483,11 @@ jobs:
                 exist; a job said unable to do what it can), or what a
                 public component, prop, or command does, or an example
                 that does not work as written. Imprecise is not false. A
-                missing qualifier, a stale count, "every" where the
-                mechanism is "most", or a restated third-party internal
-                is Advisory, and one row covers all of them.
+                missing qualifier, a stale count, or a restated
+                third-party internal is Advisory, and one row covers all
+                of them. A false claim in the PR body is a row in the
+                summary addressed to the maintainer, never inline: neither
+                this review nor the fix agent can edit the PR body.
                 When you suggest a wording change, fix by DELETION: name
                 the clause to remove so the remainder is true. Never
                 suggest adding a sentence, a qualifier, a number, a run
@@ -501,7 +503,9 @@ jobs:
                 "<!-- claude-deep-review -->" marker) and the PR's
                 reviewThreads through the GraphQL API, with each thread's
                 isResolved flag and comment authors and bodies.
-                Do not re-open a resolved thread. Do not reverse a
+                Do not re-open a resolved thread whose defect is absent
+                from the current code; a defect a later commit brought
+                back is a new finding at the normal bar. Do not reverse a
                 wording suggestion of yours the author has applied unless
                 the result is FALSE by 6a's test; a code suggestion of
                 yours that turned out to introduce a defect is a finding

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -421,10 +421,14 @@ jobs:
                against the real failing inputs. Reading the diff is not
                verification.
             3. RESIDUAL-RISK HUNT — for the failure class this PR
-               addresses, enumerate the ways it could still occur: adjacent
-               code paths, unhandled variants, boundary counts, the same bug
-               shape elsewhere in the changed subsystem. Refute each with
-               evidence, or post it as a finding.
+               addresses, enumerate the ways it could still occur in the
+               EXECUTABLE paths the diff touches (workflow logic, shell,
+               jq, source, tests): adjacent code paths, unhandled
+               variants, boundary counts. Refute each with evidence, or
+               post it as a finding — at most 3 residual-risk findings
+               per review; the rest go in the summary's Residual risk
+               bullets. Comments, docs, and the PR body are never a
+               residual risk.
             4. Verify every candidate finding against the actual code
                before posting it. Apply the lens that matches what the diff
                touches (both lenses when it touches both):
@@ -455,8 +459,9 @@ jobs:
                    nothing, swallowed errors, dead conditions
                  - idempotency/concurrency of workflows: double-fires,
                    races, re-runs, partial state
-            5. Do NOT post nitpicks, style, or formatting comments —
-               CodeRabbit and the linters cover those.
+            5. Do NOT post nitpicks, style, formatting, or wording
+               comments — CodeRabbit and the linters cover the first
+               three, and wording is governed by rule 6a.
 
             FORMAT — your output is read by BOTH the fix agent (which needs
             precise, actionable detail) and a human maintainer (who wants it
@@ -469,6 +474,35 @@ jobs:
                inflate them into blockers either. Category is Correctness /
                Accessibility / API / Coverage / SSR / Performance /
                Security / Robustness.
+            6a. PROSE IS ADVISORY BY DEFAULT. A finding whose subject is a
+                comment, a docs page, a CLAUDE.md, or the PR body is 🔵
+                Advisory — a summary row, never inline — UNLESS the text
+                is FALSE about who can trigger a job or what a
+                credentialed job can do: it names the wrong actor, role,
+                token, or trigger, or claims a control that does not
+                exist, or says a job cannot do something it can. Imprecise
+                is not false. A missing qualifier, a stale count, "every"
+                where the mechanism is "most", or a restated third-party
+                internal is Advisory, and one row covers all of them.
+                When you suggest a wording change, fix by DELETION: name
+                the clause to remove so the remainder is true. Never
+                suggest adding a sentence, a qualifier, a number, a run
+                id, or a date. The writing rules in .github/CLAUDE.md
+                ("How to be exact") and docs/CLAUDE.md define "exact".
+            6b. Never ask for statistics, run ids, tallies, or dated
+                observations in docs or comments. If the diff adds any,
+                post ONE 🔵 row for the lot: "point-in-time evidence —
+                move to the issue and link it."
+            6c. If LAST REVIEWED SHA is set, read your prior reviews and
+                the resolved threads BEFORE forming findings:
+                  gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews
+                  (bodies containing "<!-- claude-deep-review -->")
+                  gh api graphql — reviewThreads{isResolved, comments
+                  {author, body}} on the PR
+                Do not re-open a resolved thread, and do not reverse a
+                suggestion of yours the author has applied, unless the
+                result is FALSE by 6a's test. If you would reverse
+                yourself, say so in the summary's Overall line instead.
             7. Post each BLOCKING defect (🔴/🟠/🟡) as an inline comment
                with mcp__github_inline_comment__create_inline_comment
                (confirmed: true). NEVER post a 🔵 Advisory as an inline

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -487,8 +487,8 @@ jobs:
                 When you suggest a wording change, fix by DELETION: name
                 the clause to remove so the remainder is true. Never
                 suggest adding a sentence, a qualifier, a number, a run
-                id, or a date. The writing rules in .github/CLAUDE.md
-                ("How to be exact") and docs/CLAUDE.md define "exact".
+                id, or a date. Exact means the sentence claims no more
+                than the mechanism delivers; less is fine.
             6b. Never ask for statistics, run ids, tallies, or dated
                 observations in docs or comments. If the diff adds any,
                 post ONE 🔵 row for the lot: "point-in-time evidence —
@@ -499,10 +499,11 @@ jobs:
                 "<!-- claude-deep-review -->" marker) and the PR's
                 reviewThreads through the GraphQL API, with each thread's
                 isResolved flag and comment authors and bodies.
-                Do not re-open a resolved thread, and do not reverse a
-                suggestion of yours the author has applied, unless the
-                result is FALSE by 6a's test. If you would reverse
-                yourself, say so in the summary's Overall line instead.
+                Do not re-open a resolved thread. Do not reverse a
+                wording suggestion of yours the author has applied unless
+                the result is FALSE by 6a's test; a code suggestion of
+                yours that turned out to introduce a defect is a finding
+                at the normal bar, and say in it that it reverses you.
             7. Post each BLOCKING defect (🔴/🟠/🟡) as an inline comment
                with mcp__github_inline_comment__create_inline_comment
                (confirmed: true). NEVER post a 🔵 Advisory as an inline
@@ -539,9 +540,11 @@ jobs:
                  **Overall:** <2-3 sentences — is the change sound, what is the
                  riskiest part, and what should the human focus on first.>
 
-                 **Residual risk:** <1-3 bullets — the ways the addressed
-                 failure class could still occur, each refuted with the
-                 evidence you checked, or "none identified" with why.>
+                 **Residual risk:** <bullets — the ways the addressed
+                 failure class could still occur: each refuted with the
+                 evidence you checked, or, beyond the three you posted as
+                 findings, named here as open; or "none identified" with
+                 why.>
 
                  > 🏄 <one or two sentences in the voice of a laid-back
                  > California surfer summing up the vibe of this PR — fun, but

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -488,11 +488,12 @@ jobs:
                 of them. A false claim in the PR body is a row in the
                 summary addressed to the maintainer, never inline: neither
                 this review nor the fix agent can edit the PR body.
-                When you suggest a wording change, fix by DELETION: name
-                the clause to remove so the remainder is true. Never
-                suggest adding a sentence, a qualifier, a number, a run
-                id, or a date. Exact means the sentence claims no more
-                than the mechanism delivers; less is fine.
+                When you suggest a wording change, prefer DELETION: name
+                the clause to remove so the remainder is true, or the one
+                correction that makes a false clause true. Never suggest
+                adding a sentence, a qualifier, a number, a run id, or a
+                date. Exact means the sentence claims no more than the
+                mechanism delivers; less is fine.
             6b. Never ask for statistics, run ids, tallies, or dated
                 observations in docs or comments. If the diff adds any,
                 post ONE 🔵 row for the lot: "point-in-time evidence —

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -477,13 +477,15 @@ jobs:
             6a. PROSE IS ADVISORY BY DEFAULT. A finding whose subject is a
                 comment, a docs page, a CLAUDE.md, or the PR body is 🔵
                 Advisory — a summary row, never inline — UNLESS the text
-                is FALSE about who can trigger a job or what a
-                credentialed job can do: it names the wrong actor, role,
-                token, or trigger, or claims a control that does not
-                exist, or says a job cannot do something it can. Imprecise
-                is not false. A missing qualifier, a stale count, "every"
-                where the mechanism is "most", or a restated third-party
-                internal is Advisory, and one row covers all of them.
+                is FALSE about something a reader will act on: who can
+                trigger a job or what a credentialed job can do (the wrong
+                actor, role, token, or trigger; a control that does not
+                exist; a job said unable to do what it can), or what a
+                public component, prop, or command does, or an example
+                that does not work as written. Imprecise is not false. A
+                missing qualifier, a stale count, "every" where the
+                mechanism is "most", or a restated third-party internal
+                is Advisory, and one row covers all of them.
                 When you suggest a wording change, fix by DELETION: name
                 the clause to remove so the remainder is true. Never
                 suggest adding a sentence, a qualifier, a number, a run

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -494,11 +494,11 @@ jobs:
                 post ONE 🔵 row for the lot: "point-in-time evidence —
                 move to the issue and link it."
             6c. If LAST REVIEWED SHA is set, read your prior reviews and
-                the resolved threads BEFORE forming findings:
-                  gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews
-                  (bodies containing "<!-- claude-deep-review -->")
-                  gh api graphql — reviewThreads{isResolved, comments
-                  {author, body}} on the PR
+                the resolved threads BEFORE forming findings: the reviews
+                API for this PR (your reviews carry the
+                "<!-- claude-deep-review -->" marker) and the PR's
+                reviewThreads through the GraphQL API, with each thread's
+                isResolved flag and comment authors and bodies.
                 Do not re-open a resolved thread, and do not reverse a
                 suggestion of yours the author has applied, unless the
                 result is FALSE by 6a's test. If you would reverse


### PR DESCRIPTION
Refs #643.

## What changed

Prompt text only, in two workflows. No allowlist, permission, SHA, or job change.

**`claude-review.yml`**

- Rule 3, the residual-risk hunt, is scoped to the executable paths the diff touches and capped at three posted findings; the rest go in the summary's residual-risk bullets. Comments, docs, and the PR body are never a residual risk.
- Rule 5 adds wording to the list of things the reviewer does not post about.
- New rule 6a: a finding about a comment, a docs page, a CLAUDE.md, or the PR body is Advisory unless the text is false about who can trigger a job or what a credentialed job can do. Imprecise is not false. A wording suggestion names the clause to delete and never asks for an added sentence, qualifier, number, run id, or date.
- New rule 6b: the reviewer never asks for statistics or dated observations in docs, and flags any the diff adds as one Advisory row.
- New rule 6c: when `LAST REVIEWED SHA` is set, read prior reviews and resolved threads first, and do not reverse an applied suggestion unless the result is false by 6a's test. The header value arrives in a follow-up that turns a relabel into a verify pass; until then the rule is inert.

**`claude-pr-loop.yml`** fix prompt

- The "house-style findings are usually valid" steer is scoped to component files.
- Findings about comments, guide prose, or the PR body are acted on only when the text is false by the same test, fixed by deletion, and otherwise refuted in one line.

## Why

On #643, 21 of 28 review threads targeted prose, 9 were one place in the PR contradicting another, and 6 chains reversed the reviewer's own earlier suggestion. Every fix added text, and every added clause was the next round's target. The severity scale and the uncapped hunt are what made a wording objection cost a full round; this PR changes only that.

## What to check

- `pnpm format:check` and `pnpm check:conformance` pass locally.
- The repo-wide pin grep in `.github/CLAUDE.md` rule 1 prints one SHA.
- This PR modifies `claude-review.yml`, so the deep review skips it silently; CodeRabbit and Copilot are the reviewers here.

The writing rules the new 6a cites (`.github/CLAUDE.md` "How to be exact", `docs/CLAUDE.md`) land in the docs PR that follows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automated reviews now focus factual accuracy checks on relevant code and documentation, excluding workflow files and pull request text.
  * Reviews better assess workflow triggers, credentialed actions, public components, props, commands, and non-working examples.
  * Incorrect prose can be corrected or clearly refuted without unnecessary code changes.
  * Review guidance better distinguishes wording issues from code changes that introduce defects.
  * Residual-risk analysis now prioritizes touched executable paths, with additional risks included in the final summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->