### PR TITLE
fix(bestax-migrate): declare @allxsmith/bestax-bulma as a dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,9 @@ Full versioning details (breaking-change footers, tag formats): `VERSIONING.md`.
   and every miss granted the exemption. A workspace **sibling** in `dependencies` or
   `optionalDependencies` is separately a violation however the specifier is spelled (#537), and
   the only way through is a line in `SIBLING_RUNTIME_DEPS` — same declared shape — for a
-  package that depends on a sibling at runtime on purpose (#644: create-bestax and bestax-mcp
-  on `@allxsmith/bestax-bulma`, the way bulma-ui declares `bulma`; bestax-migrate follows in
-  its own PR); the test holds that declaration to the real manifests, so a removed dependency
-  cannot leave a standing exemption.
+  package that depends on a sibling at runtime on purpose (#644: the three CLIs on
+  `@allxsmith/bestax-bulma`, the way bulma-ui declares `bulma`); the test holds that declaration
+  to the real manifests, so a removed dependency cannot leave a standing exemption.
 
 ## Workflow
 

--- a/bestax-migrate/CLAUDE.md
+++ b/bestax-migrate/CLAUDE.md
@@ -148,21 +148,24 @@ What is specific to bestax-migrate is the specifier that forced it.
 uninstallable (#412). That was first patched by a `prepack` hook
 reimplementing pnpm's rewrite, and the reimplementation was wrong twice in one
 review — which is the whole argument for handing the job to pnpm instead of
-owning a subset of its logic. This is still the only package carrying such a
-specifier, so it is the one whose tarball is worth inspecting after any change
-to how packing works: `pnpm -C bestax-migrate pack`.
+owning a subset of its logic. It was the only package carrying such a
+specifier until #644 put one in every CLI, so all three tarballs are worth
+inspecting after any change to how packing works: `pnpm -C bestax-migrate pack`,
+and the same for `create-bestax` and `bestax-mcp`.
 
-`@allxsmith/bestax-bulma` still stays a **devDependency** — it is only the
-typecheck target for the e2e, never imported at runtime, and consumers of a
-codemod CLI must not be made to install the component library. Both halves of
-that are now enforced by `publishable-manifests` (#537): the protocol rule
-flags `workspace:^` in a consumer section, and the sibling rule flags a
-workspace package name in `dependencies`/`optionalDependencies` **whatever
-the specifier says** — so the plain-semver spelling that used to pass on
-review attention alone fails CI with the move-it-back fix named. One
-appearance that is NOT a counterexample: the e2e asserts the **migrated
-app's** manifest depends on the library (`e2e/kitchen-sink.test.ts`) — that
-is the codemod's output, which should depend on it, and no check reads it.
+`@allxsmith/bestax-bulma` is a declared **dependency** (#644): the codemod is
+built for the library and its manifest says so, the way bulma-ui declares
+`bulma`. Nothing in `src/` imports it at runtime — it is the typecheck target
+for the e2e and the source of the `valid*` constants the value-union tests diff
+against — and consumers of the CLI now install it along with `bulma` and, under
+npm's automatic peer install, `react`/`react-dom`. `publishable-manifests`
+(#537) still forbids a workspace sibling in `dependencies`/`optionalDependencies`
+**whatever the specifier says**; this one passes only because
+`SIBLING_RUNTIME_DEPS` in `scripts/check-conformance.mjs` declares the exact
+pair, and a test holds that declaration to the real manifest. One appearance
+that is NOT this dependency: the e2e asserts the **migrated app's** manifest
+depends on the library (`e2e/kitchen-sink.test.ts`) — that is the codemod's
+output, which should depend on it, and no check reads it.
 
 The skill lives at repo-root
 `skills/bestax-migrate/`. It **is** bundled into create-bestax (settled in #385): the

--- a/bestax-migrate/package.json
+++ b/bestax-migrate/package.json
@@ -52,13 +52,13 @@
     "url": "https://github.com/allxsmith/bestax/issues"
   },
   "dependencies": {
+    "@allxsmith/bestax-bulma": "workspace:^",
     "@babel/parser": "^7.29.8",
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "jscodeshift": "^17.3.0"
   },
   "devDependencies": {
-    "@allxsmith/bestax-bulma": "workspace:^",
     "@jest/globals": "^30.0.0",
     "@types/jest": "^30.0.0",
     "@types/jscodeshift": "^17.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
 
   bestax-migrate:
     dependencies:
+      '@allxsmith/bestax-bulma':
+        specifier: workspace:^
+        version: link:../bulma-ui
       '@babel/parser':
         specifier: ^7.29.8
         version: 7.29.8
@@ -145,9 +148,6 @@ importers:
         specifier: ^17.3.0
         version: 17.4.0(@babel/preset-env@7.29.7(@babel/core@7.29.7))
     devDependencies:
-      '@allxsmith/bestax-bulma':
-        specifier: workspace:^
-        version: link:../bulma-ui
       '@jest/globals':
         specifier: ^30.0.0
         version: 30.4.1

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -2068,9 +2068,9 @@ const PNPM_PUBLISHED = new Set([
 
 /**
  * Workspace siblings a published package depends on AT RUNTIME, on purpose
- * (#644): create-bestax and bestax-mcp are built for `@allxsmith/bestax-bulma`
- * and their manifests say so, the way bulma-ui declares `bulma` without ever
- * importing it; bestax-migrate joins this map in its own PR. This is
+ * (#644): the three CLIs are built for `@allxsmith/bestax-bulma` and their
+ * manifests say so, the way bulma-ui declares `bulma` without ever importing
+ * it. This is
  * the exemption the sibling rule below reserved for "the PR that needs one",
  * and it takes the PNPM_PUBLISHED shape for the same reason: a declaration
  * cannot be misparsed, and scripts/publishable-manifests.test.mjs checks it
@@ -2084,6 +2084,7 @@ const PNPM_PUBLISHED = new Set([
 export const SIBLING_RUNTIME_DEPS = new Map([
   ['create-bestax', new Set(['@allxsmith/bestax-bulma'])],
   ['bestax-mcp', new Set(['@allxsmith/bestax-bulma'])],
+  ['bestax-migrate', new Set(['@allxsmith/bestax-bulma'])],
 ]);
 
 /**

--- a/scripts/require-pnpm-publish.test.mjs
+++ b/scripts/require-pnpm-publish.test.mjs
@@ -172,14 +172,13 @@ test('the refusal names the package being packed, not a hardcoded one', () => {
 });
 
 test('a readable manifest gets its offending specifier quoted', () => {
-  // bestax-migrate carries one in devDependencies (create-bestax carries the
-  // same sibling in dependencies, #644), and naming it is the reason this
-  // branch exists at all.
+  // Every CLI carries one in dependencies (#644), and naming it is the reason
+  // this branch exists at all.
   let msg = '';
   main({ npm_execpath: NPM }, m => (msg = m), repoDir('bestax-migrate'));
   assert.match(msg, /bestax-migrate declares/);
   assert.match(msg, /"@allxsmith\/bestax-bulma": "workspace:\^"/);
-  assert.match(msg, /in devDependencies/);
+  assert.match(msg, /in dependencies/);
 });
 
 test('a package with no pack-time specifier is not told it has one', () => {


### PR DESCRIPTION
Third of three for #644, stacked on #649 (which is stacked on #645). Rebase onto `main` once those land.

## What

- `bestax-migrate/package.json`: the existing `"@allxsmith/bestax-bulma": "workspace:^"` moves from `devDependencies` to `dependencies`. The packed tarball reads `"^5.15.0"` in `dependencies` and nothing in `devDependencies`.
- `scripts/check-conformance.mjs`: the `bestax-migrate` line in `SIBLING_RUNTIME_DEPS`, which completes the map; the comment now describes all three CLIs.
- `scripts/require-pnpm-publish.test.mjs`: the test that quotes bestax-migrate's real specifier now expects `in dependencies`.
- `bestax-migrate/CLAUDE.md`: the "only package carrying such a specifier" and "stays a devDependency" passages rewritten to the current state, keeping the note that the migrated app's manifest depending on the library is the codemod's output, not this dependency.
- Root `CLAUDE.md`: the manifest bullet names the three CLIs.

## Why

Same as #645 and #649. The library was already here as the e2e typecheck target and the source of the `valid*` constants the value-union tests diff against; it stays that, and the manifest now also records what the codemod is built for.

## Consequences

- `npx bestax-migrate` installs the library, `bulma`, and under npm's automatic peer install `react`/`react-dom` alongside the CLI.
- `bestax-migrate#test` already waited on `@allxsmith/bestax-bulma#build` through its explicit turbo edge; `^build` now covers `build` too. No `turbo.json` change.

## Verified

- `node --test scripts/publishable-manifests.test.mjs scripts/require-pnpm-publish.test.mjs` (74), `pnpm check:conformance` green, `pnpm all` green
- `pnpm -C bestax-migrate pack`: `dependencies` carries `"^5.15.0"`, `devDependencies` no longer lists it
