### PR TITLE
docs: one home per fact, writing rules, and the Copilot section cleanup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,6 +48,12 @@ reviews:
       instructions: >
         Docusaurus documentation site. Check MDX/Markdown correctness, working
         internal links, and that documented APIs match the library.
+    - path: '.github/**'
+      instructions: >
+        Workflow comments and .github/CLAUDE.md are reviewed for false claims
+        about triggers, actors, or credentials only. Do not request added
+        qualifiers, counts, run ids, or dates; suggest deleting an overstated
+        clause instead.
     - path: '**/*.{ts,tsx}'
       instructions: >
         Follow the repo ESLint + Prettier config (Prettier 3.9.4). Prefer

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -618,6 +618,33 @@ reviewers never see it, a session called "read-only" when its token was write-sc
 encoding check described as a proof when it is a backstop. A comment that overstates its control
 is worse than no comment, because the next reader stops checking.
 
+### How to be exact: claim less
+
+Exact means claiming less, not explaining more. The way to make a security comment true is to
+delete the clause that overstates it, not to add the qualifiers that would make it true.
+
+- A security comment names the control and, when the control is a third party's, cites where
+  it lives, in one line: `# matched against the run actor by check-human-actor in
+anthropics/claude-code-action at the pinned SHA`. Do not restate the third party's
+  internals; they change under the pin and the restatement rots.
+- A count lives in a command, never in a sentence. Write the grep that produces it (rule 10's
+  `egress-policy: block` grep is the model). A hand-maintained number is wrong within months,
+  and this file has proven that three times.
+- Evidence (run ids, dates, tallies) goes on the issue and is linked. A comment says what the
+  mechanism is; the issue says how we know.
+- One home per fact. A mechanism is explained once, where it is configured; every other
+  mention is a pointer (`# same list as fix; rationale there`). Two copies are two things to
+  keep equal, and a reviewer will find the day they differ.
+- Claim the case in front of you. "Every", "only", "always" and "exactly one" are one
+  counterexample from false; "the review arm" survives, "every arm" does not.
+- Never cite a line number in prose. Lines move on the next edit; a step `id`, a job name, a
+  rule number, or a heading does not.
+- A PR body says what changed and why. State an invariant as the command that checks it
+  (`grep -c` the pin), not as today's count of what it found.
+
+The `fragile-prose` conformance check enforces the count, run-id, and line-reference rules;
+mark a deliberate exception with `bestax:count-ok` on the same line and say why.
+
 ## Where the rest is documented
 
 - **Design and operation of the AI loop, and the repository-variable table** — the

--- a/.github/workflows/claude-pr-loop.yml
+++ b/.github/workflows/claude-pr-loop.yml
@@ -2,12 +2,9 @@ name: Claude PR Loop
 
 # Review → fix → verify → converge loop for AI-authored PRs (label: ai-loop)
 # ONLY. Triggered by CodeRabbit reviews, CI completions on claude/* branches,
-# or manual dispatch; Copilot reviews are eligible too, but every run one has
-# started so far died before creating a job, jobs have appeared only when a
-# maintainer re-ran it, and since 2026-09-06 its reviews have created no run
-# at all (the ai-development guide has the data). The `gate` job is cheap
-# shell that re-derives the PR's live state and picks a mode — Claude usage
-# is spent only in fix/verify.
+# or manual dispatch; Copilot reviews are eligible too (#612). The `gate` job
+# is cheap shell that re-derives the PR's live state and picks a mode —
+# Claude usage is spent only in fix/verify.
 #
 # Modes:
 #   fix-ci      CI is red on the head → Claude fixes the root cause, pushes.
@@ -513,37 +510,17 @@ jobs:
           bot_id: '300268469'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Trigger actors are bots by design: coderabbitai[bot] and Copilot
