### PR TITLE
docs: give a hand-driven PR a stopping point, and name the stacked-PR blind spot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,11 +337,11 @@ The short version for contributors:
   leaving and why, then take the PR to human review. The reviewers keep reviewing; what changes
   is that you stop treating every finding as blocking. A finding that names a defect in
   behaviour still earns another round.
-- **A PR based on another PR's branch loses its automatic reviews.** CodeRabbit auto-reviews
-  only the base branches listed in `.coderabbit.yaml`, and the deep review cannot run on a
-  branch whose copy of `claude-review.yml` differs from the default branch's. Ask for what you
-  want on an upper PR, and prefer landing a stack one PR at a time — the docs guide has the
-  detail.
+- **A PR based on another PR's branch gets no automatic CodeRabbit review.** It auto-reviews
+  only the base branches listed in `.coderabbit.yaml`; ask for one with `@coderabbitai review`.
+  The deep review turns on its own condition — a branch whose copy of `claude-review.yml`
+  differs from the default branch's does not get one — so an upper PR carrying a workflow change
+  can lose both. Prefer landing a stack one PR at a time; the docs guide has the detail.
 - **PR titles must be scoped conventional commits** — the title becomes the squash commit and
   drives semantic-release (see [Commit Message Guidelines](#commit-message-guidelines)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,9 +332,9 @@ The short version for contributors:
   every fix is what turned #643 into 14 review rounds.
 - **Know when to stop fixing.** The autonomous loop stops after `MAX_ITERATIONS` fix rounds
   (`claude-pr-loop.yml` sets it), pauses, and labels the PR `ai-loop-paused` for a human. Give
-  a hand-driven PR the same stopping point. Once a file has been round-tripped that many times
-  and what is left is wording rather than behaviour, reply once naming the findings you are
-  leaving and why, then take the PR to human review. The reviewers keep reviewing; what changes
+  a hand-driven PR the same stopping point. Once the PR has been through that many rounds and
+  what is left is wording rather than behaviour, reply once naming the findings you are leaving
+  and why, then take the PR to human review. The reviewers keep reviewing; what changes
   is that you stop treating every finding as blocking. A finding that names a defect in
   behaviour still earns another round.
 - **A PR based on another PR's branch gets no automatic CodeRabbit review.** It auto-reviews

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,6 +330,17 @@ The short version for contributors:
   its window reopens.
   Do not relabel per push: each application spends a full opus session, and relabeling after
   every fix is what turned #643 into 14 review rounds.
+- **Know when to stop fixing.** The autonomous loop stops after `MAX_ITERATIONS` fix rounds
+  (`claude-pr-loop.yml` sets it) and hands the PR to a human with the open threads listed. Give
+  a hand-driven PR the same stopping point. Once a file has been round-tripped that many times
+  and what is left is wording rather than behaviour, reply once naming the findings you are
+  leaving and why, then take the PR to human review. The reviewers keep reviewing; what changes
+  is that you stop treating every finding as blocking. A finding that names a defect in
+  behaviour still earns another round.
+- **A PR based on another PR's branch is reviewed by fewer of them.** CodeRabbit auto-reviews
+  only the base branches listed in `.coderabbit.yaml`, and the deep review cannot run on a
+  branch that carries an unmerged change to its own workflow. Land a stack one PR at a time, or
+  retarget the upper PR once its base merges — the docs guide has the detail.
 - **PR titles must be scoped conventional commits** — the title becomes the squash commit and
   drives semantic-release (see [Commit Message Guidelines](#commit-message-guidelines)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,7 +312,7 @@ This repo uses AI reviewers and an autonomous fix loop — full details in the d
 [AI-Assisted Development](https://bestax.io/docs/guides/getting-started/ai-development).
 The short version for contributors:
 
-- **Every PR targeting `main` gets a CodeRabbit review** automatically. Address or refute its comments — it
+- **A PR targeting `main` gets a CodeRabbit review** automatically once it is out of draft. Address or refute its comments — it
   reviews incrementally and marks addressed comments "✅ Addressed". It also rate-limits, so a
   push during a spent window waits for the next one; the AI-assisted section below says how to
   nudge it. A human maintainer still reviews and merges everything.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,11 +337,10 @@ The short version for contributors:
   and why, then take the PR to human review. The reviewers keep reviewing; what changes
   is that you stop treating every finding as blocking. A finding that names a defect in
   behaviour still earns another round.
-- **A PR based on another PR's branch gets no automatic CodeRabbit review.** It auto-reviews
-  only the base branches listed in `.coderabbit.yaml`; ask for one with `@coderabbitai review`.
-  The deep review turns on its own condition — a branch whose copy of `claude-review.yml`
-  differs from the default branch's does not get one — so an upper PR carrying a workflow change
-  can lose both. Prefer landing a stack one PR at a time; the docs guide has the detail.
+- **A PR based on another PR's branch draws fewer reviewers.** Ask for what you want with
+  `@coderabbitai review`, and prefer landing a stack one PR at a time. The
+  [AI-Assisted Development](https://bestax.io/docs/guides/getting-started/ai-development) guide
+  is where the mechanism lives.
 - **PR titles must be scoped conventional commits** — the title becomes the squash commit and
   drives semantic-release (see [Commit Message Guidelines](#commit-message-guidelines)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,7 +312,7 @@ This repo uses AI reviewers and an autonomous fix loop — full details in the d
 [AI-Assisted Development](https://bestax.io/docs/guides/getting-started/ai-development).
 The short version for contributors:
 
-- **Every PR gets a CodeRabbit review** automatically. Address or refute its comments — it
+- **Every PR targeting `main` gets a CodeRabbit review** automatically. Address or refute its comments — it
   reviews incrementally and marks addressed comments "✅ Addressed". It also rate-limits, so a
   push during a spent window waits for the next one; the AI-assisted section below says how to
   nudge it. A human maintainer still reviews and merges everything.
@@ -331,16 +331,17 @@ The short version for contributors:
   Do not relabel per push: each application spends a full opus session, and relabeling after
   every fix is what turned #643 into 14 review rounds.
 - **Know when to stop fixing.** The autonomous loop stops after `MAX_ITERATIONS` fix rounds
-  (`claude-pr-loop.yml` sets it) and hands the PR to a human with the open threads listed. Give
+  (`claude-pr-loop.yml` sets it), pauses, and labels the PR `ai-loop-paused` for a human. Give
   a hand-driven PR the same stopping point. Once a file has been round-tripped that many times
   and what is left is wording rather than behaviour, reply once naming the findings you are
   leaving and why, then take the PR to human review. The reviewers keep reviewing; what changes
   is that you stop treating every finding as blocking. A finding that names a defect in
   behaviour still earns another round.
-- **A PR based on another PR's branch is reviewed by fewer of them.** CodeRabbit auto-reviews
+- **A PR based on another PR's branch loses its automatic reviews.** CodeRabbit auto-reviews
   only the base branches listed in `.coderabbit.yaml`, and the deep review cannot run on a
-  branch that carries an unmerged change to its own workflow. Land a stack one PR at a time, or
-  retarget the upper PR once its base merges — the docs guide has the detail.
+  branch whose copy of `claude-review.yml` differs from the default branch's. Ask for what you
+  want on an upper PR, and prefer landing a stack one PR at a time — the docs guide has the
+  detail.
 - **PR titles must be scoped conventional commits** — the title becomes the squash commit and
   drives semantic-release (see [Commit Message Guidelines](#commit-message-guidelines)).
 

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -30,9 +30,11 @@ The more actionable your issue, the better the agent does with it:
 
 ## For contributors: what reviews your PR
 
-Every PR gets AI review before human review:
+AI review comes before human review, and which reviewers a PR draws depends on where it
+targets and what it changes:
 
-- **CodeRabbit** reviews automatically. Respond in-thread or just push fixes — it re-reviews
+- **CodeRabbit** reviews a PR automatically once it targets the default branch and is out of
+  draft. Respond in-thread or just push fixes — it re-reviews
   each push and marks addressed comments with "✅ Addressed in commit …". If you think a
   finding is wrong, say so in the thread; a maintainer has the final word.
 - **`@claude` mentions** are restricted to the owner, members, and invited collaborators (they

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -39,14 +39,15 @@ Every PR gets AI review before human review:
   spend the maintainer's Claude usage). External contributors don't need them — just push.
 - **Copilot review** may also appear when the maintainers have it enabled.
 
-**A PR based on another PR's branch loses its automatic reviews.** CodeRabbit auto-reviews only
-the base branches listed under `auto_review.base_branches` in `.coderabbit.yaml`, which is the
-default branch alone. On any other base it posts a "Review skipped" notice, and that notice
-names `@coderabbitai review` as the way to get a single review anyway. The Claude deep review is
-separately unavailable to a branch whose copy of `claude-review.yml` differs from the default
-branch's, which an unmerged change to that file guarantees. So an upper PR in a stack is
-reviewed as far as someone asks for it and no further: mention CodeRabbit on it, and prefer
-landing a stack one PR at a time so each is reviewed against the default branch.
+**A PR based on another PR's branch gets no automatic CodeRabbit review.** CodeRabbit
+auto-reviews only the base branches listed under `auto_review.base_branches` in
+`.coderabbit.yaml`, which is the default branch alone. On any other base it posts a "Review
+skipped" notice, and that notice names `@coderabbitai review` as the way to get a single review
+anyway. Stacking affects that reviewer only. The Claude deep review turns on a separate
+condition — a branch whose copy of `claude-review.yml` differs from the default branch's does not
+get one — which an upper PR carrying an unmerged change to that file meets, so the two are easy
+to confuse. Mention CodeRabbit on an upper PR, and prefer landing a stack one PR at a time so
+each is reviewed against the default branch.
 
 A green AI review is not approval: a human maintainer still reviews and merges every PR, and
 the review-time requirements (Storybook story for UI changes, docs page for API changes,

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -39,14 +39,14 @@ Every PR gets AI review before human review:
   spend the maintainer's Claude usage). External contributors don't need them — just push.
 - **Copilot review** may also appear when the maintainers have it enabled.
 
-**A PR based on another PR's branch is reviewed by fewer of them, and nothing announces it.**
-CodeRabbit auto-reviews only the base branches listed under `auto_review.base_branches` in
-`.coderabbit.yaml`, which is the default branch alone; on any other base it posts a "Review
-skipped" notice and does not retry, and a manual mention does not override it. The Claude deep
-review is separately unavailable to a branch carrying an unmerged change to its own workflow
-file. A stacked PR can therefore reach merge having been read by Copilot alone. Either land a
-stack one PR at a time, or retarget the upper PR at the default branch once its base merges and
-let the reviewers see it there.
+**A PR based on another PR's branch loses its automatic reviews.** CodeRabbit auto-reviews only
+the base branches listed under `auto_review.base_branches` in `.coderabbit.yaml`, which is the
+default branch alone. On any other base it posts a "Review skipped" notice, and that notice
+names `@coderabbitai review` as the way to get a single review anyway. The Claude deep review is
+separately unavailable to a branch whose copy of `claude-review.yml` differs from the default
+branch's, which an unmerged change to that file guarantees. So an upper PR in a stack is
+reviewed as far as someone asks for it and no further: mention CodeRabbit on it, and prefer
+landing a stack one PR at a time so each is reviewed against the default branch.
 
 A green AI review is not approval: a human maintainer still reviews and merges every PR, and
 the review-time requirements (Storybook story for UI changes, docs page for API changes,

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -39,6 +39,15 @@ Every PR gets AI review before human review:
   spend the maintainer's Claude usage). External contributors don't need them — just push.
 - **Copilot review** may also appear when the maintainers have it enabled.
 
+**A PR based on another PR's branch is reviewed by fewer of them, and nothing announces it.**
+CodeRabbit auto-reviews only the base branches listed under `auto_review.base_branches` in
+`.coderabbit.yaml`, which is the default branch alone; on any other base it posts a "Review
+skipped" notice and does not retry, and a manual mention does not override it. The Claude deep
+review is separately unavailable to a branch carrying an unmerged change to its own workflow
+file. A stacked PR can therefore reach merge having been read by Copilot alone. Either land a
+stack one PR at a time, or retarget the upper PR at the default branch once its base merges and
+let the reviewers see it there.
+
 A green AI review is not approval: a human maintainer still reviews and merges every PR, and
 the review-time requirements (Storybook story for UI changes, docs page for API changes,
 `skills/` updates for component changes) still apply.

--- a/docs/docs/guides/getting-started/ai-development.md
+++ b/docs/docs/guides/getting-started/ai-development.md
@@ -30,8 +30,7 @@ The more actionable your issue, the better the agent does with it:
 
 ## For contributors: what reviews your PR
 
-AI review comes before human review, and which reviewers a PR draws depends on where it
-targets and what it changes:
+Which AI reviewers a PR draws depends on where it targets and what it changes:
 
 - **CodeRabbit** reviews a PR automatically once it targets the default branch and is out of
   draft. Respond in-thread or just push fixes — it re-reviews


### PR DESCRIPTION
Closes #655.

Two conventions that were only ever tribal knowledge.

**A stopping point for hand-driven PRs.** The autonomous loop stops after `MAX_ITERATIONS` fix rounds, pauses, and labels the PR for a human. A PR a maintainer drives had no equivalent, so every finding read as blocking however small. `CONTRIBUTING.md` now says to give it the same stopping point: once what is left is wording rather than behaviour, reply once naming what you are leaving and why, and take the PR to human review. The cap is cited as the workflow setting rather than a number, so it cannot drift.

**The stacked-PR blind spot.** A PR based on another PR branch loses its automatic reviews. Worth correcting the issue on one point: the CodeRabbit half is our own configuration, not a vendor limitation. `.coderabbit.yaml` lists the default branch alone under `auto_review.base_branches`, and CodeRabbit skips any other base with a notice that names `@coderabbitai review` as the way to get a single review anyway. The deep review is separately unavailable to a branch whose copy of `claude-review.yml` differs from the default branch. The guide records that where it describes what reviews a PR, names the setting so an operator can find it, and gives the two ways forward: ask for the review you want, and prefer landing a stack one PR at a time.

**On the issue evidence.** The issue cites #651 as having had no CodeRabbit review while stacked. Its base was the default branch, and its gaps were rate limits; it did get a review. The base-branch skip is real and reproduces on #579, whose base was another branch. Nothing in the guide repeats the wrong example, and the issue carries a correction.

**Review history.** The first deep review and Copilot independently caught the same two errors in the opening draft: a claim that a manual mention cannot override the skip, which the vendor notice contradicts, and the deep-review skip stated in the narrow form root `CLAUDE.md` warns about. Both corrected, along with three overstatements found alongside them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that automated CodeRabbit reviews run only for non-draft pull requests targeting the default branch.
  - Documented that stacked pull requests may not receive automatic reviews and explained how to request one.
  - Added guidance to merge stacked pull requests one at a time for review coverage.
  - Clarified the conditions for separate Claude deep reviews.
  - Updated recommendations for managing AI-assisted review cycles and fix iterations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->