### PR TITLE
fix(bestax-mcp): declare @allxsmith/bestax-bulma as a dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,10 @@ Full versioning details (breaking-change footers, tag formats): `VERSIONING.md`.
   and every miss granted the exemption. A workspace **sibling** in `dependencies` or
   `optionalDependencies` is separately a violation however the specifier is spelled (#537), and
   the only way through is a line in `SIBLING_RUNTIME_DEPS` — same declared shape — for a
-  package that depends on a sibling at runtime on purpose (#644: create-bestax on
-  `@allxsmith/bestax-bulma`, the way bulma-ui declares `bulma`; bestax-mcp and bestax-migrate
-  follow in their own PRs); the test holds that declaration to the real manifests, so a removed
-  dependency cannot leave a standing exemption.
+  package that depends on a sibling at runtime on purpose (#644: create-bestax and bestax-mcp
+  on `@allxsmith/bestax-bulma`, the way bulma-ui declares `bulma`; bestax-migrate follows in
+  its own PR); the test holds that declaration to the real manifests, so a removed dependency
+  cannot leave a standing exemption.
 
 ## Workflow
 

--- a/bestax-mcp/CLAUDE.md
+++ b/bestax-mcp/CLAUDE.md
@@ -62,11 +62,25 @@ the API pages and the skill catalog.
 
 ## Dependencies
 
-Two: `@modelcontextprotocol/sdk` and `zod` (the SDK's schema types are zod, and
-pnpm's isolated linker means anything imported must be declared). The SDK pulls
-~90 transitive packages, most of them for HTTP transports this server does not
-use — that was measured against `pnpm audit --audit-level=high` before adopting
-it, and it comes back clean. Re-check if that ever changes.
+Three. `@modelcontextprotocol/sdk` and `zod` are the two that are imported (the
+SDK's schema types are zod, and pnpm's isolated linker means anything imported
+must be declared). The SDK pulls ~90 transitive packages, most of them for HTTP
+transports this server does not use — that was measured against
+`pnpm audit --audit-level=high` before adopting it, and it comes back clean.
+Re-check if that ever changes.
+
+`@allxsmith/bestax-bulma` is declared, not imported (#644): the server is built
+for the library and its manifest says so, the way bulma-ui declares `bulma`.
+It is spelled `workspace:^`, which `pnpm publish` rewrites to the release
+current at pack time (bulma-ui releases first in the same job), and the sibling
+rule in `check:conformance` allows it only because `SIBLING_RUNTIME_DEPS`
+declares this exact pair. Two things follow. `npx bestax-mcp` installs the
+library, `bulma`, and — npm's automatic peer install — `react`/`react-dom`
+alongside the server. And the version probe in `src/version.ts` walks up from
+`cwd`, so under `npx` the server's own copy in the npx cache is never on that
+path; installed as a project devDependency instead, npm may hoist this
+dependency's copy to the project's top-level `node_modules`, and when the
+project has no copy of its own the probe reports that one.
 
 ## Tests
 

--- a/bestax-mcp/package.json
+++ b/bestax-mcp/package.json
@@ -54,6 +54,7 @@
     "url": "https://github.com/allxsmith/bestax/issues"
   },
   "dependencies": {
+    "@allxsmith/bestax-bulma": "workspace:^",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
 
   bestax-mcp:
     dependencies:
+      '@allxsmith/bestax-bulma':
+        specifier: workspace:^
+        version: link:../bulma-ui
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
         version: 1.30.0(zod@4.4.3)

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2068,9 +2068,9 @@ const PNPM_PUBLISHED = new Set([
 
 /**
  * Workspace siblings a published package depends on AT RUNTIME, on purpose
- * (#644): create-bestax is built for `@allxsmith/bestax-bulma` and its
- * manifest says so, the way bulma-ui declares `bulma` without ever importing
- * it; bestax-mcp and bestax-migrate join this map in their own PRs. This is
+ * (#644): create-bestax and bestax-mcp are built for `@allxsmith/bestax-bulma`
+ * and their manifests say so, the way bulma-ui declares `bulma` without ever
+ * importing it; bestax-migrate joins this map in its own PR. This is
  * the exemption the sibling rule below reserved for "the PR that needs one",
  * and it takes the PNPM_PUBLISHED shape for the same reason: a declaration
  * cannot be misparsed, and scripts/publishable-manifests.test.mjs checks it
@@ -2083,6 +2083,7 @@ const PNPM_PUBLISHED = new Set([
  */
 export const SIBLING_RUNTIME_DEPS = new Map([
   ['create-bestax', new Set(['@allxsmith/bestax-bulma'])],
+  ['bestax-mcp', new Set(['@allxsmith/bestax-bulma'])],
 ]);
 
 /**


### PR DESCRIPTION
Second of three for #644, stacked on #645 (it needs the `SIBLING_RUNTIME_DEPS` declaration that PR introduces). Rebase onto `main` once #645 lands.

## What

- `bestax-mcp/package.json`: `"@allxsmith/bestax-bulma": "workspace:^"` in `dependencies`. The packed tarball reads `"^5.15.0"` today.
- `scripts/check-conformance.mjs`: the `bestax-mcp` line in `SIBLING_RUNTIME_DEPS`; the manifest-reality test from #645 fails without it.
- `bestax-mcp/CLAUDE.md`: the Dependencies section counts three and explains the declared one, including how the version probe in `src/version.ts` behaves now that the server's own tree contains the library.
- Root `CLAUDE.md`: the manifest bullet names bestax-mcp alongside create-bestax.

## Why

Same as #645: the server exists for the library and its manifest says so, the way bulma-ui declares `bulma`. Nothing in `src/` imports it; the index is generated from `bulma-ui/src` as text and the package-name string in `src/version.ts` is used for a filesystem walk, deliberately never a resolve.

## Consequences

- `npx bestax-mcp` installs the library, `bulma`, and under npm's automatic peer install `react`/`react-dom` alongside the server.
- The version probe walks up from `cwd`, so under `npx` the server's own copy is not on that path. Installed as a project devDependency, npm may hoist this dependency's copy to the project's top-level `node_modules`, and when the project has none of its own the probe reports that one.
- `bestax-mcp#build` now waits on `@allxsmith/bestax-bulma#build` through turbo's `^build`; no `turbo.json` change.

## Verified

- `node --test scripts/publishable-manifests.test.mjs` (58), `pnpm check:conformance` green, `pnpm all` green
- `pnpm -C bestax-mcp pack`: `dependencies` carries `"^5.15.0"`, no `workspace:`