-          # (reviews), claude[bot] (CI workflow_run after its own pushes), and
-          # github-actions[bot] (the loop's self-dispatch continuation). The
-          # action matches this list against the RUN's actor by exact
-          # normalised login, and fix/verify run in the gate's own run, so a
-          # login the gate triggers on but this list omits fails the session's
-          # human-actor check: a red run rather than a wait (#612). The
-          # action's write-permission check is a second, narrower consumer:
-          # it runs only in PR and issue contexts (here, the review arm) and
-          # returns true for any `[bot]`-suffixed actor before reading this
-          # list, so it reaches the list only for `Copilot`, which has no
-          # suffix. On workflow_run, dispatch and schedule only the
-          # human-actor check consults it.
-          #
-          # `copilot` is the Copilot reviewer app (id 175728472), which
-          # renders as `Copilot` to Actions (the run actor, verified across
-          # every pull_request_review run this repo has had from it) and as
-          # `copilot-pull-request-reviewer[bot]` in the event payload, which
-          # is what the gate's `if:` matches; each list carries only the
-          # spelling it is compared against. Matching here is by normalised
-          # login, not by id: GitHub's other Copilot app,
-          # copilot-swe-agent[bot] (id 198982749), also renders as `Copilot`,
-          # so this entry admits either. What confines it is the gate, not
-          # the precision of this string, and each arm holds different parts
-          # of it: the review and workflow_run arms of the `if:` carry the
-          # same-repo and claude/* head tests, the workflow_dispatch arm
-          # carries neither and relies on GitHub only letting write-access
-          # actors dispatch (see the note under the `if:`), and the ai-loop
-          # label, PR-open and protected-path tests are re-derived in the
-          # gate job's shell on every arm while the two head tests are not.
-          # A CI completion with Copilot as the actor, on a claude/* head,
-          # therefore still passes all of them before fix runs.
+          # (reviews), claude[bot] (CI workflow_run after its own pushes),
+          # github-actions[bot] (the loop's self-dispatch). The action matches
+          # this list against the RUN's actor by normalised login (its
+          # human-actor check; the write-permission check reads it only in
+          # PR/issue contexts for actors without a `[bot]` suffix). `copilot`
+          # is the reviewer app's actor spelling; the payload spelling
+          # `copilot-pull-request-reviewer[bot]` is what the gate's `if:`
+          # matches. copilot-swe-agent[bot] renders the same, so the gate's
+          # same-repo and claude/* head tests are the confinement, not this
+          # string. Source: check-human-actor and check-write-permissions in
+          # anthropics/claude-code-action at the pinned SHA. Evidence: #612.
           allowed_bots: 'coderabbitai,claude,github-actions,copilot'
           use_commit_signing: true
           # Stream the full turn-by-turn (tool calls + permission denials) into
@@ -920,6 +897,7 @@ jobs:
         uses: anthropics/claude-code-action@51c47629174b5dbca955cf93690fd39c8a41dadf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Same list as fix; the rationale is on fix's entry.
           allowed_bots: 'coderabbitai,claude,github-actions,copilot'
           # Stream tool calls + denials to the log (blob-hosted artifact is
           # blocked by the proxy) so a rebuttal pass is diagnosable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,6 +321,11 @@ The short version for contributors:
   `ai-loop` and iterates with the AI reviewers until it converges, then a human reviews and
   squash-merges. Don't add or remove the loop labels (`ai-loop`, `needs-human-review`,
   `ai-loop-paused`) on PRs you don't own — they are the loop's state machine.
+- **Hand-driven PRs that want a deep review**: apply `deep-review` once at open, fix everything
+  it raised, then re-apply it once. The re-run verifies its own threads and reviews only the
+  commits since its last review; CodeRabbit re-reviews every push by itself, so let it go last.
+  Do not relabel per push: each application spends a full opus session, and relabeling after
+  every fix is what turned #643 into 14 review rounds.
 - **PR titles must be scoped conventional commits** — the title becomes the squash commit and
   drives semantic-release (see [Commit Message Guidelines](#commit-message-guidelines)).
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -114,6 +114,16 @@ it, so a novel non-standard `package.json` key and extra release churn weren't w
   `docusaurus.config.js` does not override it. That is load-bearing but easy to miss: setting
   `format: 'detect'` would make every `.md` page render its tags as literal text.
 - Markdown is prettier-formatted (`pnpm format:check` covers `md`/`mdx`).
+- **Guides are canonical reference, not lab notebooks.** No run statistics, run ids, dated
+  observations or "as of" tallies in `docs/docs/**`: the LLM index serves it as current fact,
+  and a count is stale the day after it is written. Dated snapshots belong in `blog/`, which
+  is excluded from the index (see `blog/CLAUDE.md`). Evidence goes on the issue or PR and the
+  guide links it. A claim that needs a number to be true belongs in a test or a generator, not
+  a sentence. A guide section says what the operator can do and what each switch is compared
+  against; it does not re-derive a third party's internals. Claim the case in front of you:
+  "every" and "only" are one counterexample from false. Never cite a line number; cite a
+  heading, a step id, or a flag. `check:conformance --only=fragile-prose` enforces the count,
+  run-id, and line-reference parts.
 - Scripts in `docs/scripts/` are covered by the root `pnpm lint` — run it before pushing even
   a docs-only PR (#471 broke CI on exactly this). Playwright `page.evaluate` callbacks
   execute in the browser, so declare the browser globals each callback actually uses

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -47,19 +47,19 @@ the review-time requirements (Storybook story for UI changes, docs page for API 
 
 PRs authored by the loop move through a small label lifecycle:
 
-| Label                   | Where        | Meaning                                                                                                                                                                                                                                                        |
-| ----------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `claude-fix`            | issues       | Maintainer-approved: Claude implements this issue and opens a PR                                                                                                                                                                                               |
-| `ai-loop`               | PRs          | The PR is inside the autonomous review/fix loop                                                                                                                                                                                                                |
-| `needs-human-review`    | PRs          | The loop converged (or hit a disagreement) — awaiting maintainer review/merge                                                                                                                                                                                  |
-| `ai-loop-paused`        | PRs          | The loop hit its iteration cap or a guardrail — a maintainer must intervene                                                                                                                                                                                    |
-| `deep-review`           | PRs          | Opt-in: a triage+ user applies it to run the Claude deep review on any PR (re-apply to re-run). Optionally steer it by pre-posting a PR comment starting with `deep-review:` (focus areas, suspected weak spots) — only comments from triage+ authors are used |
-| `ai-triage`             | PRs & issues | Runs one-shot AI triage (related issues + duplicates): automatic on new issues/PRs in auto mode (daily budget), or applied by a triage+ user (budget-exempt; label auto-removes)                                                                               |
-| `claude-repro`          | issues       | Triage+ user applies it: Claude drafts a candidate reproduction test and github-actions[bot] posts it for a human to run (author-only — CI does not run it). Auto-removes                                                                                      |
-| `needs-security-review` | PRs & issues | Auto-applied by the security scanner when it flags an item; blocks every entry point this repo controls — `claude-repro`, `claude-fix`, `@claude`, `@bestaxbot` — until a maintainer removes it (third-party reviewers are not gated)                          |
-| `claude-assisted`       | PRs          | Auto-applied provenance for AI-assisted PRs (bestaxbot or the Claude footer)                                                                                                                                                                                   |
-| `stale`                 | PRs          | Auto-applied after 30 days of inactivity; closes 14 days later unless activity resumes. Claude-assisted PRs skip this sweep — a separate closer sweeps them after 90 days instead                                                                              |
-| `neverstale`            | PRs          | Exempts a PR from all stale automation (both the 30/14-day sweep and the 90-day Claude-assisted closer)                                                                                                                                                        |
+| Label                   | Where        | Meaning                                                                                                                                                                                                                                                                                                                                                              |
+| ----------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude-fix`            | issues       | Maintainer-approved: Claude implements this issue and opens a PR                                                                                                                                                                                                                                                                                                     |
+| `ai-loop`               | PRs          | The PR is inside the autonomous review/fix loop                                                                                                                                                                                                                                                                                                                      |
+| `needs-human-review`    | PRs          | The loop converged (or hit a disagreement) — awaiting maintainer review/merge                                                                                                                                                                                                                                                                                        |
+| `ai-loop-paused`        | PRs          | The loop hit its iteration cap or a guardrail — a maintainer must intervene                                                                                                                                                                                                                                                                                          |
+| `deep-review`           | PRs          | Opt-in: a triage+ user applies it to run the Claude deep review on any PR (re-apply once, after fixes, for a verify pass over the delta; a steer starting `deep-review: fresh` forces a full review). Optionally steer it by pre-posting a PR comment starting with `deep-review:` (focus areas, suspected weak spots) — only comments from triage+ authors are used |
+| `ai-triage`             | PRs & issues | Runs one-shot AI triage (related issues + duplicates): automatic on new issues/PRs in auto mode (daily budget), or applied by a triage+ user (budget-exempt; label auto-removes)                                                                                                                                                                                     |
+| `claude-repro`          | issues       | Triage+ user applies it: Claude drafts a candidate reproduction test and github-actions[bot] posts it for a human to run (author-only — CI does not run it). Auto-removes                                                                                                                                                                                            |
+| `needs-security-review` | PRs & issues | Auto-applied by the security scanner when it flags an item; blocks every entry point this repo controls — `claude-repro`, `claude-fix`, `@claude`, `@bestaxbot` — until a maintainer removes it (third-party reviewers are not gated)                                                                                                                                |
+| `claude-assisted`       | PRs          | Auto-applied provenance for AI-assisted PRs (bestaxbot or the Claude footer)                                                                                                                                                                                                                                                                                         |
+| `stale`                 | PRs          | Auto-applied after 30 days of inactivity; closes 14 days later unless activity resumes. Claude-assisted PRs skip this sweep — a separate closer sweeps them after 90 days instead                                                                                                                                                                                    |
+| `neverstale`            | PRs          | Exempts a PR from all stale automation (both the 30/14-day sweep and the 90-day Claude-assisted closer)                                                                                                                                                                                                                                                              |
 
 ### AI triage
 
@@ -213,84 +213,23 @@ separate store and none are documented here.
 | `AI_SCAN_DAILY_LIMIT`   | `20`                  | integer                | Auto scans per UTC day                                                                                                                     |
 | `AI_LOOP_COPILOT`       | `false`               | must be exactly `true` | Requests a Copilot review on loop PRs (Copilot's own automatic review skips bot-authored PRs on personal repos, so it has to be asked for) |
 
-The gate job's `if:` names Copilot alongside CodeRabbit: a submitted review from either is
-**eligible** to fire the gate on an `ai-loop` PR. That condition reads no `AI_LOOP_COPILOT`, only
-`AI_LOOP_ENABLED`, so it is live for any Copilot review, including one a maintainer requests by
-hand, which is how every Copilot review on a loop PR has arrived so far (#573, #624).
-`AI_LOOP_COPILOT` decides only whether `claude-implement.yml` asks for the review; unsetting it is
-not a kill switch for this trigger. `AI_LOOP_ENABLED=false` and removing `ai-loop` are. Eligible is
-the honest word, and the split between runs that start and runs that do not is not random. Whether a
-`Claude PR Loop` run for a Copilot review ever creates a job is decided by whether a maintainer
-re-ran it. Every run Copilot has triggered arrived as `run_attempt: 1` with `triggering_actor:
-Copilot` and died before a job existed (100 `failure` with zero jobs and 21 `action_required`, 121
-so far), so no job `if:` was evaluated. The only ones that reached a job are among the 19 a
-maintainer re-ran by hand: on a re-run `triggering_actor` becomes the re-runner, which is what the
-`allxsmith` rows in that query are, and not a record of who requested the review. Eighteen of those
-created all six jobs and evaluated the gate's `if:`, which before this change matched only
-`coderabbitai[bot]`; run `33041194214` was cancelled with none. Runs `33586960606`, `33232938014`
-and `33035152465` are three of the eighteen, on `claude/*` heads, and `33586960606` is the worked
-example: attempt 1 was `action_required` with zero jobs, attempt 2 produced the six. So there is no
-observed case of a Copilot review starting a loop run unaided. Since 2026-09-06 the shape has
-changed again: Copilot's reviews on PR #643 that day (all of them its "encountered an error"
-submissions) created no `Claude PR Loop` run at all, so the query below can come back with nothing
-new rather than a fresh startup failure, and absence of a run is the expected reading, not a broken
-query. Whether `AI_LOOP_COPILOT=true` changes any of this is untested: the variable has never been
-on, so no review requested by `claude-implement.yml` has been observed. The request itself starts
-nothing (it is made under the workflow's `GITHUB_TOKEN`, and nothing here listens for
-`review_requested`), but the review Copilot then submits is its own event under its own credentials,
-so treat that path as unknown rather than ruled out. In every case observed so far, a Copilot-only
-finding has still waited for the next natural event: a CI or deep-review completion, a CodeRabbit
-review, or the 2-hourly watchdog sweep. The widened condition removes our side of the obstacle; it
-is not a latency guarantee. Treat a `Claude PR Loop` run **with jobs** as the proof. Keep the
-`--paginate` and the `run_attempt` column: the most recent page alone is all startup failures, which
-is how the absolute version of this claim was first written, and without the attempt number the
-re-runs look like a second kind of trigger.
+The gate job's `if:` names Copilot alongside CodeRabbit, so a submitted review from either is
+eligible to fire the gate on an `ai-loop` PR. That condition reads `AI_LOOP_ENABLED` only:
+`AI_LOOP_COPILOT` decides whether `claude-implement.yml` requests the review, and unsetting it
+is not a kill switch for the trigger. `AI_LOOP_ENABLED=false` and removing `ai-loop` are.
 
-```bash
-gh api --paginate \
-  "repos/allxsmith/bestax/actions/workflows/claude-pr-loop.yml/runs?event=pull_request_review" \
-  --jq '.workflow_runs[] | select(.actor.login=="Copilot")
-        | [.id, .run_attempt, .triggering_actor.login, .conclusion, .head_branch] | @tsv'
-```
+Two lists name the reviewer and are compared against different strings. The gate's `if:` is
+matched against the event payload (`review.user.login`, `copilot-pull-request-reviewer[bot]`);
+`allowed_bots` on the fix and verify sessions is matched against the run's actor (`Copilot`).
+Each list carries only the spelling it is compared against. When adding a reviewer, read its
+login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`) and put each
+spelling where it is compared. The `ACTIONABLE` counter matches the prefix
+`^(coderabbitai|copilot)` deliberately: a new `copilot-*` app is counted as work owed, but it
+cannot admit itself to a session holding `AI_LOOP_PAT` just by existing.
 
-Two lists have to name the reviewer for that to work end to end, and they are matched against
-different strings. The `pull_request_review` branch of the gate job's `if:` is matched against the
-event payload (`review.user.login`); the `allowed_bots` list on the fix and verify sessions is
-matched against the **run's actor**, and nothing else. A reviewer in one but not the other either
-waits for an unrelated event (a CI or deep-review completion, the other reviewer, or the 2-hourly
-watchdog sweep) or fails the session's human-actor check outright. The action's write-permission
-check also reads `allowed_bots`, but only in PR and issue contexts and only for an actor without a
-`[bot]` suffix, which here means `Copilot` on the review arm; every other entry and every other arm
-is decided by the human-actor check alone.
-
-Those two strings are not always the same. The Copilot reviewer app renders as
-`copilot-pull-request-reviewer[bot]` in the payload and as `Copilot` to Actions, so the payload
-spelling is what makes the gate condition match and the actor spelling is what makes `allowed_bots`
-match. `allowed_bots` compares normalised logins, not account ids, and GitHub's other Copilot app
-(`copilot-swe-agent[bot]`) also renders as `Copilot`, so that entry admits either; the confinement
-is the gate, not the precision of the string, and each arm holds different parts of it. The review
-and CI-completion arms of the `if:` carry the same-repo and `claude/*` head tests; the
-manual-dispatch arm carries neither and relies on GitHub only letting write-access users dispatch.
-The `ai-loop` label, PR-open and protected-path tests are re-derived in the gate job's shell on
-every arm, and the two head tests are not. So a CI completion with `Copilot` as the actor, on a
-`claude/*` head, still passes all of them before `fix` runs. Each list carries only the spelling it
-is compared against; a hedge entry in the other place would match nothing today and, in
-`allowed_bots`, would widen an allowlist on the job holding `AI_LOOP_PAT` for no observed reason.
-CodeRabbit needs one spelling because both surfaces agree on it. When adding a reviewer, read its
-login off a real run (`gh api repos/<repo>/actions/runs/<id> --jq .actor.login`, since `gh run list`
-exposes no actor field) as well as off the API, and put each spelling where it is actually compared
-(#612).
-
-One divergence deliberately remains. The gate's `if:` names exact logins, while the `ACTIONABLE`
-counter, and the fix job's terminal check that repeats it, match the case-insensitive prefix
-`^(coderabbitai|copilot)`. A thread opened by any other `copilot-*` app, `copilot-swe-agent[bot]`
-today or a future reviewer app, is therefore still counted as work the loop owes while its review
-fires no gate run (its run actor can still reach `fix` through the CI-completion arm described
-above, where the gate confines it), which is the same wait of up to two hours that #612 describes.
-That is the safe direction: a new `copilot-*` app cannot admit itself to a session holding
-`AI_LOOP_PAT` just by existing. But it means the two agree only for the logins named above, so
-adding a reviewer means adding it to the `if:` and to `allowed_bots`, not only to the counter's
-regex.
+No Copilot review has yet started a loop run unaided; the runs that reached a job were manual
+re-runs. The evidence and the query that produced it are
+[on #612](https://github.com/allxsmith/bestax/issues/612#issuecomment-5563800114).
 
 Anything that spends model usage is **explicit opt-in** — it must be present and set, and
 deleting it turns the feature off rather than on:


### PR DESCRIPTION
Refs #643, #612. Follows #646 and #647, which change the reviewer; this PR changes what gets written.

## What changed

- **`docs/docs/guides/getting-started/ai-development.md`**: the Copilot section is cut from a page of run statistics, run ids, and a dated observation to the operator-facing facts. The evidence paragraph and its query were posted verbatim [on #612](https://github.com/allxsmith/bestax/issues/612#issuecomment-5563800114) and the guide links there. The `deep-review` label row describes the relabel as a verify pass.
- **`.github/workflows/claude-pr-loop.yml`**, comments only: the `allowed_bots` block on `fix` is cut to the mechanism with its source cited at the pin; the header no longer repeats the observation; the `verify` job's identical list gets a pointer to the `fix` rationale.
- **`.github/CLAUDE.md`**: a new "How to be exact: claim less" section under the review checklist. Cite the control, do not restate third-party internals; a count lives in a command; evidence goes on the issue; one home per fact; no absolute quantifiers; no line references; a PR body says what changed.
- **`docs/CLAUDE.md`**: guides are canonical reference, not lab notebooks. The same rules for `docs/docs/**`, with the blog named as where dated snapshots belong.
- **`CONTRIBUTING.md`**: the hand-driven review process. Deep review once at open, fix, one relabel for the verify pass, CodeRabbit last, never relabel per push.
- **`.coderabbit.yaml`**: a `.github/**` path instruction so CodeRabbit reviews workflow comments for false claims about triggers, actors, or credentials only, and suggests deletion rather than added qualifiers.

## Why

On #643, the text that was written to satisfy reviews became the thing the next review found fault with. The rules here make the text less fragile: true after the next unrelated edit, not only today.

## What to check

- `pnpm format:check` and `pnpm check:conformance` pass locally.
- The guide section under `AI_LOOP_COPILOT` reads as a complete explanation without the evidence.
- Both rule sections cite `fragile-prose`, the conformance check that enforces the count, run-id, and line-reference parts; it arrives in the next PR.

This PR is the first live test of #646's prose rules, so its deep review should wait until #646 has merged and `main` is merged in here.
